### PR TITLE
#7 Update docs, create Sidebar

### DIFF
--- a/documentation/Home.md
+++ b/documentation/Home.md
@@ -1,8 +1,0 @@
-# Welcome to the **openMsupply** Application Manager front end wiki!
-
-Please see [ReadMe](__README) for information about maintaining this documentation.
-
-## Contents
-
-- [Internal Documentation](internal/Home-Internal.md)
-- [Setup](internal/setup/Setup.md)

--- a/documentation/_Sidebar.md
+++ b/documentation/_Sidebar.md
@@ -1,0 +1,9 @@
+### [Internal Docs](internal/Home.md)
+
+- [Navigation & URL overview](internal/Overview-of-Navigation-&-URL-structure.md)
+- [Back-end docs](https://github.com/openmsupply/application-manager-server/wiki)
+
+### [Setup](internal/setup/Setup.md)
+
+- [Apollo Client](internal/setup/Apollo-client.md)
+- [Webpack](internal/setup/Webpack.md)

--- a/documentation/external/Home-External.md
+++ b/documentation/external/Home-External.md
@@ -1,1 +1,0 @@
-### External documentation for Front-end

--- a/documentation/internal/Home.md
+++ b/documentation/internal/Home.md
@@ -1,5 +1,7 @@
 # Internal Documentation for Front-end
 
+Please see [ReadMe](../__README.md) for information about maintaining this documentation.
+
 ## Contents
 
 - [Setup](setup/Setup.md)

--- a/utils/convert_docs_to_wiki.py
+++ b/utils/convert_docs_to_wiki.py
@@ -7,7 +7,7 @@ docs_path = "./documentation"
 output_path = "./documentation/_wiki"
 markup_formats = [".md", ".markdown"]
 media_types = [".png", ".jpg", ".gif", ".svg"]
-ignore = ["ignore"]  # File or folder names to ignore
+ignore = ["external"]  # File or folder names to ignore
 ext_ignore = [".DS_Store"]  # File extensions to ignore
 
 


### PR DESCRIPTION
Fixes #7. 

1. Remove top-most `Home.md` file and rename `internal/Home-Internal.md` back to `internal/Home.md` (This will automatically make it the wiki "home" page.
2. Exclude `external` folder from being pushed to the wiki.
3. Create `_Sidebar.md` to represent the folder structure.