### PR TITLE
#15 core plugins skeleton front end

### DIFF
--- a/src/elementPlugins/ApplicationViewWrapper.tsx
+++ b/src/elementPlugins/ApplicationViewWrapper.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { ErrorBoundary, pluginProvider } from './'
+import { ApplicatioViewProps, PluginComponents } from './types'
+
+const ApplicationViewWrapper = (props: ApplicatioViewProps) => {
+  const {
+    templateElement: { elementTypePluginCode: pluginCode },
+    isVisible,
+  } = props
+
+  if (!pluginCode || !isVisible) return null
+
+  const { ApplicationView }: PluginComponents = pluginProvider.getPluginElement(pluginCode)
+
+  return (
+    <ErrorBoundary pluginCode={pluginCode}>
+      <React.Suspense fallback="Loading Plugin">{<ApplicationView {...props} />}</React.Suspense>
+    </ErrorBoundary>
+  )
+}
+
+export default ApplicationViewWrapper

--- a/src/elementPlugins/ApplicationViewWrapper.tsx
+++ b/src/elementPlugins/ApplicationViewWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { ErrorBoundary, pluginProvider } from './'
 import { ApplicatioViewProps, PluginComponents } from './types'
 
-const ApplicationViewWrapper = (props: ApplicatioViewProps) => {
+const ApplicationViewWrapper: React.FC<ApplicatioViewProps> = (props) => {
   const {
     templateElement: { elementTypePluginCode: pluginCode },
     isVisible,

--- a/src/elementPlugins/ErrorBoundary.tsx
+++ b/src/elementPlugins/ErrorBoundary.tsx
@@ -24,7 +24,7 @@ class ErrorBoundary extends React.Component<Props, State> {
     const knownError = Object.values(PLUGIN_ERRORS).find(
       (errorMessage) => errorMessage === error.message
     )
-    return { hasError: true, errorMessage: knownError ? error.message : '' }
+    return { hasError: true, errorMessage: knownError ? error.message : 'Failed to load plugin' }
   }
 
   // This trigger is for logging, can use prop 'eroror', 'errorInfo'
@@ -36,7 +36,7 @@ class ErrorBoundary extends React.Component<Props, State> {
     if (this.state.hasError) {
       return (
         <Label basic color="red">
-          {`${this.state.errorMessage || 'Failed to load plugin'}
+          {`${this.state.errorMessage}
             code: ${this.props.pluginCode}`}
         </Label>
       )

--- a/src/elementPlugins/ErrorBoundary.tsx
+++ b/src/elementPlugins/ErrorBoundary.tsx
@@ -27,7 +27,7 @@ class ErrorBoundary extends React.Component<Props, State> {
     return { hasError: true, errorMessage: knownError ? error.message : 'Failed to load plugin' }
   }
 
-  // This trigger is for logging, can use prop 'eroror', 'errorInfo'
+  // This trigger is for logging, can use prop 'error', 'errorInfo'
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.log(error, errorInfo)
   }

--- a/src/elementPlugins/ErrorBoundary.tsx
+++ b/src/elementPlugins/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { Label } from 'semantic-ui-react'
+import { PLUGIN_ERRORS } from './pluginProvider'
+
+type Props = {
+  pluginCode: any
+  children: JSX.Element
+}
+
+type State = Readonly<{
+  hasError: boolean
+  errorMessage: string
+}>
+
+class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false, errorMessage: '' }
+  }
+
+  // This trigger is for updating UI, can use prop 'error' in this method
+  static getDerivedStateFromError(error: Error) {
+    console.log(Error)
+    const knownError = Object.values(PLUGIN_ERRORS).find(
+      (errorMessage) => errorMessage === error.message
+    )
+    return { hasError: true, errorMessage: knownError ? error.message : '' }
+  }
+
+  // This trigger is for logging, can use prop 'eroror', 'errorInfo'
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.log(error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Label basic color="red">
+          {`${this.state.errorMessage || 'Failed to load plugin'}
+            code: ${this.props.pluginCode}`}
+        </Label>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/elementPlugins/JsonInput.tsx
+++ b/src/elementPlugins/JsonInput.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react'
+import { Input } from 'semantic-ui-react'
+
+const JsonInput = ({
+  label,
+  initialValue,
+  onUpdate,
+}: {
+  label: string
+  initialValue: string
+  onUpdate: any
+}) => {
+  const [value, setValue] = useState(initialValue)
+  const [error, setError] = useState(false)
+
+  return (
+    <Input
+      fluid
+      label={label}
+      onChange={onChange(setError, setValue, onUpdate)}
+      value={value}
+      error={error}
+    />
+  )
+}
+
+function onChange(setError: any, setValue: any, onUpdate: any) {
+  return (_: any, { value }: any) => {
+    setValue(value)
+
+    try {
+      JSON.parse(value)
+      onUpdate(value)
+      setError(false)
+    } catch (e) {
+      setError(true)
+    }
+  }
+}
+
+export default JsonInput

--- a/src/elementPlugins/TemplateViewWrapper.tsx
+++ b/src/elementPlugins/TemplateViewWrapper.tsx
@@ -101,7 +101,7 @@ function onJsonFieldChange(key: string, onUpdate: OnUpdateTemplateWrapperView) {
   }
 }
 
-function onFieldChange(key: string, onUpdate: any, onSetValue: any) {
+function onFieldChange(key: string, onUpdate: OnUpdateTemplateWrapperView, onSetValue: any) {
   return (_: any, { value }: any) => {
     onSetValue(value)
     onUpdate({ [key]: value })

--- a/src/elementPlugins/TemplateViewWrapper.tsx
+++ b/src/elementPlugins/TemplateViewWrapper.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Input, Dropdown, Segment } from 'semantic-ui-react'
+import { TemplateElement } from '../generated/graphql'
 import { pluginProvider, ErrorBoundary, JsonInput } from './'
 import { OnUpdateTemplateWrapperView, PluginComponents, TemplateViewWrapperProps } from './types'
 
@@ -63,20 +64,20 @@ const TemplateViewWrapper = (props: TemplateViewWrapperProps) => {
     </Segment>
   )
 }
+
 const jsonFields = {
   isRequired: 'Is Required Condition',
   isEditable: 'Is Editable Condition',
 }
-// any for templateElement due to Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'TemplateElement'
-// TODO fix
-function renderJsonFields(templateElement: any, onUpdate: OnUpdateTemplateWrapperView) {
+
+function renderJsonFields(templateElement: TemplateElement, onUpdate: OnUpdateTemplateWrapperView) {
   return (
     <>
       {Object.entries(jsonFields).map(([key, title]) => (
         <JsonInput
           key={key}
           label={title}
-          initialValue={templateElement[key]}
+          initialValue={templateElement[key as keyof TemplateElement]}
           onUpdate={onJsonFieldChange(key, onUpdate)}
         />
       ))}

--- a/src/elementPlugins/TemplateViewWrapper.tsx
+++ b/src/elementPlugins/TemplateViewWrapper.tsx
@@ -95,7 +95,7 @@ function getPluginOptions() {
   })
 }
 
-function onJsonFieldChange(key: string, onUpdate: any) {
+function onJsonFieldChange(key: string, onUpdate: OnUpdateTemplateWrapperView) {
   return (value: string) => {
     onUpdate({ [key]: value })
   }
@@ -108,7 +108,11 @@ function onFieldChange(key: string, onUpdate: any, onSetValue: any) {
   }
 }
 
-function onPluginSelection(setPluginCode: any, setPluginInfo: any, onUpdate: any) {
+function onPluginSelection(
+  setPluginCode: any,
+  setPluginInfo: any,
+  onUpdate: OnUpdateTemplateWrapperView
+) {
   return (_: any, { value: pluginCode }: any) => {
     setPluginCode(pluginCode)
     setPluginInfo(pluginProvider.pluginManifest[pluginCode])

--- a/src/elementPlugins/TemplateViewWrapper.tsx
+++ b/src/elementPlugins/TemplateViewWrapper.tsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react'
+import { Input, Dropdown, Segment } from 'semantic-ui-react'
+import { pluginProvider, ErrorBoundary, JsonInput } from './'
+import { PluginComponents, TemplateViewWrapperProps } from './types'
+
+const TemplateViewWrapper = (props: TemplateViewWrapperProps) => {
+  const { templateElement, onUpdate } = props
+
+  const {
+    elementTypePluginCode: initialPluginCode,
+    parameters: initialParameters,
+    title: initialTitle,
+    code,
+    visibilityCondition,
+  } = templateElement
+
+  if (!initialPluginCode) return null
+
+  const [pluginCode, setPluginCode] = useState(initialPluginCode)
+  const [pluginInfo, setPluginInfo] = useState(pluginProvider.pluginManifest[initialPluginCode])
+  const [title, setTitle] = useState(initialTitle)
+
+  const { TemplateView }: PluginComponents = pluginProvider.getPluginElement(pluginCode)
+
+  return (
+    <Segment>
+      <Dropdown
+        options={getPluginOptions()}
+        selection
+        onChange={onPluginSelection(setPluginCode, setPluginInfo, onUpdate)}
+        value={pluginCode}
+      />
+      <Input fluid label="Code" value={/*not editable in this PR*/ code} />
+      <JsonInput
+        label={'Is Visible Condition'}
+        initialValue={visibilityCondition}
+        onUpdate={onJsonFieldChange('visibilityCondition', onUpdate)}
+      />
+
+      {pluginInfo.category === 'Informative' ? null : renderJsonFields(templateElement, onUpdate)}
+
+      {pluginInfo.category === 'Informative' ? null : (
+        <Input
+          fluid
+          label="Label"
+          value={title}
+          onChange={onFieldChange('title', onUpdate, setTitle)}
+        />
+      )}
+
+      <ErrorBoundary pluginCode={pluginCode}>
+        <React.Suspense fallback="Loading Plugin">
+          {
+            <TemplateView
+              parameters={initialParameters}
+              onUpdate={(newParameters: any) =>
+                onUpdate({ parameters: { ...initialParameters, ...newParameters } })
+              }
+            />
+          }
+        </React.Suspense>
+      </ErrorBoundary>
+    </Segment>
+  )
+}
+const jsonFields = {
+  isRequired: 'Is Required Condition',
+  isEditable: 'Is Editable Condition',
+}
+// any for templateElement due to Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'TemplateElement'
+// TODO fix
+function renderJsonFields(templateElement: any, onUpdate: any) {
+  return (
+    <>
+      {Object.entries(jsonFields).map(([key, title]) => (
+        <JsonInput
+          key={key}
+          label={title}
+          initialValue={templateElement[key]}
+          onUpdate={onJsonFieldChange(key, onUpdate)}
+        />
+      ))}
+    </>
+  )
+}
+
+function getPluginOptions() {
+  return Object.entries(pluginProvider.pluginManifest).map(([pluginCode, pluginInfo]) => {
+    return {
+      key: pluginCode,
+      value: pluginCode,
+      text: pluginInfo.displayName,
+    }
+  })
+}
+
+function onJsonFieldChange(key: string, onUpdate: any) {
+  return (value: string) => {
+    onUpdate({ [key]: value })
+  }
+}
+
+function onFieldChange(key: string, onUpdate: any, onSetValue: any) {
+  return (_: any, { value }: any) => {
+    onSetValue(value)
+    onUpdate({ [key]: value })
+  }
+}
+
+function onPluginSelection(setPluginCode: any, setPluginInfo: any, onUpdate: any) {
+  return (_: any, { value: pluginCode }: any) => {
+    setPluginCode(pluginCode)
+    setPluginInfo(pluginProvider.pluginManifest[pluginCode])
+    onUpdate({ elementTypePluginCode: pluginCode })
+  }
+}
+
+export default TemplateViewWrapper

--- a/src/elementPlugins/TemplateViewWrapper.tsx
+++ b/src/elementPlugins/TemplateViewWrapper.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Input, Dropdown, Segment } from 'semantic-ui-react'
 import { pluginProvider, ErrorBoundary, JsonInput } from './'
-import { PluginComponents, TemplateViewWrapperProps } from './types'
+import { OnUpdateTemplateWrapperView, PluginComponents, TemplateViewWrapperProps } from './types'
 
 const TemplateViewWrapper = (props: TemplateViewWrapperProps) => {
   const { templateElement, onUpdate } = props
@@ -69,7 +69,7 @@ const jsonFields = {
 }
 // any for templateElement due to Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'TemplateElement'
 // TODO fix
-function renderJsonFields(templateElement: any, onUpdate: any) {
+function renderJsonFields(templateElement: any, onUpdate: OnUpdateTemplateWrapperView) {
   return (
     <>
       {Object.entries(jsonFields).map(([key, title]) => (

--- a/src/elementPlugins/basicText/pluginConfig.json
+++ b/src/elementPlugins/basicText/pluginConfig.json
@@ -1,0 +1,7 @@
+{
+  "isCore": true,
+  "code": "basicText",
+  "displayName": "Basic Text Input",
+  "//": "categories types: 'Input'|'Informative'",
+  "category": "Input"
+}

--- a/src/elementPlugins/basicText/src/ApplicationView.tsx
+++ b/src/elementPlugins/basicText/src/ApplicationView.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react'
+import { Form } from 'semantic-ui-react'
+import { ApplicatioViewProps } from '../../types'
+
+const ApplicationView = ({
+  templateElement,
+  onUpdate,
+  initialValue,
+  isEditable,
+}: ApplicatioViewProps) => {
+  const [validationMessage, setValidationMessage] = useState('')
+  const [value, setValue] = useState(initialValue)
+
+  return (
+    <Form.Input
+      fluid
+      label={templateElement.title}
+      placeholder={templateElement.parameters.placeholder}
+      onChange={onChange(setValue, setValidationMessage, onUpdate)}
+      value={value}
+      disabled={!isEditable}
+      error={
+        validationMessage
+          ? {
+              content: validationMessage,
+              pointing: 'above',
+            }
+          : null
+      }
+    />
+  )
+}
+
+function onChange(updateValue: any, updateValidationMessage: any, onUpdate: any) {
+  return (_: any, { value }: any) => {
+    updateValue(value)
+    // Validation here is just an example.
+    // ideally we use validation condition from templateElement and query evaluator
+    if (value.match(/^[a-zA-Z ]*$/) == null) {
+      updateValidationMessage('Should only have letters and space')
+      onUpdate({ isValid: false })
+    } else {
+      updateValidationMessage('')
+      onUpdate({ value: value, isValid: true })
+    }
+  }
+}
+
+export default ApplicationView

--- a/src/elementPlugins/basicText/src/TemplateView.tsx
+++ b/src/elementPlugins/basicText/src/TemplateView.tsx
@@ -1,0 +1,16 @@
+import React, { useState } from 'react'
+import { Input } from 'semantic-ui-react'
+import { TemplateViewProps } from '../../types'
+
+// TODO type should be global
+const TemplateView = ({ parameters, onUpdate }: TemplateViewProps) => {
+  const [placeholder, setPlaceholder] = useState(parameters.placeholder)
+
+  const onChange = (_: any, { value }: any) => {
+    setPlaceholder(value)
+    onUpdate({ placeholder: value })
+  }
+  return <Input fluid label={'Placeholder'} value={placeholder} onChange={onChange} />
+}
+
+export default TemplateView

--- a/src/elementPlugins/index.tsx
+++ b/src/elementPlugins/index.tsx
@@ -1,0 +1,7 @@
+import ApplicationViewWrapper from './ApplicationViewWrapper'
+import TemplateViewWrapper from './TemplateViewWrapper'
+import pluginProvider from './pluginProvider'
+import ErrorBoundary from './ErrorBoundary'
+import JsonInput from './JsonInput'
+
+export { ApplicationViewWrapper, ErrorBoundary, JsonInput, TemplateViewWrapper, pluginProvider }

--- a/src/elementPlugins/pluginProvider.tsx
+++ b/src/elementPlugins/pluginProvider.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { PluginManifest, PluginComponents, Plugins } from './types'
+
+const PLUGIN_COMPONENTS = ['ApplicationView', 'TemplateView']
+const PLUGIN_ERRORS = {
+  PLUGIN_NOT_IN_MANIFEST: 'Plugin is not present in plugin manifest',
+  PLUGINS_NOT_LOADED: 'Plugins are not loaded, check connection with server',
+}
+
+let pluginProviderInstance: pluginProvider | null = null
+
+class pluginProvider {
+  // Have to add ! since constructor may not declare = {}, due to if statement with return
+  plugins!: Plugins
+  pluginManifest!: PluginManifest
+
+  constructor() {
+    if (pluginProviderInstance) return pluginProviderInstance
+    pluginProviderInstance = this
+
+    this.plugins = {}
+    this.pluginManifest = {}
+  }
+
+  getPluginElement(code: string) {
+    if (Object.values(this.pluginManifest).length == 0)
+      return returnWithError(new Error(PLUGIN_ERRORS.PLUGINS_NOT_LOADED))
+
+    const { [code]: pluginConfig } = this.pluginManifest
+    if (!pluginConfig) return returnWithError(new Error(PLUGIN_ERRORS.PLUGIN_NOT_IN_MANIFEST))
+
+    if (this.plugins[code]) return this.plugins[code]
+
+    if (process.env.development || pluginConfig.isCore) {
+      this.plugins[code] = getLocalElementPlugin(pluginConfig.folderName)
+    } else {
+      this.plugins[code] = getRemoteElementPlugin(pluginConfig.folderName)
+    }
+    return this.plugins[code]
+  }
+}
+
+function getLocalElementPlugin(folderName: string) {
+  const result: PluginComponents = {}
+  PLUGIN_COMPONENTS.forEach((componentName) => {
+    result[componentName] = React.lazy(
+      // the exlude comment is to tell webpack not to include node_modules in possible
+      // lazy imports, so when we are developing a new remote plugin, it will have node_modules
+      // folder, during development it will be lazy loaded with this command
+      () => import(/* webpackExclude: /node_modules/ */ `./${folderName}/src/${componentName}`)
+    )
+  })
+
+  return result
+}
+
+// Since the interface for getPluginElement should always return { pluginComponents }
+// this helper will return a reject with an error
+function returnWithError(error: Error) {
+  const result: PluginComponents = {}
+  PLUGIN_COMPONENTS.forEach(
+    (componentName) =>
+      (result[componentName] = React.lazy(async () => {
+        throw error
+      }))
+  )
+
+  return result
+}
+
+function getRemoteElementPlugin(code: string) {
+  const result: PluginComponents = {}
+  PLUGIN_COMPONENTS.forEach((componentName) => {
+    // TODO will be added in another PR
+    result[componentName] = () => <div>Not Implemented</div>
+  })
+  return result
+}
+
+export default new pluginProvider()
+export { PLUGIN_ERRORS }

--- a/src/elementPlugins/textInfo/pluginConfig.json
+++ b/src/elementPlugins/textInfo/pluginConfig.json
@@ -1,0 +1,7 @@
+{
+  "isCore": true,
+  "code": "textInfo",
+  "displayName": "Static Text",
+  "//": "categories types: 'Input'|'Informative'",
+  "category": "Informative"
+}

--- a/src/elementPlugins/textInfo/src/ApplicationView.tsx
+++ b/src/elementPlugins/textInfo/src/ApplicationView.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { Message } from 'semantic-ui-react'
+import { ApplicatioViewProps } from '../../types'
+
+const ApplicationView = ({ templateElement: { parameters } }: ApplicatioViewProps) => {
+  return (
+    <Message>
+      <Message.Header>{parameters.title}</Message.Header>
+      <p>{parameters.text}</p>
+    </Message>
+  )
+}
+
+export default ApplicationView

--- a/src/elementPlugins/textInfo/src/TemplateView.tsx
+++ b/src/elementPlugins/textInfo/src/TemplateView.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react'
+import { Input } from 'semantic-ui-react'
+import { TemplateViewProps } from '../../types'
+
+const TemplateView = ({ parameters, onUpdate }: TemplateViewProps) => {
+  const [text, setText] = useState(parameters.text)
+  const [title, setTitle] = useState(parameters.title)
+
+  const onChangeText = (_: any, { value }: any) => {
+    setText(value)
+    onUpdate({ text: value })
+  }
+  const onChangeTitle = (_: any, { value }: any) => {
+    setTitle(value)
+    onUpdate({ title: value })
+  }
+  return (
+    <>
+      <Input fluid label={'Title'} value={title} onChange={onChangeTitle} />
+      <Input fluid label={'Text'} value={text} onChange={onChangeText} />
+    </>
+  )
+}
+
+export default TemplateView

--- a/src/elementPlugins/types.ts
+++ b/src/elementPlugins/types.ts
@@ -15,7 +15,7 @@ interface ApplicatioViewProps {
 }
 
 interface OnUpdateTemplateWrapperView {
-  (updateObject: { elementTypePluginCode?: string; parameters: any }): void
+  (updateObject: { [key: string]: any }): void
 }
 
 interface TemplateViewWrapperProps {

--- a/src/elementPlugins/types.ts
+++ b/src/elementPlugins/types.ts
@@ -1,0 +1,64 @@
+import { TemplateElement } from '../generated/graphql'
+
+interface OnUpdateApplicationView {
+  (updateObject: { value?: any; isValid: boolean }): void
+}
+
+interface ApplicatioViewProps {
+  templateElement: TemplateElement
+  onUpdate: OnUpdateApplicationView
+  isVisible: boolean
+  isEditable: boolean
+  // applicationState,
+  // graphQLclient
+  initialValue: any // Could be a primative or an object with any shape
+}
+
+interface OnUpdateTemplateWrapperView {
+  (updateObject: { elementTypePluginCode?: string; parameters: any }): void
+}
+
+interface TemplateViewWrapperProps {
+  templateElement: TemplateElement
+  onUpdate: OnUpdateTemplateWrapperView
+}
+
+interface OnUpdateTemplateView {
+  (parameters: any): void
+}
+
+interface TemplateViewProps {
+  parameters: any
+  onUpdate: OnUpdateTemplateView
+}
+
+interface PluginConfig {
+  isCore?: boolean
+  folderName: string
+  displayName: string
+  category: 'Input' | 'Informative'
+}
+
+interface PluginManifest {
+  [key: string]: PluginConfig
+}
+
+interface PluginComponents {
+  [key: string]: React.FunctionComponent<ApplicatioViewProps | TemplateViewProps>
+}
+
+interface Plugins {
+  [key: string]: PluginComponents
+}
+export {
+  OnUpdateApplicationView,
+  OnUpdateTemplateWrapperView,
+  TemplateViewProps,
+  OnUpdateTemplateView,
+  ApplicatioViewProps,
+  TemplateViewWrapperProps,
+  PluginConfig,
+  PluginManifest,
+  PluginComponents,
+  Plugins,
+}

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -2204,7 +2204,7 @@ export type TemplateElementCondition = {
   /** Checks for equality with the object’s `elementTypePluginCode` field. */
   elementTypePluginCode?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `isRequired` field. */
-  isRequired?: Maybe<Scalars['Boolean']>;
+  isRequired?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `isEditable` field. */
   isEditable?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `parameters` field. */


### PR DESCRIPTION
To test please use this branch (https://github.com/openmsupply/application-manager-web-app/tree/%2315-Core-plugins-skeleton-front-end-EXAMPLE) and go to /pluginElement (you can change template configuration and they will reflect in the application state), also the diff for your reference: https://github.com/openmsupply/application-manager-web-app/compare/%2315-Core-plugins-skeleton-front-end...%2315-Core-plugins-skeleton-front-end-EXAMPLE

# THIS PR

First of all I've added a rough roadmap for the rest of the work on plugins: https://github.com/openmsupply/application-manager-web-app/issues/15#issuecomment-705289839

Basically each plugin resides in a folder within `elementPlugins`, they have:

###  jsonConfig

https://github.com/openmsupply/application-manager-web-app/blob/5b3c45a3d597e2b4fe99a629b682b0da24d0703c/src/elementPlugins/basicText/pluginConfig.json#L1-L7

This config would be read by back end for each of the folders and an endpoint will be exposed. For now it's hard coded in the example.

###  Views

In src folder, default exports of components (ApplicationView and TemplateView) for now

### Wrappers

These are generic wrappers, they reside in `elementPlugins` folder, `ApplicationViewWrapper` and `TemplateViewWrapper`.  

### Plugin Provider

This is a singleton class (might change to be a context). It's used to get plugin elements, it needs to be loaded with manifest: 

https://github.com/openmsupply/application-manager-web-app/blob/55d609f64595afdfde2520a8f9c46032b5791622/src/components/ElementPluginCheck.tsx#L8-L21

getPluginElement in this class will always return and object containing 'ApplicationView' and 'TemplateView', instead of returning ready component, it return a promise (React.lazy), if there are any problems/errors they are thrown within that promise, which is caught by error boundary:

https://github.com/openmsupply/application-manager-web-app/blob/5b3c45a3d597e2b4fe99a629b682b0da24d0703c/src/elementPlugins/ApplicationViewWrapper.tsx#L13-L18

In the upcoming PR, when remote plugins are loaded, there will be an extra step (module federation related), that will load the entry point scripts, then load module from it. Result will be the same though. Also in dev we would not require an endpoint to serve remote plugins, they will be launched together with the app (just the React.lazy).

There could be an issue with pluginProvider, when rest point is implemented (i.e. pluginManifest is not loaded in time). This can be resolved in a number of ways, will see if it's needed.

### Types and Props

There is a type .ts files, this should really be a global declaration file, but i had issues creating one.

#### ApplicationView 

https://github.com/openmsupply/application-manager-web-app/blob/5b3c45a3d597e2b4fe99a629b682b0da24d0703c/src/elementPlugins/types.ts#L7-L15

The idea of isVisible and isEditable being booleans, is the parent component should be responsible for evaluating the expression.

onUpdate can be called with either 'value': .., or 'isValid' or both (value should only be updated when it's valid)
Parent component is responsible for making sure it's placed correctly in stage:

https://github.com/openmsupply/application-manager-web-app/blob/55d609f64595afdfde2520a8f9c46032b5791622/src/components/ElementPluginCheck.tsx#L113

https://github.com/openmsupply/application-manager-web-app/blob/55d609f64595afdfde2520a8f9c46032b5791622/src/components/ElementPluginCheck.tsx#L146-L152

#### TemplateView

https://github.com/openmsupply/application-manager-web-app/blob/5b3c45a3d597e2b4fe99a629b682b0da24d0703c/src/elementPlugins/types.ts#L30-L33

Only has access to parameters and onUpdate only changes key: values in parameters, once again parent component (wrapper or parent) needs to make sure new keys/values are joined correctly to the template config, this might need a little bit of refinement.

#### TemplateViewWrapper

Unlike ApplicationViewWrapper, TemplateViewWrapper differs in type to TemplateView, this is because of generic functionality.

Basically TemplateViewWrapper is responsible for these enterable fields:

* isVisible
* code
* pluginType

If category of plugin in Input, it also handles:

* ValidationCondition
* isEditable
* isRequired


### Extras

- There is a little bit of typescript tidy up (i.e. onChange method)

- And I am sure peer review would lead to some question and changes

 - Validation condition entry and how to use evaluator


