### PR TITLE
#27 Hook to load template query

### DIFF
--- a/src/components/Application/ApplicationStart.tsx
+++ b/src/components/Application/ApplicationStart.tsx
@@ -10,7 +10,7 @@ export interface ApplicationStartProps {
 
 const ApplicationStart: React.FC<ApplicationStartProps> = (props) => {
   const { template: type, sections, handleClick } = props
-  
+
   return (
     <Container text>
       <Header as="h1" content={type ? type.description : 'Create application page'} />
@@ -25,10 +25,7 @@ const ApplicationStart: React.FC<ApplicationStartProps> = (props) => {
                 <List.Item key={`list-item-${section.code}`} content={section.title} />
               ))}
           </List>
-          <Button
-            content={type.name}
-            onClick={handleClick}
-          />
+          <Button content={type.name} onClick={handleClick} />
         </Segment>
       )}
       {!type && <Label content="No Application" />}

--- a/src/components/Application/ApplicationStart.tsx
+++ b/src/components/Application/ApplicationStart.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Button, Container, Header, Label, List, Segment } from 'semantic-ui-react'
-import { TemplatePayload, TemplateSectionPayload } from '../../utils/types'
+import { TemplateTypePayload, TemplateSectionPayload } from '../../utils/types'
 
 export interface ApplicationStartProps {
-  template: TemplatePayload
+  template: TemplateTypePayload
   sections: TemplateSectionPayload[]
   handleClick: () => void
 }

--- a/src/containers/Application/ApplicationCreate.tsx
+++ b/src/containers/Application/ApplicationCreate.tsx
@@ -27,11 +27,10 @@ type FlattenType = {
 
 const ApplicationCreate: React.FC<ApplicationCreateProps> = (props) => {
   const { applicationState, setApplicationState } = useApplicationState()
-  const { type, handleClick } = props
+  const { type: templateCode, handleClick } = props
   const { replace } = useRouter()
 
-  const template = useLoadTemplate({type})
-  const { currentType, currentSections } = template
+  const { currentType, currentSections }  = useLoadTemplate({templateCode})
 
   const { data, loading, error} = useGetApplicationQuery({
     variables: {
@@ -103,7 +102,7 @@ const ApplicationCreate: React.FC<ApplicationCreateProps> = (props) => {
     }
   }, [applicationState])
 
-  return template.loading ? (
+  return loading ? (
     <Loading />
   ) : (
     currentType && currentSections ?

--- a/src/containers/Application/ApplicationCreate.tsx
+++ b/src/containers/Application/ApplicationCreate.tsx
@@ -30,92 +30,99 @@ const ApplicationCreate: React.FC<ApplicationCreateProps> = (props) => {
   const { type: templateCode, handleClick } = props
   const { replace } = useRouter()
 
-  const { currentType, currentSections }  = useLoadTemplate({templateCode})
-
-  const { data, loading, error} = useGetApplicationQuery({
-    variables: {
-      serial: applicationState.serialNumber as number
-    }
+  const { loading: templateIsLoading, templateType, templateSections } = useLoadTemplate({
+    templateCode,
   })
 
-  useEffect(()=> {
-    if (data && data.applications && data.applications.nodes.length>0) {
+  const { data, loading, error } = useGetApplicationQuery({
+    variables: {
+      serial: applicationState.serialNumber as string,
+    },
+  })
+
+  useEffect(() => {
+    if (data && data.applications && data.applications.nodes.length > 0) {
       if (data.applications.nodes.length > 1)
         console.log('More than one application returned. Only one expected!')
-      const application = data.applications.nodes[0] as Application 
-      
+      const application = data.applications.nodes[0] as Application
+
       // Check the return application has sections
-      if (!application.applicationSections || 
-        application.applicationSections.nodes.length === 0)
+      if (!application.applicationSections || application.applicationSections.nodes.length === 0)
         return // TODO: Should reset application here?
-      
+
       const pages = Array<Page>()
       // Flatten section and elements
       const sections = application.applicationSections.nodes as ApplicationSection[]
       sections.forEach((section) => {
         const { templateSection } = section
         if (!templateSection) return
-        const { id, code, templateElementsBySectionId, title} = templateSection
+        const { id, code, templateElementsBySectionId, title } = templateSection
         // TODO: Remove elements not visible in the current stage...
         // TODO: concat all sections elements...
         const elements = templateElementsBySectionId.nodes as TemplateElement[]
         const result = elements.map((element: TemplateElement) => {
           const { code: elementCode, elementTypePluginCode: pluginCode } = element
-          return { templateId: id, sectionCode: code as string, sectionTitle: title as string, elementCode, pluginCode: pluginCode as string }
+          return {
+            templateId: id,
+            sectionCode: code as string,
+            sectionTitle: title as string,
+            elementCode,
+            pluginCode: pluginCode as string,
+          }
         })
 
         // Add first and last element of page
-        let page: Page = { templateId: id, sectionTitle: title as string, sectionCode: code as string }
+        let page: Page = {
+          templateId: id,
+          sectionTitle: title as string,
+          sectionCode: code as string,
+        }
         result.forEach((element: FlattenType) => {
           const { firstElement, lastElement } = page
-          
-          if (!firstElement) 
-            page.firstElement = element.elementCode
-          if (!lastElement && element.pluginCode === 'pagebreak') 
+
+          if (!firstElement) page.firstElement = element.elementCode
+          if (!lastElement && element.pluginCode === 'pagebreak')
             page.lastElement = element.elementCode
-          
+
           if (page.firstElement && page.lastElement) {
             pages.push(page)
             page = { templateId: id, sectionTitle: title as string, sectionCode: code as string }
           }
         })
         if (page.firstElement && !page.lastElement) {
-          pages.push({ ...page, lastElement: null})
+          pages.push({ ...page, lastElement: null })
         }
       })
-      setApplicationState({type: 'setPages', pages})
+      setApplicationState({ type: 'setPages', pages })
     }
   }, [data, error])
 
   useEffect(() => {
     const { pageNumber, pageIndex, pages, serialNumber } = applicationState
     if (serialNumber && pages) {
-      
-      if (pages === null || pageIndex === null) return 
+      if (pages === null || pageIndex === null) return
       const sectionCode = pages[pageIndex].sectionCode
 
       // Show the application current step (current pageNumber)
-      if (sectionCode)
-        replace(`${serialNumber}/${sectionCode}/page${pageNumber}`)
-      else
-      replace(`${serialNumber}/summary`)
+      if (sectionCode) replace(`${serialNumber}/${sectionCode}/page${pageNumber}`)
+      else replace(`${serialNumber}/summary`)
     }
   }, [applicationState])
 
-  return loading ? (
+  return templateIsLoading ? (
     <Loading />
+  ) : templateType && templateSections ? (
+    <Container>
+      <ApplicationStart
+        template={templateType}
+        sections={templateSections}
+        handleClick={() => handleClick(templateType)}
+      />
+      {loading ? <Loading /> : null}
+    </Container>
   ) : (
-    currentType && currentSections ?
-      <Container>
-        <ApplicationStart
-          template={currentType}
-          sections={currentSections}
-          handleClick={() => handleClick(currentType)}
-        />
-      {loading ? <Loading/> : null}
-      </Container> :
-      <Header as='h2' icon='exclamation circle' content="No template found!"/>
-    )
+    <Header as="h2" icon="exclamation circle" content="No template found!" />
+  )
 }
 
 export default ApplicationCreate

--- a/src/containers/Application/ApplicationCreate.tsx
+++ b/src/containers/Application/ApplicationCreate.tsx
@@ -1,22 +1,20 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import {
   Application,
   ApplicationSection,
-  Template,
   TemplateElement,
-  TemplateSection,
   useGetApplicationQuery,
-  useGetTemplateQuery,
 } from '../../utils/generated/graphql'
-import { TemplatePayload, TemplateSectionPayload } from '../../utils/types'
+import { TemplateTypePayload } from '../../utils/types'
 import { ApplicationStart, Loading } from '../../components'
 import { useApplicationState, Page } from '../../contexts/ApplicationState'
 import { useRouter } from '../../utils/hooks/useRouter'
-import { Container } from 'semantic-ui-react'
+import { Container, Header, Label } from 'semantic-ui-react'
+import useLoadTemplate from '../../utils/hooks/useLoadTemplate'
 
 interface ApplicationCreateProps {
   type: string
-  handleClick: (template: TemplatePayload) => void
+  handleClick: (template: TemplateTypePayload) => void
 }
 
 type FlattenType = {
@@ -28,51 +26,18 @@ type FlattenType = {
 }
 
 const ApplicationCreate: React.FC<ApplicationCreateProps> = (props) => {
-  const [ currentTemplate, setTemplate ] = useState<TemplatePayload | null>(null)
-  const [ currentTemplateSections, setSections ] = useState<TemplateSectionPayload[]| null>(null)
   const { applicationState, setApplicationState } = useApplicationState()
   const { type, handleClick } = props
   const { replace } = useRouter()
 
-  const { data: templateData, loading: loadingTemplate, error: errorTemplate } = useGetTemplateQuery({ 
-    variables: { 
-      code: type 
-    } 
-  })
+  const template = useLoadTemplate({type})
+  const { currentType, currentSections } = template
 
   const { data, loading, error} = useGetApplicationQuery({
     variables: {
       serial: applicationState.serialNumber as number
     }
   })
-
-  useEffect(() => {
-    if (templateData && templateData.templates && templateData.templates.nodes) {
-      if (templateData.templates.nodes.length > 1)
-        console.log('More than one template returned. Only one expected!')
-
-      // Send the template to the local state
-      const template = templateData.templates.nodes[0] as Template
-      const { id, code, name } = template
-      const templateName = name ? name : 'Undefined name'
-      const templateType = { id, code, name: templateName, description: 'Include some description for this template', documents: Array<string>()}
-      setTemplate(templateType)
-
-      // Send the template sections to the local state
-      if (template.templateSections && template.templateSections.nodes) {
-        if (template.templateSections.nodes.length === 0)
-          console.log('No Section on the template returned. At least one expected!')
-        else {
-          const sections = template.templateSections.nodes.map((section) => {
-            const { id, code, title, templateElementsBySectionId} = section as TemplateSection
-            const elementsCount = templateElementsBySectionId.nodes.length
-            return { id, code: code as string, title: title as string, elementsCount }
-          })
-          setSections(sections)
-        }
-      }
-    }
-  }, [templateData, errorTemplate])
 
   useEffect(()=> {
     if (data && data.applications && data.applications.nodes.length>0) {
@@ -138,20 +103,20 @@ const ApplicationCreate: React.FC<ApplicationCreateProps> = (props) => {
     }
   }, [applicationState])
 
-  return loadingTemplate ? (
+  return template.loading ? (
     <Loading />
   ) : (
-    currentTemplate && currentTemplateSections && (
+    currentType && currentSections ?
       <Container>
         <ApplicationStart
-          template={currentTemplate}
-          sections={currentTemplateSections}
-          handleClick={() => handleClick(currentTemplate)}
+          template={currentType}
+          sections={currentSections}
+          handleClick={() => handleClick(currentType)}
         />
       {loading ? <Loading/> : null}
-      </Container>
+      </Container> :
+      <Header as='h2' icon='exclamation circle' content="No template found!"/>
     )
-  )
 }
 
 export default ApplicationCreate

--- a/src/containers/Application/ApplicationNew.tsx
+++ b/src/containers/Application/ApplicationNew.tsx
@@ -29,7 +29,7 @@ const ApplicationNew: React.FC = () => {
     refetchQueries: [
       {
         query: getApplicationQuery,
-        variables: { serial: Number(applicationState.serialNumber) },
+        variables: { serial: applicationState.serialNumber },
       },
     ],
   })
@@ -60,7 +60,7 @@ function handleCreateApplication(createApplicationMutation: any, payload: Applic
     createApplicationMutation({
       variables: {
         name: `Test application of ${template.name}`,
-        serial: Number(serialNumber),
+        serial: serialNumber,
         templateId: template.id,
       },
     })

--- a/src/containers/Application/ApplicationNew.tsx
+++ b/src/containers/Application/ApplicationNew.tsx
@@ -2,11 +2,12 @@ import React from 'react'
 import ApplicationCreate from './ApplicationCreate'
 import { ApplicationSelectType } from '../../components'
 import { useRouter } from '../../utils/hooks/useRouter'
-import { Application,
+import {
+  Application,
   CreateApplicationMutation,
   CreateSectionMutation,
   useCreateApplicationMutation,
-useCreateSectionMutation,
+  useCreateSectionMutation,
 } from '../../utils/generated/graphql'
 import { ApplicationPayload, SectionPayload, TemplateTypePayload } from '../../utils/types'
 import getApplicationQuery from '../../utils/graphql/queries/getApplication.query'
@@ -16,11 +17,12 @@ const ApplicationNew: React.FC = () => {
   const { applicationState, setApplicationState } = useApplicationState()
   const { query } = useRouter()
   const { type } = query
-  
+
   const [createApplicationMutation] = useCreateApplicationMutation({
     onCompleted: (data: CreateApplicationMutation) => {
-    onCreateApplicationCompleted(data, createSectionMutation)
-  }})
+      onCreateApplicationCompleted(data, createSectionMutation)
+    },
+  })
   const [createSectionMutation] = useCreateSectionMutation({
     onCompleted: onCreateSectionsCompleted,
     // Update cached query of getApplication
@@ -33,15 +35,18 @@ const ApplicationNew: React.FC = () => {
   })
 
   return type ? (
-    <ApplicationCreate type={type} handleClick={(template: TemplateTypePayload) => {
-       // TODO: New issue to generate serial - should be done in server?
-      const serialNumber = Math.round(Math.random() * 10000)
-      setApplicationState({type: 'setSerialNumber', serialNumber})
-      handleCreateApplication(createApplicationMutation, {
-        template,
-        serialNumber 
-      })}
-    }/>
+    <ApplicationCreate
+      type={type}
+      handleClick={(template: TemplateTypePayload) => {
+        // TODO: New issue to generate serial - should be done in server?
+        const serialNumber = Math.round(Math.random() * 10000).toString()
+        setApplicationState({ type: 'setSerialNumber', serialNumber })
+        handleCreateApplication(createApplicationMutation, {
+          template,
+          serialNumber,
+        })
+      }}
+    />
   ) : (
     <ApplicationSelectType />
   )
@@ -49,7 +54,7 @@ const ApplicationNew: React.FC = () => {
 
 export default ApplicationNew
 
-function handleCreateApplication (createApplicationMutation: any, payload: ApplicationPayload) {
+function handleCreateApplication(createApplicationMutation: any, payload: ApplicationPayload) {
   const { serialNumber, template } = payload
   try {
     createApplicationMutation({
@@ -57,14 +62,17 @@ function handleCreateApplication (createApplicationMutation: any, payload: Appli
         name: `Test application of ${template.name}`,
         serial: Number(serialNumber),
         templateId: template.id,
-      }
+      },
     })
   } catch (error) {
     console.error(error)
   }
 }
 
-function onCreateApplicationCompleted ({createApplication}: CreateApplicationMutation, createSectionMutation: any) {
+function onCreateApplicationCompleted(
+  { createApplication }: CreateApplicationMutation,
+  createSectionMutation: any
+) {
   if (createApplication) {
     const application = createApplication.application as Application
     if (application.template && application.template.templateSections.nodes) {
@@ -72,12 +80,15 @@ function onCreateApplicationCompleted ({createApplication}: CreateApplicationMut
         section ? section.id : -1
       )
       console.log(`Success to create application ${application.serial}!`)
-      createApplicationSection({ applicationId: application.id, templateSections: sections }, createSectionMutation)
+      createApplicationSection(
+        { applicationId: application.id, templateSections: sections },
+        createSectionMutation
+      )
     } else console.log('Create application failed - no sections!')
   } else console.log('Create application failed - no data!')
 }
 
-function createApplicationSection (payload: SectionPayload, createSectionMutation: any) {
+function createApplicationSection(payload: SectionPayload, createSectionMutation: any) {
   const { applicationId, templateSections } = payload
   try {
     templateSections.forEach((sectionId) => {
@@ -85,15 +96,15 @@ function createApplicationSection (payload: SectionPayload, createSectionMutatio
         variables: {
           applicationId,
           templateSectionId: sectionId,
-        }
+        },
       })
     })
   } catch (error) {
     console.error(error)
   }
 }
-  
-function onCreateSectionsCompleted ({ createApplicationSection }: CreateSectionMutation) {
+
+function onCreateSectionsCompleted({ createApplicationSection }: CreateSectionMutation) {
   if (
     createApplicationSection &&
     createApplicationSection.applicationSection &&

--- a/src/containers/Application/ApplicationNew.tsx
+++ b/src/containers/Application/ApplicationNew.tsx
@@ -8,7 +8,7 @@ import { Application,
   useCreateApplicationMutation,
 useCreateSectionMutation,
 } from '../../utils/generated/graphql'
-import { ApplicationPayload, SectionPayload, TemplatePayload } from '../../utils/types'
+import { ApplicationPayload, SectionPayload, TemplateTypePayload } from '../../utils/types'
 import getApplicationQuery from '../../utils/graphql/queries/getApplication.query'
 import { useApplicationState } from '../../contexts/ApplicationState'
 
@@ -33,7 +33,7 @@ const ApplicationNew: React.FC = () => {
   })
 
   return type ? (
-    <ApplicationCreate type={type} handleClick={(template: TemplatePayload) => {
+    <ApplicationCreate type={type} handleClick={(template: TemplateTypePayload) => {
        // TODO: New issue to generate serial - should be done in server?
       const serialNumber = Math.round(Math.random() * 10000)
       setApplicationState({type: 'setSerialNumber', serialNumber})

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -2,20 +2,17 @@ import React, { useEffect, useState } from 'react'
 import { useRouter } from '../../utils/hooks/useRouter'
 import ApplicationStep from './ApplicationStep'
 import { ApplicationHeader, Loading } from '../../components'
-import {
-  Application,
-  useGetApplicationQuery,
-} from '../../utils/generated/graphql'
+import { Application, useGetApplicationQuery } from '../../utils/generated/graphql'
 import { Container, Grid, Label, Segment } from 'semantic-ui-react'
 
 const ApplicationPage: React.FC = () => {
-  const [ applicationName, setName ] = useState('')
+  const [applicationName, setName] = useState('')
   const { query } = useRouter()
   const { mode, serialNumber } = query
 
   const { data, loading, error } = useGetApplicationQuery({
     variables: {
-      serial: Number(serialNumber),
+      serial: serialNumber as string,
     },
   })
 
@@ -34,22 +31,24 @@ const ApplicationPage: React.FC = () => {
   return loading ? (
     <Loading />
   ) : serialNumber ? (
-  <Segment.Group>
-    <ApplicationHeader mode={mode} serialNumber={serialNumber} name={applicationName} />
-    <Container>
-      <Grid columns={2} stackable textAlign='center'>
-        <Grid.Row>
-          <Grid.Column>
-            <Segment>Place holder for progress</Segment>
-          </Grid.Column>
-          <Grid.Column>
-            <ApplicationStep/>
-          </Grid.Column>
-        </Grid.Row>
-      </Grid>
-    </Container>
+    <Segment.Group>
+      <ApplicationHeader mode={mode} serialNumber={serialNumber} name={applicationName} />
+      <Container>
+        <Grid columns={2} stackable textAlign="center">
+          <Grid.Row>
+            <Grid.Column>
+              <Segment>Place holder for progress</Segment>
+            </Grid.Column>
+            <Grid.Column>
+              <ApplicationStep />
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+      </Container>
     </Segment.Group>
-    ) : <Label content="Application can't be displayed"/>
+  ) : (
+    <Label content="Application can't be displayed" />
+  )
 }
 
 export default ApplicationPage

--- a/src/contexts/ApplicationState.tsx
+++ b/src/contexts/ApplicationState.tsx
@@ -12,22 +12,22 @@ type ApplicationState = {
   pageIndex: number | null
   pageNumber: number | null
   pages: Page[] | null
-  serialNumber: number | null
+  serialNumber: string | null
 }
 
 export type ApplicationActions =
   | {
       type: 'setSerialNumber'
-      serialNumber: number
+      serialNumber: string
     }
   | {
-    type: 'setCurretPage'
-    pageNumber: number
-  }
+      type: 'setCurretPage'
+      pageNumber: number
+    }
   | {
-    type: 'setPages'
-    pages: Page[]
-  }
+      type: 'setPages'
+      pages: Page[]
+    }
   | {
       type: 'reset'
     }
@@ -42,21 +42,21 @@ const reducer = (state: ApplicationState, action: ApplicationActions) => {
         ...state,
         serialNumber,
       }
-      case 'setCurretPage':
-        const { pageNumber } = action
-        return {
-          ...state,
-          pageIndex: (!state.pages) ? null : state.pages.length >= pageNumber ? pageNumber-1 : null,
-          pageNumber 
-        }
-      case 'setPages':
-        const { pages } = action
-        return {
-          ...state,
-          pages,
-          pageIndex: pages.length > 0 ? 0 : null,
-          pageNumber: 1
-        }
+    case 'setCurretPage':
+      const { pageNumber } = action
+      return {
+        ...state,
+        pageIndex: !state.pages ? null : state.pages.length >= pageNumber ? pageNumber - 1 : null,
+        pageNumber,
+      }
+    case 'setPages':
+      const { pages } = action
+      return {
+        ...state,
+        pages,
+        pageIndex: pages.length > 0 ? 0 : null,
+        pageNumber: 1,
+      }
     case 'reset':
       return initialState
     default:
@@ -68,7 +68,7 @@ const initialState: ApplicationState = {
   pageIndex: null,
   pageNumber: null,
   pages: null,
-  serialNumber: null
+  serialNumber: null,
 }
 
 // By setting the typings here, we ensure we get intellisense in VS Code

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -91,6 +91,7 @@ export type Query = Node & {
   actionPlugin?: Maybe<ActionPlugin>;
   actionQueue?: Maybe<ActionQueue>;
   application?: Maybe<Application>;
+  applicationBySerial?: Maybe<Application>;
   applicationResponse?: Maybe<ApplicationResponse>;
   applicationSection?: Maybe<ApplicationSection>;
   applicationStageHistory?: Maybe<ApplicationStageHistory>;
@@ -593,6 +594,12 @@ export type QueryActionQueueArgs = {
 /** The root query type which gives access points into the data universe. */
 export type QueryApplicationArgs = {
   id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryApplicationBySerialArgs = {
+  serial: Scalars['String'];
 };
 
 
@@ -1562,8 +1569,6 @@ export enum ApplicationsOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
-  UniqueIdentifierAsc = 'UNIQUE_IDENTIFIER_ASC',
-  UniqueIdentifierDesc = 'UNIQUE_IDENTIFIER_DESC',
   TemplateIdAsc = 'TEMPLATE_ID_ASC',
   TemplateIdDesc = 'TEMPLATE_ID_DESC',
   UserIdAsc = 'USER_ID_ASC',
@@ -1586,14 +1591,12 @@ export enum ApplicationsOrderBy {
 export type ApplicationCondition = {
   /** Checks for equality with the object’s `id` field. */
   id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `uniqueIdentifier` field. */
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `templateId` field. */
   templateId?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `userId` field. */
   userId?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `serial` field. */
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `name` field. */
   name?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `outcome` field. */
@@ -1614,14 +1617,12 @@ export enum ApplicationOutcome {
 export type ApplicationFilter = {
   /** Filter by the object’s `id` field. */
   id?: Maybe<IntFilter>;
-  /** Filter by the object’s `uniqueIdentifier` field. */
-  uniqueIdentifier?: Maybe<StringFilter>;
   /** Filter by the object’s `templateId` field. */
   templateId?: Maybe<IntFilter>;
   /** Filter by the object’s `userId` field. */
   userId?: Maybe<IntFilter>;
   /** Filter by the object’s `serial` field. */
-  serial?: Maybe<IntFilter>;
+  serial?: Maybe<StringFilter>;
   /** Filter by the object’s `name` field. */
   name?: Maybe<StringFilter>;
   /** Filter by the object’s `outcome` field. */
@@ -3159,10 +3160,9 @@ export type Application = Node & {
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: Scalars['ID'];
   id: Scalars['Int'];
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -5751,6 +5751,8 @@ export type Mutation = {
   updateApplicationByNodeId?: Maybe<UpdateApplicationPayload>;
   /** Updates a single `Application` using a unique key and a patch. */
   updateApplication?: Maybe<UpdateApplicationPayload>;
+  /** Updates a single `Application` using a unique key and a patch. */
+  updateApplicationBySerial?: Maybe<UpdateApplicationPayload>;
   /** Updates a single `ApplicationResponse` using its globally unique id and a patch. */
   updateApplicationResponseByNodeId?: Maybe<UpdateApplicationResponsePayload>;
   /** Updates a single `ApplicationResponse` using a unique key and a patch. */
@@ -5867,6 +5869,8 @@ export type Mutation = {
   deleteApplicationByNodeId?: Maybe<DeleteApplicationPayload>;
   /** Deletes a single `Application` using a unique key. */
   deleteApplication?: Maybe<DeleteApplicationPayload>;
+  /** Deletes a single `Application` using a unique key. */
+  deleteApplicationBySerial?: Maybe<DeleteApplicationPayload>;
   /** Deletes a single `ApplicationResponse` using its globally unique id. */
   deleteApplicationResponseByNodeId?: Maybe<DeleteApplicationResponsePayload>;
   /** Deletes a single `ApplicationResponse` using a unique key. */
@@ -6181,6 +6185,12 @@ export type MutationUpdateApplicationByNodeIdArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateApplicationArgs = {
   input: UpdateApplicationInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateApplicationBySerialArgs = {
+  input: UpdateApplicationBySerialInput;
 };
 
 
@@ -6529,6 +6539,12 @@ export type MutationDeleteApplicationByNodeIdArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteApplicationArgs = {
   input: DeleteApplicationInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteApplicationBySerialArgs = {
+  input: DeleteApplicationBySerialInput;
 };
 
 
@@ -7121,10 +7137,9 @@ export type CreateApplicationInput = {
 /** An input for mutations affecting `Application` */
 export type ApplicationInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8155,13 +8170,19 @@ export type ApplicationTemplateIdFkeyInverseInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<Array<ApplicationApplicationPkeyConnect>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<Array<ApplicationApplicationSerialKeyConnect>>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<Array<ApplicationNodeIdConnect>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<Array<ApplicationApplicationPkeyDelete>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<Array<ApplicationApplicationSerialKeyDelete>>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<Array<ApplicationNodeIdDelete>>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<Array<ApplicationOnApplicationForApplicationTemplateIdFkeyUsingApplicationPkeyUpdate>>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<Array<ApplicationOnApplicationForApplicationTemplateIdFkeyUsingApplicationSerialKeyUpdate>>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<Array<TemplateOnApplicationForApplicationTemplateIdFkeyNodeIdUpdate>>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8173,6 +8194,11 @@ export type ApplicationApplicationPkeyConnect = {
   id: Scalars['Int'];
 };
 
+/** The fields on `application` to look up the row to connect. */
+export type ApplicationApplicationSerialKeyConnect = {
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to connect. */
 export type ApplicationNodeIdConnect = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -8182,6 +8208,11 @@ export type ApplicationNodeIdConnect = {
 /** The fields on `application` to look up the row to delete. */
 export type ApplicationApplicationPkeyDelete = {
   id: Scalars['Int'];
+};
+
+/** The fields on `application` to look up the row to delete. */
+export type ApplicationApplicationSerialKeyDelete = {
+  serial: Scalars['String'];
 };
 
 /** The globally unique `ID` look up for the row to delete. */
@@ -8200,9 +8231,8 @@ export type ApplicationOnApplicationForApplicationTemplateIdFkeyUsingApplication
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnApplicationForApplicationTemplateIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8267,13 +8297,19 @@ export type ApplicationUserIdFkeyInverseInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<Array<ApplicationApplicationPkeyConnect>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<Array<ApplicationApplicationSerialKeyConnect>>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<Array<ApplicationNodeIdConnect>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<Array<ApplicationApplicationPkeyDelete>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<Array<ApplicationApplicationSerialKeyDelete>>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<Array<ApplicationNodeIdDelete>>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<Array<ApplicationOnApplicationForApplicationUserIdFkeyUsingApplicationPkeyUpdate>>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<Array<ApplicationOnApplicationForApplicationUserIdFkeyUsingApplicationSerialKeyUpdate>>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<Array<UserOnApplicationForApplicationUserIdFkeyNodeIdUpdate>>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8290,9 +8326,8 @@ export type ApplicationOnApplicationForApplicationUserIdFkeyUsingApplicationPkey
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnApplicationForApplicationUserIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8370,13 +8405,19 @@ export type ApplicationSectionApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnApplicationSectionForApplicationSectionApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnApplicationSectionForApplicationSectionApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<ApplicationSectionOnApplicationSectionForApplicationSectionApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8393,10 +8434,9 @@ export type ApplicationOnApplicationSectionForApplicationSectionApplicationIdFke
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnApplicationSectionForApplicationSectionApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8477,13 +8517,19 @@ export type ApplicationStageHistoryApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<ApplicationStageHistoryOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8500,10 +8546,9 @@ export type ApplicationOnApplicationStageHistoryForApplicationStageHistoryApplic
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8844,13 +8889,19 @@ export type ApplicationResponseApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnApplicationResponseForApplicationResponseApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnApplicationResponseForApplicationResponseApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<ApplicationResponseOnApplicationResponseForApplicationResponseApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8867,10 +8918,9 @@ export type ApplicationOnApplicationResponseForApplicationResponseApplicationIdF
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnApplicationResponseForApplicationResponseApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8951,13 +9001,19 @@ export type ReviewApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnReviewForReviewApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnReviewForReviewApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<ReviewOnReviewForReviewApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8974,10 +9030,9 @@ export type ApplicationOnReviewForReviewApplicationIdFkeyUsingApplicationPkeyUpd
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnReviewForReviewApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -9334,13 +9389,19 @@ export type FileApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnFileForFileApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnFileForFileApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<FileOnFileForFileApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -9357,10 +9418,9 @@ export type ApplicationOnFileForFileApplicationIdFkeyUsingApplicationPkeyUpdate 
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnFileForFileApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -9529,13 +9589,19 @@ export type NotificationApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnNotificationForNotificationApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnNotificationForNotificationApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<NotificationOnNotificationForNotificationApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -9552,10 +9618,9 @@ export type ApplicationOnNotificationForNotificationApplicationIdFkeyUsingApplic
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnNotificationForNotificationApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -9570,6 +9635,13 @@ export type UpdateApplicationOnNotificationForNotificationApplicationIdFkeyPatch
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnNotificationForNotificationApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnNotificationForNotificationApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type NotificationOnNotificationForNotificationApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -9581,10 +9653,9 @@ export type NotificationOnNotificationForNotificationApplicationIdFkeyNodeIdUpda
 /** Represents an update to a `Application`. Fields that are set will be updated. */
 export type ApplicationPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -9602,10 +9673,9 @@ export type ApplicationPatch = {
 /** The `application` to be created by this mutation. */
 export type NotificationApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -11615,6 +11685,13 @@ export type NotificationApplicationIdFkeyNotificationCreateInput = {
   fileToDocumentId?: Maybe<NotificationDocumentIdFkeyInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnFileForFileApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnFileForFileApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type FileOnFileForFileApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -11626,10 +11703,9 @@ export type FileOnFileForFileApplicationIdFkeyNodeIdUpdate = {
 /** The `application` to be created by this mutation. */
 export type FileApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -11810,6 +11886,13 @@ export type FileApplicationIdFkeyFileCreateInput = {
   notificationsUsingId?: Maybe<NotificationDocumentIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnReviewForReviewApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnReviewForReviewApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type ReviewOnReviewForReviewApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -11821,10 +11904,9 @@ export type ReviewOnReviewForReviewApplicationIdFkeyNodeIdUpdate = {
 /** The `application` to be created by this mutation. */
 export type ReviewApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -11859,6 +11941,13 @@ export type ReviewApplicationIdFkeyReviewCreateInput = {
   notificationsUsingId?: Maybe<NotificationReviewIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationResponseForApplicationResponseApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationResponseForApplicationResponseApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type ApplicationResponseOnApplicationResponseForApplicationResponseApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -11870,10 +11959,9 @@ export type ApplicationResponseOnApplicationResponseForApplicationResponseApplic
 /** The `application` to be created by this mutation. */
 export type ApplicationResponseApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -12068,6 +12156,13 @@ export type ApplicationResponseApplicationIdFkeyApplicationResponseCreateInput =
   filesUsingId?: Maybe<FileApplicationResponseIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type ApplicationStageHistoryOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -12079,10 +12174,9 @@ export type ApplicationStageHistoryOnApplicationStageHistoryForApplicationStageH
 /** The `application` to be created by this mutation. */
 export type ApplicationStageHistoryApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -12117,6 +12211,13 @@ export type ApplicationStageHistoryApplicationIdFkeyApplicationStageHistoryCreat
   reviewSectionAssignmentsUsingId?: Maybe<ReviewSectionAssignmentStageIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationSectionForApplicationSectionApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationSectionForApplicationSectionApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type ApplicationSectionOnApplicationSectionForApplicationSectionApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -12128,10 +12229,9 @@ export type ApplicationSectionOnApplicationSectionForApplicationSectionApplicati
 /** The `application` to be created by this mutation. */
 export type ApplicationSectionApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -12163,6 +12263,13 @@ export type ApplicationSectionApplicationIdFkeyApplicationSectionCreateInput = {
   reviewSectionAssignmentsUsingId?: Maybe<ReviewSectionAssignmentSectionIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationForApplicationUserIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationForApplicationUserIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type UserOnApplicationForApplicationUserIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -12174,9 +12281,8 @@ export type UserOnApplicationForApplicationUserIdFkeyNodeIdUpdate = {
 /** The `application` to be created by this mutation. */
 export type ApplicationUserIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -12217,6 +12323,13 @@ export type ApplicationUserIdFkeyUserCreateInput = {
   notificationsUsingId?: Maybe<NotificationUserIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationForApplicationTemplateIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationForApplicationTemplateIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type TemplateOnApplicationForApplicationTemplateIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -12228,9 +12341,8 @@ export type TemplateOnApplicationForApplicationTemplateIdFkeyNodeIdUpdate = {
 /** The `application` to be created by this mutation. */
 export type ApplicationTemplateIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -14189,6 +14301,15 @@ export type UpdateApplicationInput = {
   id: Scalars['Int'];
 };
 
+/** All input for the `updateApplicationBySerial` mutation. */
+export type UpdateApplicationBySerialInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `Application` being updated. */
+  patch: ApplicationPatch;
+  serial: Scalars['String'];
+};
+
 /** All input for the `updateApplicationResponseByNodeId` mutation. */
 export type UpdateApplicationResponseByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -15378,6 +15499,13 @@ export type DeleteApplicationInput = {
   id: Scalars['Int'];
 };
 
+/** All input for the `deleteApplicationBySerial` mutation. */
+export type DeleteApplicationBySerialInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  serial: Scalars['String'];
+};
+
 /** All input for the `deleteApplicationResponseByNodeId` mutation. */
 export type DeleteApplicationResponseByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -16373,7 +16501,7 @@ export type AddNewUserFragment = (
 
 export type CreateApplicationMutationVariables = Exact<{
   name: Scalars['String'];
-  serial: Scalars['Int'];
+  serial: Scalars['String'];
   templateId: Scalars['Int'];
 }>;
 
@@ -16479,7 +16607,7 @@ export type UpdateApplicationMutation = (
 );
 
 export type GetApplicationQueryVariables = Exact<{
-  serial: Scalars['Int'];
+  serial: Scalars['String'];
 }>;
 
 
@@ -16497,7 +16625,6 @@ export type GetApplicationQuery = (
         { __typename?: 'ApplicationSectionsConnection' }
         & { nodes: Array<Maybe<(
           { __typename?: 'ApplicationSection' }
-          & Pick<ApplicationSection, 'id'>
           & { templateSection?: Maybe<(
             { __typename?: 'TemplateSection' }
             & Pick<TemplateSection, 'id' | 'title' | 'code'>
@@ -16607,7 +16734,7 @@ export const AddNewUserFragmentDoc = gql`
 }
     `;
 export const CreateApplicationDocument = gql`
-    mutation createApplication($name: String!, $serial: Int!, $templateId: Int!) {
+    mutation createApplication($name: String!, $serial: String!, $templateId: Int!) {
   createApplication(input: {application: {name: $name, serial: $serial, templateId: $templateId, isActive: true, outcome: PENDING}}) {
     application {
       id
@@ -16805,7 +16932,7 @@ export type UpdateApplicationMutationHookResult = ReturnType<typeof useUpdateApp
 export type UpdateApplicationMutationResult = Apollo.MutationResult<UpdateApplicationMutation>;
 export type UpdateApplicationMutationOptions = Apollo.BaseMutationOptions<UpdateApplicationMutation, UpdateApplicationMutationVariables>;
 export const GetApplicationDocument = gql`
-    query getApplication($serial: Int!) {
+    query getApplication($serial: String!) {
   applications(condition: {serial: $serial}) {
     nodes {
       id
@@ -16819,7 +16946,6 @@ export const GetApplicationDocument = gql`
       }
       applicationSections {
         nodes {
-          id
           templateSection {
             id
             title

--- a/src/utils/graphql/mutations/createApplication.mutation.ts
+++ b/src/utils/graphql/mutations/createApplication.mutation.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export default gql`
-  mutation createApplication($name: String!, $serial: Int!, $templateId: Int!) {
+  mutation createApplication($name: String!, $serial: String!, $templateId: Int!) {
     createApplication(
       input: {
         application: {

--- a/src/utils/graphql/queries/getApplication.query.ts
+++ b/src/utils/graphql/queries/getApplication.query.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export default gql`
-  query getApplication($serial: Int!) {
+  query getApplication($serial: String!) {
     applications(condition: { serial: $serial }) {
       nodes {
         id

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -87,9 +87,9 @@ function checkForTemplateErrors(data: GetTemplateQuery | undefined) {
 }
 
 function checkForTemplatSectionErrors(template: Template) {
-  if (template?.templateSections?.nodes === null) return 'Uexpected template section result'
+  if (template?.templateSections?.nodes === null) return 'Unexpected template section result'
   const numberOfSections = template?.templateSections?.nodes.length as number
-  if (numberOfSections === 0) return 'No template secitons'
+  if (numberOfSections === 0) return 'No template sections'
   return null
 }
 

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -13,8 +13,8 @@ interface useLoadTemplateProps {
 
 const useLoadTemplate = (props: useLoadTemplateProps) => {
   const { templateCode } = props
-  const [currentType, setType] = useState<TemplateTypePayload | null>(null)
-  const [currentSections, setSections] = useState<TemplateSectionPayload[] | null>(null)
+  const [templateType, setTemplateType] = useState<TemplateTypePayload | null>(null)
+  const [templateSections, setTemplateSections] = useState<TemplateSectionPayload[] | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -59,14 +59,14 @@ const useLoadTemplate = (props: useLoadTemplateProps) => {
       return templateSection
     })
 
-    setType({
+    setTemplateType({
       id,
       code,
       name: name ? name : 'Undefined name',
       description: 'Include some description for this template',
       documents: Array<string>(),
     })
-    setSections(sections)
+    setTemplateSections(sections)
     setLoading(false)
   }, [data])
 
@@ -74,8 +74,8 @@ const useLoadTemplate = (props: useLoadTemplateProps) => {
     loading,
     appolloError,
     error,
-    currentType,
-    currentSections,
+    templateType,
+    templateSections,
   }
 }
 

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -18,16 +18,15 @@ const useLoadTemplate = (props: useLoadTemplateProps) => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
-  const { data, loading: appoloLoading, error: appolloError } = useGetTemplateQuery({
+  const { data, loading: appoloLoading, error: apolloError } = useGetTemplateQuery({
     variables: {
       code: templateCode,
     },
   })
 
   useEffect(() => {
-    if (appolloError) return
+    if (apolloError) return
     if (appoloLoading) return
-
     // Check that only one tempalte matched
     let error = checkForTemplateErrors(data)
     if (error) {
@@ -72,7 +71,7 @@ const useLoadTemplate = (props: useLoadTemplateProps) => {
 
   return {
     loading,
-    appolloError,
+    apolloError,
     error,
     templateType,
     templateSections,
@@ -80,7 +79,7 @@ const useLoadTemplate = (props: useLoadTemplateProps) => {
 }
 
 function checkForTemplateErrors(data: GetTemplateQuery | undefined) {
-  if (data?.templates?.nodes?.length) return 'Unexpected template result'
+  if (data?.templates?.nodes?.length === null) return 'Unexpected template result'
   const numberOfTemplates = data?.templates?.nodes.length as number
   if (numberOfTemplates === 0) return 'Template not found'
   if (numberOfTemplates > 1) return 'More then one template found'
@@ -88,7 +87,7 @@ function checkForTemplateErrors(data: GetTemplateQuery | undefined) {
 }
 
 function checkForTemplatSectionErrors(template: Template) {
-  if (template?.templateSections?.nodes) return 'Uexpected template section result'
+  if (template?.templateSections?.nodes === null) return 'Uexpected template section result'
   const numberOfSections = template?.templateSections?.nodes.length as number
   if (numberOfSections === 0) return 'No template secitons'
   return null

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+import { Template, TemplateSection, useGetTemplateQuery } from '../generated/graphql'
+import { TemplateTypePayload, TemplateSectionPayload } from '../types'
+
+interface useLoadTemplateProps {
+    type: string
+}
+
+const useLoadTemplate = (props: useLoadTemplateProps) => {
+    const { type } = props
+    const [ currentType, setType ] = useState<TemplateTypePayload | null>(null)
+    const [ currentSections, setSections ] = useState<TemplateSectionPayload[]| null>(null)
+    
+    const { data, loading, error } = useGetTemplateQuery({
+        variables: { 
+            code: type 
+          }
+    })
+
+    useEffect(() => {
+        if (data && data.templates) {
+            if (data.templates.nodes.length === 0) return
+            if (data.templates.nodes.length > 1)
+              console.log('More than one template returned. Only one expected!')
+            console.log('data.templates', data.templates);
+            
+            // Send the template to the local state
+            const template = data.templates.nodes[0] as Template
+            console.log('template', template);
+            
+            const { id, code, name } = template
+            const templateType = { 
+                id, 
+                code, 
+                name: name ? name : 'Undefined name', 
+                description: 'Include some description for this template', 
+                documents: Array<string>()
+            }
+            setType(templateType)
+      
+            // Send the template sections to the local state
+            if (template.templateSections && template.templateSections.nodes) {
+              if (template.templateSections.nodes.length === 0)
+                console.log('No Section on the template returned. At least one expected!')
+              else {
+                const sections = template.templateSections.nodes.map((section) => {
+                  const { id, code, title, templateElementsBySectionId} = section as TemplateSection
+                  const elementsCount = templateElementsBySectionId.nodes.length
+                  const templateSection: TemplateSectionPayload = {
+                    id, 
+                    code: code as string, 
+                    title: title as string, 
+                    elementsCount
+                  }
+                  return templateSection
+                })
+                setSections(sections)
+              }
+            }
+          }
+    }, [data])
+
+    return {
+        loading,
+        error,
+        currentType,
+        currentSections
+    }
+}
+
+export default useLoadTemplate

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -6,7 +6,7 @@ export {
 }
 
 interface ApplicationPayload {
-    serialNumber: number
+    serialNumber: string
     template: TemplateTypePayload
 }
   

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,13 +1,13 @@
 export {
     ApplicationPayload,
     SectionPayload,
-    TemplatePayload,
+    TemplateTypePayload,
     TemplateSectionPayload
 }
 
 interface ApplicationPayload {
     serialNumber: number
-    template: TemplatePayload
+    template: TemplateTypePayload
 }
   
 interface SectionPayload {
@@ -15,7 +15,7 @@ interface SectionPayload {
     templateSections: number[]
 }
 
-interface TemplatePayload {
+interface TemplateTypePayload {
     id: number
     name: string
     code: string


### PR DESCRIPTION
Fix #27. Merging to #14 (will be merged back to master as bulk).

## Changes
- Renamed type `TemplatePayload` to TemplateTypePayload`
- Created hook to do `getTemplateQuery`. It makes the query using another Apollo-client hook that returns `data`, `loading` and `error`.  The `data` returned is manipulated after its returned to get only a few properties. Then the properties, error and loading status are returned by this hook. 