### PR TITLE
#28 Hook to load application (with all elements)

### DIFF
--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react'
+import {
+    Application,
+    ApplicationSection,
+    useGetApplicationQuery,
+  } from '../../utils/generated/graphql'
+
+interface useLoadApplicationProps {
+    serialNumber: number
+}
+
+const useLoadApplication = (props: useLoadApplicationProps) => {
+    const { serialNumber } = props
+    const [ currentSection, setCurrentSection ] = useState<string | null>(null)
+
+    const { data, loading, error} = useGetApplicationQuery({
+        variables: {
+          serial: serialNumber
+        }
+      })
+
+
+  useEffect(()=> {
+    if (data && data.applications) {
+        if (data.applications.nodes.length === 0) return
+      if (data.applications.nodes.length > 1)
+        console.log('More than one application returned. Only one expected!')
+        const application = data.applications.nodes[0] as Application
+      
+        // Check the return application has sections
+        if (!application.applicationSections || 
+          application.applicationSections.nodes.length === 0)
+          return
+
+        // Find title of first section in application
+        const section = application.applicationSections.nodes[0] as ApplicationSection
+        const { templateSection } = section
+        if (!templateSection) return
+
+        // TODO: Remove elements not visible in the current stage...
+
+        const { code } = templateSection
+        setCurrentSection(code as string)
+    }
+  }, [data, error])
+
+  return {
+      error,
+      loading,
+      currentSection
+  }
+}
+
+export default useLoadApplication


### PR DESCRIPTION
Fix #28. Merging to #14 (will be merged back to master as bulk).

## Changes
- Removed use of `pages` from ApplicationState - since the logic to get the pages in each section will be moved (see #33)
- Created hook to do `getApplicationQuery`. It makes the query using another Apollo-client hook that returns `data`, `loading` and `error`.  The goal is to have all the elements from one application loaded in cache before the application can be filled by the user - all the next queries for each section will be using the data stored in the cache. 
For now what is returned by this hook is the currentSection `code` to be used in the URL. This will change depending on the application be a draft - it should show the application on the same step the applicant was filling - which is not been done yet!