### PR TITLE
#35 Response object hook

### DIFF
--- a/src/components/Application/ApplicationStart.tsx
+++ b/src/components/Application/ApplicationStart.tsx
@@ -1,16 +1,16 @@
 import React from 'react'
 import { Button, Container, Header, Label, List, Segment } from 'semantic-ui-react'
-import { TemplatePayload, TemplateSectionPayload } from '../../utils/types'
+import { TemplateTypePayload, TemplateSectionPayload } from '../../utils/types'
 
 export interface ApplicationStartProps {
-  template: TemplatePayload
+  template: TemplateTypePayload
   sections: TemplateSectionPayload[]
   handleClick: () => void
 }
 
 const ApplicationStart: React.FC<ApplicationStartProps> = (props) => {
   const { template: type, sections, handleClick } = props
-  
+
   return (
     <Container text>
       <Header as="h1" content={type ? type.description : 'Create application page'} />
@@ -25,10 +25,7 @@ const ApplicationStart: React.FC<ApplicationStartProps> = (props) => {
                 <List.Item key={`list-item-${section.code}`} content={section.title} />
               ))}
           </List>
-          <Button
-            content={type.name}
-            onClick={handleClick}
-          />
+          <Button content={type.name} onClick={handleClick} />
         </Segment>
       )}
       {!type && <Label content="No Application" />}

--- a/src/containers/Application/ApplicationCreate.tsx
+++ b/src/containers/Application/ApplicationCreate.tsx
@@ -1,9 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import {
-  Template,
-  TemplateSection,
-  useGetTemplateQuery,
-} from '../../utils/generated/graphql'
+import { Template, TemplateSection, useGetTemplateQuery } from '../../utils/generated/graphql'
 import { TemplatePayload, TemplateSectionPayload } from '../../utils/types'
 import { ApplicationStart, Loading } from '../../components'
 import { useApplicationState } from '../../contexts/ApplicationState'
@@ -25,20 +21,24 @@ type FlattenType = {
 }
 
 const ApplicationCreate: React.FC<ApplicationCreateProps> = (props) => {
-  const [ currentTemplate, setTemplate ] = useState<TemplatePayload | null>(null)
-  const [ currentTemplateSections, setSections ] = useState<TemplateSectionPayload[]| null>(null)
+  const [currentTemplate, setTemplate] = useState<TemplatePayload | null>(null)
+  const [currentTemplateSections, setSections] = useState<TemplateSectionPayload[] | null>(null)
   const { applicationState } = useApplicationState()
   const { serialNumber } = applicationState
   const { type, handleClick } = props
   const { push } = useRouter()
 
-  const { data: templateData, loading: loadingTemplate, error: errorTemplate } = useGetTemplateQuery({ 
-    variables: { 
-      code: type 
-    } 
+  const {
+    data: templateData,
+    loading: loadingTemplate,
+    error: errorTemplate,
+  } = useGetTemplateQuery({
+    variables: {
+      code: type,
+    },
   })
 
-  const application = useLoadApplication({serialNumber: serialNumber as number})
+  const application = useLoadApplication({ serialNumber: serialNumber as string })
   const { currentSection } = application
 
   useEffect(() => {
@@ -50,7 +50,13 @@ const ApplicationCreate: React.FC<ApplicationCreateProps> = (props) => {
       const template = templateData.templates.nodes[0] as Template
       const { id, code, name } = template
       const templateName = name ? name : 'Undefined name'
-      const templateType = { id, code, name: templateName, description: 'Include some description for this template', documents: Array<string>()}
+      const templateType = {
+        id,
+        code,
+        name: templateName,
+        description: 'Include some description for this template',
+        documents: Array<string>(),
+      }
       setTemplate(templateType)
 
       // Send the template sections to the local state
@@ -59,7 +65,7 @@ const ApplicationCreate: React.FC<ApplicationCreateProps> = (props) => {
           console.log('No Section on the template returned. At least one expected!')
         else {
           const sections = template.templateSections.nodes.map((section) => {
-            const { id, code, title, templateElementsBySectionId} = section as TemplateSection
+            const { id, code, title, templateElementsBySectionId } = section as TemplateSection
             const elementsCount = templateElementsBySectionId.nodes.length
             return { id, code: code as string, title: title as string, elementsCount }
           })
@@ -88,7 +94,7 @@ const ApplicationCreate: React.FC<ApplicationCreateProps> = (props) => {
           sections={currentTemplateSections}
           handleClick={() => handleClick(currentTemplate)}
         />
-      {application.loading ? <Loading/> : null}
+        {application.loading ? <Loading /> : null}
       </Container>
     )
   )

--- a/src/containers/Application/ApplicationCreate.tsx
+++ b/src/containers/Application/ApplicationCreate.tsx
@@ -1,15 +1,21 @@
-import React, { useEffect, useState } from 'react'
-import { Template, TemplateSection, useGetTemplateQuery } from '../../utils/generated/graphql'
-import { TemplatePayload, TemplateSectionPayload } from '../../utils/types'
+import React, { useEffect } from 'react'
+import {
+  Application,
+  ApplicationSection,
+  TemplateElement,
+  useGetApplicationQuery,
+} from '../../utils/generated/graphql'
+import { TemplateTypePayload } from '../../utils/types'
 import { ApplicationStart, Loading } from '../../components'
 import { useApplicationState } from '../../contexts/ApplicationState'
 import { useRouter } from '../../utils/hooks/useRouter'
-import { Container } from 'semantic-ui-react'
+import { Container, Header, Label } from 'semantic-ui-react'
+import useLoadTemplate from '../../utils/hooks/useLoadTemplate'
 import useLoadApplication from '../../utils/hooks/useLoadApplication'
 
 interface ApplicationCreateProps {
   type: string
-  handleClick: (template: TemplatePayload) => void
+  handleClick: (template: TemplateTypePayload) => void
 }
 
 type FlattenType = {
@@ -21,59 +27,16 @@ type FlattenType = {
 }
 
 const ApplicationCreate: React.FC<ApplicationCreateProps> = (props) => {
-  const [currentTemplate, setTemplate] = useState<TemplatePayload | null>(null)
-  const [currentTemplateSections, setSections] = useState<TemplateSectionPayload[] | null>(null)
-  const { applicationState } = useApplicationState()
-  const { serialNumber } = applicationState
-  const { type, handleClick } = props
+  const { applicationState, setApplicationState } = useApplicationState()
+  const { type: templateCode, handleClick } = props
   const { push } = useRouter()
+  const { serialNumber } = applicationState
 
-  const {
-    data: templateData,
-    loading: loadingTemplate,
-    error: errorTemplate,
-  } = useGetTemplateQuery({
-    variables: {
-      code: type,
-    },
+  const { loading: templateIsLoading, templateType, templateSections } = useLoadTemplate({
+    templateCode,
   })
 
-  const application = useLoadApplication({ serialNumber: serialNumber as string })
-  const { currentSection } = application
-
-  useEffect(() => {
-    if (templateData && templateData.templates && templateData.templates.nodes) {
-      if (templateData.templates.nodes.length > 1)
-        console.log('More than one template returned. Only one expected!')
-
-      // Send the template to the local state
-      const template = templateData.templates.nodes[0] as Template
-      const { id, code, name } = template
-      const templateName = name ? name : 'Undefined name'
-      const templateType = {
-        id,
-        code,
-        name: templateName,
-        description: 'Include some description for this template',
-        documents: Array<string>(),
-      }
-      setTemplate(templateType)
-
-      // Send the template sections to the local state
-      if (template.templateSections && template.templateSections.nodes) {
-        if (template.templateSections.nodes.length === 0)
-          console.log('No Section on the template returned. At least one expected!')
-        else {
-          const sections = template.templateSections.nodes.map((section) => {
-            const { id, code, title, templateElementsBySectionId } = section as TemplateSection
-            const elementsCount = templateElementsBySectionId.nodes.length
-            return { id, code: code as string, title: title as string, elementsCount }
-          })
-          setSections(sections)
-        }
-      }
-    }
-  }, [templateData, errorTemplate])
+  const { currentSection, loading } = useLoadApplication({ serialNumber: serialNumber as string })
 
   useEffect(() => {
     if (serialNumber && currentSection) {
@@ -84,19 +47,19 @@ const ApplicationCreate: React.FC<ApplicationCreateProps> = (props) => {
     }
   }, [serialNumber, currentSection])
 
-  return loadingTemplate ? (
+  return templateIsLoading ? (
     <Loading />
+  ) : templateType && templateSections ? (
+    <Container>
+      <ApplicationStart
+        template={templateType}
+        sections={templateSections}
+        handleClick={() => handleClick(templateType)}
+      />
+      {loading ? <Loading /> : null}
+    </Container>
   ) : (
-    currentTemplate && currentTemplateSections && (
-      <Container>
-        <ApplicationStart
-          template={currentTemplate}
-          sections={currentTemplateSections}
-          handleClick={() => handleClick(currentTemplate)}
-        />
-        {application.loading ? <Loading /> : null}
-      </Container>
-    )
+    <Header as="h2" icon="exclamation circle" content="No template found!" />
   )
 }
 

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -2,14 +2,12 @@ import React, { useEffect, useState } from 'react'
 import { useRouter } from '../../utils/hooks/useRouter'
 import ApplicationStep from './ApplicationStep'
 import { ApplicationHeader, Loading } from '../../components'
-import {
-  Application,
-  useGetApplicationQuery,
-} from '../../utils/generated/graphql'
+import { Application, useGetApplicationQuery } from '../../utils/generated/graphql'
 import { Container, Grid, Label, Segment } from 'semantic-ui-react'
+import useGetAllResponses from '../../utils/hooks/useGetAllResponses'
 
 const ApplicationPage: React.FC = () => {
-  const [ applicationName, setName ] = useState('')
+  const [applicationName, setName] = useState('')
   const { query } = useRouter()
   const { mode, serialNumber } = query
 
@@ -18,6 +16,10 @@ const ApplicationPage: React.FC = () => {
       serial: Number(serialNumber),
     },
   })
+
+  const { allResponses } = useGetAllResponses({ serialNumber: Number(serialNumber) })
+
+  // console.log(allResponses)
 
   useEffect(() => {
     if (data && data.applications && data.applications.nodes) {
@@ -34,22 +36,24 @@ const ApplicationPage: React.FC = () => {
   return loading ? (
     <Loading />
   ) : serialNumber ? (
-  <Segment.Group>
-    <ApplicationHeader mode={mode} serialNumber={serialNumber} name={applicationName} />
-    <Container>
-      <Grid columns={2} stackable textAlign='center'>
-        <Grid.Row>
-          <Grid.Column>
-            <Segment>Place holder for progress</Segment>
-          </Grid.Column>
-          <Grid.Column>
-            <ApplicationStep/>
-          </Grid.Column>
-        </Grid.Row>
-      </Grid>
-    </Container>
+    <Segment.Group>
+      <ApplicationHeader mode={mode} serialNumber={serialNumber} name={applicationName} />
+      <Container>
+        <Grid columns={2} stackable textAlign="center">
+          <Grid.Row>
+            <Grid.Column>
+              <Segment>Place holder for progress</Segment>
+            </Grid.Column>
+            <Grid.Column>
+              <ApplicationStep />
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
+      </Container>
     </Segment.Group>
-    ) : <Label content="Application can't be displayed"/>
+  ) : (
+    <Label content="Application can't be displayed" />
+  )
 }
 
 export default ApplicationPage

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -4,7 +4,7 @@ import ApplicationStep from './ApplicationStep'
 import { ApplicationHeader, Loading } from '../../components'
 import { Application, useGetApplicationQuery } from '../../utils/generated/graphql'
 import { Container, Grid, Label, Segment } from 'semantic-ui-react'
-import useGetAllResponses from '../../utils/hooks/useGetAllResponses'
+import useGetResponsesByCode from '../../utils/hooks/useGetResponsesByCode'
 
 const ApplicationPage: React.FC = () => {
   const [applicationName, setName] = useState('')
@@ -13,11 +13,11 @@ const ApplicationPage: React.FC = () => {
 
   const { data, loading, error } = useGetApplicationQuery({
     variables: {
-      serial: Number(serialNumber),
+      serial: serialNumber as string,
     },
   })
 
-  const { responsesByCode } = useGetAllResponses({ serialNumber: Number(serialNumber) })
+  const { responsesByCode } = useGetResponsesByCode({ serialNumber: serialNumber as string })
 
   useEffect(() => {
     if (data && data.applications && data.applications.nodes) {

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -17,9 +17,7 @@ const ApplicationPage: React.FC = () => {
     },
   })
 
-  const { allResponses } = useGetAllResponses({ serialNumber: Number(serialNumber) })
-
-  // console.log(allResponses)
+  const { responsesByCode } = useGetAllResponses({ serialNumber: Number(serialNumber) })
 
   useEffect(() => {
     if (data && data.applications && data.applications.nodes) {

--- a/src/contexts/ApplicationState.tsx
+++ b/src/contexts/ApplicationState.tsx
@@ -12,22 +12,22 @@ type ApplicationState = {
   pageIndex: number | null
   pageNumber: number | null
   pages: Page[] | null
-  serialNumber: number | null
+  serialNumber: string | null
 }
 
 export type ApplicationActions =
   | {
       type: 'setSerialNumber'
-      serialNumber: number
+      serialNumber: string
     }
   | {
-    type: 'setCurretPage'
-    pageNumber: number
-  }
+      type: 'setCurretPage'
+      pageNumber: number
+    }
   | {
-    type: 'setPages'
-    pages: Page[]
-  }
+      type: 'setPages'
+      pages: Page[]
+    }
   | {
       type: 'reset'
     }
@@ -42,21 +42,21 @@ const reducer = (state: ApplicationState, action: ApplicationActions) => {
         ...state,
         serialNumber,
       }
-      case 'setCurretPage':
-        const { pageNumber } = action
-        return {
-          ...state,
-          pageIndex: (!state.pages) ? null : state.pages.length >= pageNumber ? pageNumber-1 : null,
-          pageNumber 
-        }
-      case 'setPages':
-        const { pages } = action
-        return {
-          ...state,
-          pages,
-          pageIndex: pages.length > 0 ? 0 : null,
-          pageNumber: 1
-        }
+    case 'setCurretPage':
+      const { pageNumber } = action
+      return {
+        ...state,
+        pageIndex: !state.pages ? null : state.pages.length >= pageNumber ? pageNumber - 1 : null,
+        pageNumber,
+      }
+    case 'setPages':
+      const { pages } = action
+      return {
+        ...state,
+        pages,
+        pageIndex: pages.length > 0 ? 0 : null,
+        pageNumber: 1,
+      }
     case 'reset':
       return initialState
     default:
@@ -68,7 +68,7 @@ const initialState: ApplicationState = {
   pageIndex: null,
   pageNumber: null,
   pages: null,
-  serialNumber: null
+  serialNumber: null,
 }
 
 // By setting the typings here, we ensure we get intellisense in VS Code

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -16497,7 +16497,6 @@ export type GetApplicationQuery = (
         { __typename?: 'ApplicationSectionsConnection' }
         & { nodes: Array<Maybe<(
           { __typename?: 'ApplicationSection' }
-          & Pick<ApplicationSection, 'id'>
           & { templateSection?: Maybe<(
             { __typename?: 'TemplateSection' }
             & Pick<TemplateSection, 'id' | 'title' | 'code'>
@@ -16508,6 +16507,16 @@ export type GetApplicationQuery = (
                 & Pick<TemplateElement, 'code' | 'elementTypePluginCode'>
               )>> }
             ) }
+          )> }
+        )>> }
+      ), applicationResponses: (
+        { __typename?: 'ApplicationResponsesConnection' }
+        & { nodes: Array<Maybe<(
+          { __typename?: 'ApplicationResponse' }
+          & Pick<ApplicationResponse, 'value'>
+          & { templateElement?: Maybe<(
+            { __typename?: 'TemplateElement' }
+            & Pick<TemplateElement, 'code'>
           )> }
         )>> }
       ) }
@@ -16819,7 +16828,6 @@ export const GetApplicationDocument = gql`
       }
       applicationSections {
         nodes {
-          id
           templateSection {
             id
             title

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -16833,6 +16833,14 @@ export const GetApplicationDocument = gql`
           }
         }
       }
+      applicationResponses {
+        nodes {
+          value
+          templateElement {
+            code
+          }
+        }
+      }
     }
   }
 }

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -16566,6 +16566,13 @@ export type CreateSectionMutation = (
       & { templateSection?: Maybe<(
         { __typename?: 'TemplateSection' }
         & Pick<TemplateSection, 'title'>
+        & { templateElementsBySectionId: (
+          { __typename?: 'TemplateElementsConnection' }
+          & { nodes: Array<Maybe<(
+            { __typename?: 'TemplateElement' }
+            & Pick<TemplateElement, 'id' | 'code' | 'category' | 'elementTypePluginCode'>
+          )>> }
+        ) }
       )> }
     )> }
   )> }
@@ -16837,6 +16844,14 @@ export const CreateSectionDocument = gql`
       applicationId
       templateSection {
         title
+        templateElementsBySectionId {
+          nodes {
+            id
+            code
+            category
+            elementTypePluginCode
+          }
+        }
       }
     }
   }

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -91,6 +91,7 @@ export type Query = Node & {
   actionPlugin?: Maybe<ActionPlugin>;
   actionQueue?: Maybe<ActionQueue>;
   application?: Maybe<Application>;
+  applicationBySerial?: Maybe<Application>;
   applicationResponse?: Maybe<ApplicationResponse>;
   applicationSection?: Maybe<ApplicationSection>;
   applicationStageHistory?: Maybe<ApplicationStageHistory>;
@@ -593,6 +594,12 @@ export type QueryActionQueueArgs = {
 /** The root query type which gives access points into the data universe. */
 export type QueryApplicationArgs = {
   id: Scalars['Int'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryApplicationBySerialArgs = {
+  serial: Scalars['String'];
 };
 
 
@@ -1562,8 +1569,6 @@ export enum ApplicationsOrderBy {
   Natural = 'NATURAL',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
-  UniqueIdentifierAsc = 'UNIQUE_IDENTIFIER_ASC',
-  UniqueIdentifierDesc = 'UNIQUE_IDENTIFIER_DESC',
   TemplateIdAsc = 'TEMPLATE_ID_ASC',
   TemplateIdDesc = 'TEMPLATE_ID_DESC',
   UserIdAsc = 'USER_ID_ASC',
@@ -1586,14 +1591,12 @@ export enum ApplicationsOrderBy {
 export type ApplicationCondition = {
   /** Checks for equality with the object’s `id` field. */
   id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `uniqueIdentifier` field. */
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `templateId` field. */
   templateId?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `userId` field. */
   userId?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `serial` field. */
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `name` field. */
   name?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `outcome` field. */
@@ -1614,14 +1617,12 @@ export enum ApplicationOutcome {
 export type ApplicationFilter = {
   /** Filter by the object’s `id` field. */
   id?: Maybe<IntFilter>;
-  /** Filter by the object’s `uniqueIdentifier` field. */
-  uniqueIdentifier?: Maybe<StringFilter>;
   /** Filter by the object’s `templateId` field. */
   templateId?: Maybe<IntFilter>;
   /** Filter by the object’s `userId` field. */
   userId?: Maybe<IntFilter>;
   /** Filter by the object’s `serial` field. */
-  serial?: Maybe<IntFilter>;
+  serial?: Maybe<StringFilter>;
   /** Filter by the object’s `name` field. */
   name?: Maybe<StringFilter>;
   /** Filter by the object’s `outcome` field. */
@@ -3159,10 +3160,9 @@ export type Application = Node & {
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: Scalars['ID'];
   id: Scalars['Int'];
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -5751,6 +5751,8 @@ export type Mutation = {
   updateApplicationByNodeId?: Maybe<UpdateApplicationPayload>;
   /** Updates a single `Application` using a unique key and a patch. */
   updateApplication?: Maybe<UpdateApplicationPayload>;
+  /** Updates a single `Application` using a unique key and a patch. */
+  updateApplicationBySerial?: Maybe<UpdateApplicationPayload>;
   /** Updates a single `ApplicationResponse` using its globally unique id and a patch. */
   updateApplicationResponseByNodeId?: Maybe<UpdateApplicationResponsePayload>;
   /** Updates a single `ApplicationResponse` using a unique key and a patch. */
@@ -5867,6 +5869,8 @@ export type Mutation = {
   deleteApplicationByNodeId?: Maybe<DeleteApplicationPayload>;
   /** Deletes a single `Application` using a unique key. */
   deleteApplication?: Maybe<DeleteApplicationPayload>;
+  /** Deletes a single `Application` using a unique key. */
+  deleteApplicationBySerial?: Maybe<DeleteApplicationPayload>;
   /** Deletes a single `ApplicationResponse` using its globally unique id. */
   deleteApplicationResponseByNodeId?: Maybe<DeleteApplicationResponsePayload>;
   /** Deletes a single `ApplicationResponse` using a unique key. */
@@ -6181,6 +6185,12 @@ export type MutationUpdateApplicationByNodeIdArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateApplicationArgs = {
   input: UpdateApplicationInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateApplicationBySerialArgs = {
+  input: UpdateApplicationBySerialInput;
 };
 
 
@@ -6529,6 +6539,12 @@ export type MutationDeleteApplicationByNodeIdArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteApplicationArgs = {
   input: DeleteApplicationInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteApplicationBySerialArgs = {
+  input: DeleteApplicationBySerialInput;
 };
 
 
@@ -7121,10 +7137,9 @@ export type CreateApplicationInput = {
 /** An input for mutations affecting `Application` */
 export type ApplicationInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8155,13 +8170,19 @@ export type ApplicationTemplateIdFkeyInverseInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<Array<ApplicationApplicationPkeyConnect>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<Array<ApplicationApplicationSerialKeyConnect>>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<Array<ApplicationNodeIdConnect>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<Array<ApplicationApplicationPkeyDelete>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<Array<ApplicationApplicationSerialKeyDelete>>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<Array<ApplicationNodeIdDelete>>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<Array<ApplicationOnApplicationForApplicationTemplateIdFkeyUsingApplicationPkeyUpdate>>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<Array<ApplicationOnApplicationForApplicationTemplateIdFkeyUsingApplicationSerialKeyUpdate>>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<Array<TemplateOnApplicationForApplicationTemplateIdFkeyNodeIdUpdate>>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8173,6 +8194,11 @@ export type ApplicationApplicationPkeyConnect = {
   id: Scalars['Int'];
 };
 
+/** The fields on `application` to look up the row to connect. */
+export type ApplicationApplicationSerialKeyConnect = {
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to connect. */
 export type ApplicationNodeIdConnect = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -8182,6 +8208,11 @@ export type ApplicationNodeIdConnect = {
 /** The fields on `application` to look up the row to delete. */
 export type ApplicationApplicationPkeyDelete = {
   id: Scalars['Int'];
+};
+
+/** The fields on `application` to look up the row to delete. */
+export type ApplicationApplicationSerialKeyDelete = {
+  serial: Scalars['String'];
 };
 
 /** The globally unique `ID` look up for the row to delete. */
@@ -8200,9 +8231,8 @@ export type ApplicationOnApplicationForApplicationTemplateIdFkeyUsingApplication
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnApplicationForApplicationTemplateIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8267,13 +8297,19 @@ export type ApplicationUserIdFkeyInverseInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<Array<ApplicationApplicationPkeyConnect>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<Array<ApplicationApplicationSerialKeyConnect>>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<Array<ApplicationNodeIdConnect>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<Array<ApplicationApplicationPkeyDelete>>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<Array<ApplicationApplicationSerialKeyDelete>>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<Array<ApplicationNodeIdDelete>>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<Array<ApplicationOnApplicationForApplicationUserIdFkeyUsingApplicationPkeyUpdate>>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<Array<ApplicationOnApplicationForApplicationUserIdFkeyUsingApplicationSerialKeyUpdate>>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<Array<UserOnApplicationForApplicationUserIdFkeyNodeIdUpdate>>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8290,9 +8326,8 @@ export type ApplicationOnApplicationForApplicationUserIdFkeyUsingApplicationPkey
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnApplicationForApplicationUserIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8370,13 +8405,19 @@ export type ApplicationSectionApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnApplicationSectionForApplicationSectionApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnApplicationSectionForApplicationSectionApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<ApplicationSectionOnApplicationSectionForApplicationSectionApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8393,10 +8434,9 @@ export type ApplicationOnApplicationSectionForApplicationSectionApplicationIdFke
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnApplicationSectionForApplicationSectionApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8477,13 +8517,19 @@ export type ApplicationStageHistoryApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<ApplicationStageHistoryOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8500,10 +8546,9 @@ export type ApplicationOnApplicationStageHistoryForApplicationStageHistoryApplic
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8844,13 +8889,19 @@ export type ApplicationResponseApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnApplicationResponseForApplicationResponseApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnApplicationResponseForApplicationResponseApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<ApplicationResponseOnApplicationResponseForApplicationResponseApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8867,10 +8918,9 @@ export type ApplicationOnApplicationResponseForApplicationResponseApplicationIdF
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnApplicationResponseForApplicationResponseApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -8951,13 +9001,19 @@ export type ReviewApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnReviewForReviewApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnReviewForReviewApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<ReviewOnReviewForReviewApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -8974,10 +9030,9 @@ export type ApplicationOnReviewForReviewApplicationIdFkeyUsingApplicationPkeyUpd
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnReviewForReviewApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -9334,13 +9389,19 @@ export type FileApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnFileForFileApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnFileForFileApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<FileOnFileForFileApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -9357,10 +9418,9 @@ export type ApplicationOnFileForFileApplicationIdFkeyUsingApplicationPkeyUpdate 
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnFileForFileApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -9529,13 +9589,19 @@ export type NotificationApplicationIdFkeyInput = {
   /** The primary key(s) for `application` for the far side of the relationship. */
   connectById?: Maybe<ApplicationApplicationPkeyConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  connectBySerial?: Maybe<ApplicationApplicationSerialKeyConnect>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   connectByNodeId?: Maybe<ApplicationNodeIdConnect>;
   /** The primary key(s) for `application` for the far side of the relationship. */
   deleteById?: Maybe<ApplicationApplicationPkeyDelete>;
   /** The primary key(s) for `application` for the far side of the relationship. */
+  deleteBySerial?: Maybe<ApplicationApplicationSerialKeyDelete>;
+  /** The primary key(s) for `application` for the far side of the relationship. */
   deleteByNodeId?: Maybe<ApplicationNodeIdDelete>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateById?: Maybe<ApplicationOnNotificationForNotificationApplicationIdFkeyUsingApplicationPkeyUpdate>;
+  /** The primary key(s) and patch data for `application` for the far side of the relationship. */
+  updateBySerial?: Maybe<ApplicationOnNotificationForNotificationApplicationIdFkeyUsingApplicationSerialKeyUpdate>;
   /** The primary key(s) and patch data for `application` for the far side of the relationship. */
   updateByNodeId?: Maybe<NotificationOnNotificationForNotificationApplicationIdFkeyNodeIdUpdate>;
   /** A `ApplicationInput` object that will be created and connected to this object. */
@@ -9552,10 +9618,9 @@ export type ApplicationOnNotificationForNotificationApplicationIdFkeyUsingApplic
 /** An object where the defined keys will be set on the `application` being updated. */
 export type UpdateApplicationOnNotificationForNotificationApplicationIdFkeyPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -9570,6 +9635,13 @@ export type UpdateApplicationOnNotificationForNotificationApplicationIdFkeyPatch
   notificationsUsingId?: Maybe<NotificationApplicationIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnNotificationForNotificationApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnNotificationForNotificationApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type NotificationOnNotificationForNotificationApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -9581,10 +9653,9 @@ export type NotificationOnNotificationForNotificationApplicationIdFkeyNodeIdUpda
 /** Represents an update to a `Application`. Fields that are set will be updated. */
 export type ApplicationPatch = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -9602,10 +9673,9 @@ export type ApplicationPatch = {
 /** The `application` to be created by this mutation. */
 export type NotificationApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -11615,6 +11685,13 @@ export type NotificationApplicationIdFkeyNotificationCreateInput = {
   fileToDocumentId?: Maybe<NotificationDocumentIdFkeyInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnFileForFileApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnFileForFileApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type FileOnFileForFileApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -11626,10 +11703,9 @@ export type FileOnFileForFileApplicationIdFkeyNodeIdUpdate = {
 /** The `application` to be created by this mutation. */
 export type FileApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -11810,6 +11886,13 @@ export type FileApplicationIdFkeyFileCreateInput = {
   notificationsUsingId?: Maybe<NotificationDocumentIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnReviewForReviewApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnReviewForReviewApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type ReviewOnReviewForReviewApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -11821,10 +11904,9 @@ export type ReviewOnReviewForReviewApplicationIdFkeyNodeIdUpdate = {
 /** The `application` to be created by this mutation. */
 export type ReviewApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -11859,6 +11941,13 @@ export type ReviewApplicationIdFkeyReviewCreateInput = {
   notificationsUsingId?: Maybe<NotificationReviewIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationResponseForApplicationResponseApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationResponseForApplicationResponseApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type ApplicationResponseOnApplicationResponseForApplicationResponseApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -11870,10 +11959,9 @@ export type ApplicationResponseOnApplicationResponseForApplicationResponseApplic
 /** The `application` to be created by this mutation. */
 export type ApplicationResponseApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -12068,6 +12156,13 @@ export type ApplicationResponseApplicationIdFkeyApplicationResponseCreateInput =
   filesUsingId?: Maybe<FileApplicationResponseIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type ApplicationStageHistoryOnApplicationStageHistoryForApplicationStageHistoryApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -12079,10 +12174,9 @@ export type ApplicationStageHistoryOnApplicationStageHistoryForApplicationStageH
 /** The `application` to be created by this mutation. */
 export type ApplicationStageHistoryApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -12117,6 +12211,13 @@ export type ApplicationStageHistoryApplicationIdFkeyApplicationStageHistoryCreat
   reviewSectionAssignmentsUsingId?: Maybe<ReviewSectionAssignmentStageIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationSectionForApplicationSectionApplicationIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationSectionForApplicationSectionApplicationIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type ApplicationSectionOnApplicationSectionForApplicationSectionApplicationIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -12128,10 +12229,9 @@ export type ApplicationSectionOnApplicationSectionForApplicationSectionApplicati
 /** The `application` to be created by this mutation. */
 export type ApplicationSectionApplicationIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -12163,6 +12263,13 @@ export type ApplicationSectionApplicationIdFkeyApplicationSectionCreateInput = {
   reviewSectionAssignmentsUsingId?: Maybe<ReviewSectionAssignmentSectionIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationForApplicationUserIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationForApplicationUserIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type UserOnApplicationForApplicationUserIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -12174,9 +12281,8 @@ export type UserOnApplicationForApplicationUserIdFkeyNodeIdUpdate = {
 /** The `application` to be created by this mutation. */
 export type ApplicationUserIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   templateId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -12217,6 +12323,13 @@ export type ApplicationUserIdFkeyUserCreateInput = {
   notificationsUsingId?: Maybe<NotificationUserIdFkeyInverseInput>;
 };
 
+/** The fields on `application` to look up the row to update. */
+export type ApplicationOnApplicationForApplicationTemplateIdFkeyUsingApplicationSerialKeyUpdate = {
+  /** An object where the defined keys will be set on the `application` being updated. */
+  patch: UpdateApplicationOnApplicationForApplicationTemplateIdFkeyPatch;
+  serial: Scalars['String'];
+};
+
 /** The globally unique `ID` look up for the row to update. */
 export type TemplateOnApplicationForApplicationTemplateIdFkeyNodeIdUpdate = {
   /** The globally unique `ID` which identifies a single `application` to be connected. */
@@ -12228,9 +12341,8 @@ export type TemplateOnApplicationForApplicationTemplateIdFkeyNodeIdUpdate = {
 /** The `application` to be created by this mutation. */
 export type ApplicationTemplateIdFkeyApplicationCreateInput = {
   id?: Maybe<Scalars['Int']>;
-  uniqueIdentifier?: Maybe<Scalars['String']>;
   userId?: Maybe<Scalars['Int']>;
-  serial?: Maybe<Scalars['Int']>;
+  serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   outcome?: Maybe<ApplicationOutcome>;
   isActive?: Maybe<Scalars['Boolean']>;
@@ -14189,6 +14301,15 @@ export type UpdateApplicationInput = {
   id: Scalars['Int'];
 };
 
+/** All input for the `updateApplicationBySerial` mutation. */
+export type UpdateApplicationBySerialInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `Application` being updated. */
+  patch: ApplicationPatch;
+  serial: Scalars['String'];
+};
+
 /** All input for the `updateApplicationResponseByNodeId` mutation. */
 export type UpdateApplicationResponseByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -15378,6 +15499,13 @@ export type DeleteApplicationInput = {
   id: Scalars['Int'];
 };
 
+/** All input for the `deleteApplicationBySerial` mutation. */
+export type DeleteApplicationBySerialInput = {
+  /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
+  clientMutationId?: Maybe<Scalars['String']>;
+  serial: Scalars['String'];
+};
+
 /** All input for the `deleteApplicationResponseByNodeId` mutation. */
 export type DeleteApplicationResponseByNodeIdInput = {
   /** An arbitrary string value with no semantic meaning. Will be included in the payload verbatim. May be used to track mutations by the client. */
@@ -16373,7 +16501,7 @@ export type AddNewUserFragment = (
 
 export type CreateApplicationMutationVariables = Exact<{
   name: Scalars['String'];
-  serial: Scalars['Int'];
+  serial: Scalars['String'];
   templateId: Scalars['Int'];
 }>;
 
@@ -16479,7 +16607,7 @@ export type UpdateApplicationMutation = (
 );
 
 export type GetApplicationQueryVariables = Exact<{
-  serial: Scalars['Int'];
+  serial: Scalars['String'];
 }>;
 
 
@@ -16616,7 +16744,7 @@ export const AddNewUserFragmentDoc = gql`
 }
     `;
 export const CreateApplicationDocument = gql`
-    mutation createApplication($name: String!, $serial: Int!, $templateId: Int!) {
+    mutation createApplication($name: String!, $serial: String!, $templateId: Int!) {
   createApplication(input: {application: {name: $name, serial: $serial, templateId: $templateId, isActive: true, outcome: PENDING}}) {
     application {
       id
@@ -16814,7 +16942,7 @@ export type UpdateApplicationMutationHookResult = ReturnType<typeof useUpdateApp
 export type UpdateApplicationMutationResult = Apollo.MutationResult<UpdateApplicationMutation>;
 export type UpdateApplicationMutationOptions = Apollo.BaseMutationOptions<UpdateApplicationMutation, UpdateApplicationMutationVariables>;
 export const GetApplicationDocument = gql`
-    query getApplication($serial: Int!) {
+    query getApplication($serial: String!) {
   applications(condition: {serial: $serial}) {
     nodes {
       id

--- a/src/utils/graphql/mutations/createApplication.mutation.ts
+++ b/src/utils/graphql/mutations/createApplication.mutation.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export default gql`
-  mutation createApplication($name: String!, $serial: Int!, $templateId: Int!) {
+  mutation createApplication($name: String!, $serial: String!, $templateId: Int!) {
     createApplication(
       input: {
         application: {

--- a/src/utils/graphql/mutations/createSection.mutation.ts
+++ b/src/utils/graphql/mutations/createSection.mutation.ts
@@ -11,6 +11,14 @@ export default gql`
         applicationId
         templateSection {
           title
+          templateElementsBySectionId {
+            nodes {
+              id
+              code
+              category
+              elementTypePluginCode
+            }
+          }
         }
       }
     }

--- a/src/utils/graphql/queries/getApplication.query.ts
+++ b/src/utils/graphql/queries/getApplication.query.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client'
 
 export default gql`
-  query getApplication($serial: Int!) {
+  query getApplication($serial: String!) {
     applications(condition: { serial: $serial }) {
       nodes {
         id

--- a/src/utils/graphql/queries/getApplication.query.ts
+++ b/src/utils/graphql/queries/getApplication.query.ts
@@ -28,6 +28,14 @@ export default gql`
             }
           }
         }
+        applicationResponses {
+          nodes {
+            value
+            templateElement {
+              code
+            }
+          }
+        }
       }
     }
   }

--- a/src/utils/hooks/useCreateApplication.tsx
+++ b/src/utils/hooks/useCreateApplication.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react'
+import {
+    Application,
+    ApplicationSection,
+    CreateApplicationMutation,
+    CreateResponseMutation,
+    CreateSectionMutation,
+    TemplateElement,
+    TemplateSection,
+    useCreateApplicationMutation,
+    useCreateResponseMutation,
+    useCreateSectionMutation,
+  } from '../../utils/generated/graphql'
+  import getApplicationQuery from '../../utils/graphql/queries/getApplication.query'
+import { ResponsePayload, SectionPayload } from '../types'
+
+const useCreateApplication = () => {
+    const [ serialNumber, setSerialNumber ] = useState<string | null>(null)
+
+    const [ applicationMutation ] = useCreateApplicationMutation({
+        onCompleted: (data: CreateApplicationMutation) =>         
+            onCreateApplicationCompleted(data, setSerialNumber, sectionMutation)
+    })
+
+    const [ sectionMutation ] = useCreateSectionMutation({
+        onCompleted: (data: CreateSectionMutation) => 
+            onCreateSectionCompleted(data, responseMutation),
+        
+        // Update cached query of getApplication
+        refetchQueries: [
+            {
+                query: getApplicationQuery,
+                variables: { serial: serialNumber },
+            },
+        ],
+    })
+
+    const [ responseMutation ] = useCreateResponseMutation({
+        onCompleted: onCreateResponseCompleted,
+        // TODO: Update cached query of getResponses -- if needed
+    })
+
+    return {
+        applicationMutation 
+    }
+}
+  
+function onCreateApplicationCompleted ({createApplication}: CreateApplicationMutation, 
+    setSerialNumber: React.Dispatch<React.SetStateAction<string| null>>, 
+    sectionMutation: any) {
+    
+    const { id, serial, template } = createApplication?.application as Application
+    const sectionsIds = template?.templateSections.nodes.map(section => section ? section.id : null)
+
+    if (id && serial && sectionsIds) {
+        console.log(`Success to create application: ${serial}!`)
+        setSerialNumber(serial)
+        createApplicationSections({ 
+            applicationId: id, 
+            templateSections: sectionsIds 
+        }, sectionMutation)
+
+    } else console.log('Failed to create application - wrong data!', createApplication)
+}
+  
+function createApplicationSections (payload: SectionPayload, sectionMutation: any) {
+    const { applicationId, templateSections } = payload
+    try {
+        templateSections.forEach((id) => {
+            sectionMutation({
+                variables: {
+                    applicationId,
+                    templateSectionId: id,
+                }
+            })
+        })
+    } catch (error) {
+        console.error(error)
+    }
+}
+
+function onCreateSectionCompleted ({ createApplicationSection }: CreateSectionMutation, responseMutation: any) {  
+    const { applicationId, templateSection } = createApplicationSection?.applicationSection as ApplicationSection
+    const elements = templateSection?.templateElementsBySectionId.nodes as TemplateElement[]
+
+    if (applicationId && templateSection && elements) {
+        const questions = elements.filter(({category}) => category === 'QUESTION')
+        console.log(`Success to create application section: ${templateSection.title}`)
+
+        createApplicationResponse({ 
+            applicationId: applicationId as number, 
+            templateQuestions: questions
+        }, responseMutation)
+    } else console.log('Failed to create application section - wrong data!', createApplicationSection)
+}
+
+function createApplicationResponse (payload: ResponsePayload, responseMutation: any) {
+    const { applicationId, templateQuestions } = payload
+    try {
+        templateQuestions.forEach(({id}) => {
+            responseMutation({
+                variables: {
+                    applicationId,
+                    templateElementId: id,
+                    timeCreated: new Date(Date.now())
+                }
+            })
+        })
+    } catch (error) {
+        console.error(error)
+    }
+}
+
+function onCreateResponseCompleted ({ createApplicationResponse }: CreateResponseMutation) {
+    const question = createApplicationResponse?.applicationResponse?.templateElement as TemplateElement
+    if (question) {
+        console.log(`Success to create application response: ${question.code}`)
+    } else console.log('Failed to create application response - wrong data!', createApplicationResponse)
+}
+
+export default useCreateApplication

--- a/src/utils/hooks/useGetAllResponses.tsx
+++ b/src/utils/hooks/useGetAllResponses.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect } from 'react'
-import { Application, ApplicationSection, useGetApplicationQuery } from '../generated/graphql'
-import { AllResponses } from '../types'
+import {
+  Application,
+  ApplicationResponse,
+  ApplicationSection,
+  useGetApplicationQuery,
+} from '../generated/graphql'
+import { ResponsesByCode } from '../types'
 
 interface useLoadApplicationProps {
   serialNumber: number
@@ -8,7 +13,7 @@ interface useLoadApplicationProps {
 
 const useGetAllResponses = (props: useLoadApplicationProps) => {
   const { serialNumber } = props
-  const [allResponses, setAllResponses] = useState({})
+  const [responsesByCode, setResponsesByCode] = useState({})
   const { data, loading, error } = useGetApplicationQuery({
     variables: { serial: serialNumber },
   })
@@ -19,23 +24,24 @@ const useGetAllResponses = (props: useLoadApplicationProps) => {
       if (data.applications.nodes.length > 1)
         console.log('More than one application returned. Only one expected!')
 
-      const applicationResponses = data.applications.nodes[0]?.applicationResponses.nodes
+      const applicationResponses = data.applications.nodes[0]?.applicationResponses
+        .nodes as ApplicationResponse[]
 
-      const currentResponses = {} as AllResponses
+      const currentResponses = {} as ResponsesByCode
 
-      applicationResponses?.forEach((response) => {
+      applicationResponses.forEach((response) => {
         const code = response?.templateElement?.code
         if (code) currentResponses[code] = response?.value?.text || response?.value
       })
 
-      setAllResponses(currentResponses)
+      setResponsesByCode(currentResponses)
     }
   }, [data, error])
 
   return {
     error,
     loading,
-    allResponses,
+    responsesByCode,
   }
 }
 

--- a/src/utils/hooks/useGetAllResponses.tsx
+++ b/src/utils/hooks/useGetAllResponses.tsx
@@ -1,38 +1,31 @@
 import { useState, useEffect } from 'react'
-import {
-    Application,
-    ApplicationSection,
-    useGetApplicationQuery,
-  } from '../generated/graphql'
-import { Response, AllResponses} from '../types'
+import { Application, ApplicationSection, useGetApplicationQuery } from '../generated/graphql'
+import { AllResponses } from '../types'
 
 interface useLoadApplicationProps {
-    serialNumber: number
+  serialNumber: number
 }
 
 const useGetAllResponses = (props: useLoadApplicationProps) => {
-    const { serialNumber } = props
-    const [allResponses, setAllResponses] = useState({})
-    const { data, loading, error} = useGetApplicationQuery({
-        variables: {
-          serial: serialNumber
-        }
-      })
+  const { serialNumber } = props
+  const [allResponses, setAllResponses] = useState({})
+  const { data, loading, error } = useGetApplicationQuery({
+    variables: { serial: serialNumber },
+  })
 
-
-  useEffect(()=> {
+  useEffect(() => {
     if (data?.applications) {
-        if (data.applications.nodes.length === 0) return
+      if (data.applications.nodes.length === 0) return
       if (data.applications.nodes.length > 1)
         console.log('More than one application returned. Only one expected!')
-        
+
       const applicationResponses = data.applications.nodes[0]?.applicationResponses.nodes
-      
+
       const currentResponses = {} as AllResponses
 
       applicationResponses?.forEach((response) => {
         const code = response?.templateElement?.code
-        if (code) currentResponses[code] = response?.value
+        if (code) currentResponses[code] = response?.value?.text || response?.value
       })
 
       setAllResponses(currentResponses)
@@ -40,9 +33,9 @@ const useGetAllResponses = (props: useLoadApplicationProps) => {
   }, [data, error])
 
   return {
-      error,
-      loading,
-      allResponses
+    error,
+    loading,
+    allResponses,
   }
 }
 

--- a/src/utils/hooks/useGetAllResponses.tsx
+++ b/src/utils/hooks/useGetAllResponses.tsx
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react'
+import {
+    Application,
+    ApplicationSection,
+    useGetApplicationQuery,
+  } from '../generated/graphql'
+import { Response, AllResponses} from '../types'
+
+interface useLoadApplicationProps {
+    serialNumber: number
+}
+
+const useGetAllResponses = (props: useLoadApplicationProps) => {
+    const { serialNumber } = props
+    const [allResponses, setAllResponses] = useState({})
+    const { data, loading, error} = useGetApplicationQuery({
+        variables: {
+          serial: serialNumber
+        }
+      })
+
+
+  useEffect(()=> {
+    if (data?.applications) {
+        if (data.applications.nodes.length === 0) return
+      if (data.applications.nodes.length > 1)
+        console.log('More than one application returned. Only one expected!')
+        
+      const applicationResponses = data.applications.nodes[0]?.applicationResponses.nodes
+      
+      const currentResponses = {} as AllResponses
+
+      applicationResponses?.forEach((response) => {
+        const code = response?.templateElement?.code
+        if (code) currentResponses[code] = response?.value
+      })
+
+      setAllResponses(currentResponses)
+    }
+  }, [data, error])
+
+  return {
+      error,
+      loading,
+      allResponses
+  }
+}
+
+export default useGetAllResponses

--- a/src/utils/hooks/useGetResponsesByCode.tsx
+++ b/src/utils/hooks/useGetResponsesByCode.tsx
@@ -8,10 +8,10 @@ import {
 import { ResponsesByCode } from '../types'
 
 interface useLoadApplicationProps {
-  serialNumber: number
+  serialNumber: string
 }
 
-const useGetAllResponses = (props: useLoadApplicationProps) => {
+const useGetResponsesByCode = (props: useLoadApplicationProps) => {
   const { serialNumber } = props
   const [responsesByCode, setResponsesByCode] = useState({})
   const { data, loading, error } = useGetApplicationQuery({
@@ -45,4 +45,4 @@ const useGetAllResponses = (props: useLoadApplicationProps) => {
   }
 }
 
-export default useGetAllResponses
+export default useGetResponsesByCode

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -3,7 +3,7 @@ import {
     Application,
     ApplicationSection,
     useGetApplicationQuery,
-  } from '../../utils/generated/graphql'
+  } from '../generated/graphql'
 
 interface useLoadApplicationProps {
     serialNumber: number

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -1,53 +1,47 @@
 import { useState, useEffect } from 'react'
-import {
-    Application,
-    ApplicationSection,
-    useGetApplicationQuery,
-  } from '../generated/graphql'
+import { Application, ApplicationSection, useGetApplicationQuery } from '../generated/graphql'
 
 interface useLoadApplicationProps {
-    serialNumber: number
+  serialNumber: string
 }
 
 const useLoadApplication = (props: useLoadApplicationProps) => {
-    const { serialNumber } = props
-    const [ currentSection, setCurrentSection ] = useState<string | null>(null)
+  const { serialNumber } = props
+  const [currentSection, setCurrentSection] = useState<string | null>(null)
 
-    const { data, loading, error} = useGetApplicationQuery({
-        variables: {
-          serial: serialNumber
-        }
-      })
+  const { data, loading, error } = useGetApplicationQuery({
+    variables: {
+      serial: serialNumber,
+    },
+  })
 
-
-  useEffect(()=> {
+  useEffect(() => {
     if (data && data.applications) {
-        if (data.applications.nodes.length === 0) return
+      if (data.applications.nodes.length === 0) return
       if (data.applications.nodes.length > 1)
         console.log('More than one application returned. Only one expected!')
-        const application = data.applications.nodes[0] as Application
-      
-        // Check the return application has sections
-        if (!application.applicationSections || 
-          application.applicationSections.nodes.length === 0)
-          return
+      const application = data.applications.nodes[0] as Application
 
-        // Find title of first section in application
-        const section = application.applicationSections.nodes[0] as ApplicationSection
-        const { templateSection } = section
-        if (!templateSection) return
+      // Check the return application has sections
+      if (!application.applicationSections || application.applicationSections.nodes.length === 0)
+        return
 
-        // TODO: Remove elements not visible in the current stage...
+      // Find title of first section in application
+      const section = application.applicationSections.nodes[0] as ApplicationSection
+      const { templateSection } = section
+      if (!templateSection) return
 
-        const { code } = templateSection
-        setCurrentSection(code as string)
+      // TODO: Remove elements not visible in the current stage...
+
+      const { code } = templateSection
+      setCurrentSection(code as string)
     }
   }, [data, error])
 
   return {
-      error,
-      loading,
-      currentSection
+    error,
+    loading,
+    currentSection,
   }
 }
 

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+import {
+  GetTemplateQuery,
+  Template,
+  TemplateSection,
+  useGetTemplateQuery,
+} from '../generated/graphql'
+import { TemplateTypePayload, TemplateSectionPayload } from '../types'
+
+interface useLoadTemplateProps {
+  templateCode: string
+}
+
+const useLoadTemplate = (props: useLoadTemplateProps) => {
+  const { templateCode } = props
+  const [templateType, setTemplateType] = useState<TemplateTypePayload | null>(null)
+  const [templateSections, setTemplateSections] = useState<TemplateSectionPayload[] | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const { data, loading: appoloLoading, error: apolloError } = useGetTemplateQuery({
+    variables: {
+      code: templateCode,
+    },
+  })
+
+  useEffect(() => {
+    if (apolloError) return
+    if (appoloLoading) return
+    // Check that only one tempalte matched
+    let error = checkForTemplateErrors(data)
+    if (error) {
+      setError(error)
+      setLoading(false)
+      return
+    }
+
+    const template = data?.templates?.nodes[0] as Template
+
+    error = checkForTemplatSectionErrors(template)
+    if (error) {
+      setError(error)
+      setLoading(false)
+      return
+    }
+
+    const { id, code, name, templateSections } = template
+
+    const sections = templateSections.nodes.map((section) => {
+      const { id, code, title, templateElementsBySectionId } = section as TemplateSection
+      const elementsCount = templateElementsBySectionId.nodes.length
+      const templateSection: TemplateSectionPayload = {
+        id,
+        code: code as string,
+        title: title as string,
+        elementsCount,
+      }
+      return templateSection
+    })
+
+    setTemplateType({
+      id,
+      code,
+      name: name ? name : 'Undefined name',
+      description: 'Include some description for this template',
+      documents: Array<string>(),
+    })
+    setTemplateSections(sections)
+    setLoading(false)
+  }, [data])
+
+  return {
+    loading,
+    apolloError,
+    error,
+    templateType,
+    templateSections,
+  }
+}
+
+function checkForTemplateErrors(data: GetTemplateQuery | undefined) {
+  if (data?.templates?.nodes?.length === null) return 'Unexpected template result'
+  const numberOfTemplates = data?.templates?.nodes.length as number
+  if (numberOfTemplates === 0) return 'Template not found'
+  if (numberOfTemplates > 1) return 'More then one template found'
+  return null
+}
+
+function checkForTemplatSectionErrors(template: Template) {
+  if (template?.templateSections?.nodes === null) return 'Unexpected template section result'
+  const numberOfSections = template?.templateSections?.nodes.length as number
+  if (numberOfSections === 0) return 'No template sections'
+  return null
+}
+
+export default useLoadTemplate

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,7 +8,7 @@ export {
 }
 
 interface ApplicationPayload {
-  serialNumber: number
+  serialNumber: string
   template: TemplatePayload
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,31 +1,43 @@
 export {
-    ApplicationPayload,
-    SectionPayload,
-    TemplatePayload,
-    TemplateSectionPayload
+  ApplicationPayload,
+  SectionPayload,
+  TemplatePayload,
+  TemplateSectionPayload,
+  Response,
+  AllResponses,
 }
 
 interface ApplicationPayload {
-    serialNumber: number
-    template: TemplatePayload
+  serialNumber: number
+  template: TemplatePayload
 }
-  
+
 interface SectionPayload {
-    applicationId: number
-    templateSections: number[]
+  applicationId: number
+  templateSections: number[]
 }
 
 interface TemplatePayload {
-    id: number
-    name: string
-    code: string
-    description: string
-    documents: Array<string>
+  id: number
+  name: string
+  code: string
+  description: string
+  documents: Array<string>
 }
 
 interface TemplateSectionPayload {
-    id: number
-    code: string
-    title: string
-    elementsCount: number
+  id: number
+  code: string
+  title: string
+  elementsCount: number
+}
+
+type Response = {
+  text: string | null | undefined
+  optionIndex?: number
+  reference?: any // Not yet decided how to represent
+}
+
+interface AllResponses {
+  [key: string]: Response | string
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,23 +1,31 @@
+import { TemplateElement } from './generated/graphql'
+
 export {
   ApplicationPayload,
   SectionPayload,
-  TemplatePayload,
+  TemplateTypePayload,
   TemplateSectionPayload,
   Response,
   ResponsesByCode,
+  ResponsePayload,
 }
 
 interface ApplicationPayload {
   serialNumber: string
-  template: TemplatePayload
+  template: TemplateTypePayload
+}
+
+interface ResponsePayload {
+  applicationId: number
+  templateQuestions: TemplateElement[]
 }
 
 interface SectionPayload {
   applicationId: number
-  templateSections: number[]
+  templateSections: (number | null)[]
 }
 
-interface TemplatePayload {
+interface TemplateTypePayload {
   id: number
   name: string
   code: string

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,7 +4,7 @@ export {
   TemplatePayload,
   TemplateSectionPayload,
   Response,
-  AllResponses,
+  ResponsesByCode,
 }
 
 interface ApplicationPayload {
@@ -38,6 +38,6 @@ type Response = {
   reference?: any // Not yet decided how to represent
 }
 
-interface AllResponses {
+interface ResponsesByCode {
   [key: string]: Response | string
 }


### PR DESCRIPTION
Fixes #34. Merge back into #28 (which in turn goes into #14)

Created the hook (`useGetAllResponses`) and confirmed that it works by calling it in `ApplicationPage`. 

Updated the `useGetApplicationQuery` to also return all responses for this application.

We'll probably want to add this hook to the main ApplicationState context at some point, but leaving that out for now to avoid conflicting with @nmadruga 's changes.