### PR TITLE
#58 update logic of elements order by index

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,20 @@
+import { InMemoryCache } from '@apollo/client'
+import { TemplateElementsConnection } from './utils/generated/graphql'
+
+const cache = new InMemoryCache({
+    typePolicies: {
+      TemplateSection: {
+        fields: {
+          pageCount: {
+              read(_, { readField }) {
+                // TODO: Move code to find number of pages per section (in useLoadTemplete) to here
+                  const elementsConnection = readField('templateElementsBySectionId') as TemplateElementsConnection
+                  return 0
+              }
+          }
+        }
+      }
+    }
+})
+
+export default cache

--- a/src/containers/Application/ApplicationCreate.tsx
+++ b/src/containers/Application/ApplicationCreate.tsx
@@ -27,7 +27,6 @@ const ApplicationCreate: React.FC = () => {
       templateSections &&
       templateSections.length > 0
     ) {
-      setApplicationState({ type: 'setSections', sections: templateSections })
       // Call Application page on first section
       const firstSection = templateSections[0].code
       // The pageNumber starts in 1 when is a new application.

--- a/src/containers/Application/ApplicationCreate.tsx
+++ b/src/containers/Application/ApplicationCreate.tsx
@@ -27,6 +27,7 @@ const ApplicationCreate: React.FC = () => {
       templateSections &&
       templateSections.length > 0
     ) {
+      setApplicationState({ type: 'setSections', sections: templateSections })
       // Call Application page on first section
       const firstSection = templateSections[0].code
       // The pageNumber starts in 1 when is a new application.

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -10,7 +10,7 @@ import { SectionPages } from '../../utils/types'
 const ApplicationPage: React.FC = () => {
   const [pageIndex, setPageIndex] = useState(0)
   const { query, push, goBack } = useRouter()
-  const { mode, serialNumber, sectionCode, git diff } = query
+  const { mode, serialNumber, sectionCode, page } = query
 
   const { error, loading, applicationName, applicationSections } = useLoadApplication({
     serialNumber: serialNumber as string,

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -5,22 +5,19 @@ import { Container, Grid, Label, Segment } from 'semantic-ui-react'
 import useGetElementsInPage from '../../utils/hooks/useGetElementsInPage'
 import useLoadApplication from '../../utils/hooks/useLoadApplication'
 import useGetResponsesByCode from '../../utils/hooks/useGetResponsesByCode'
-import { useApplicationState } from '../../contexts/ApplicationState'
 import { TemplateSectionPayload } from '../../utils/types'
 
 const ApplicationPage: React.FC = () => {
-  const { applicationState } = useApplicationState()
   const { query, push } = useRouter()
   const { mode, serialNumber, sectionCode, page } = query
-  const { sections } = applicationState
 
-  const { error, loading, applicationName } = useLoadApplication({
+  const { error, loading, applicationName, templateSections } = useLoadApplication({
     serialNumber: serialNumber as string,
   })
 
-  const currentSection = sections.find(({ code }) => code == sectionCode)
+  const currentSection = templateSections.find(({ code }) => code == sectionCode)
 
-  const { responsesByCode } = useGetResponsesByCode({ serialNumber: serialNumber as string })
+  // const { responsesByCode } = useGetResponsesByCode({ serialNumber: serialNumber as string })
 
   const { elements, loadingElements, errorElements } = useGetElementsInPage({
     sectionTemplateId: currentSection ? currentSection.id : -1,
@@ -31,7 +28,7 @@ const ApplicationPage: React.FC = () => {
     serialNumber: serialNumber as string,
     sectionCode: sectionCode as string,
     currentPage: Number(page) as number,
-    sections,
+    sections: templateSections,
     push,
   }
 

--- a/src/contexts/ApplicationState.tsx
+++ b/src/contexts/ApplicationState.tsx
@@ -1,6 +1,8 @@
 import React, { createContext, useContext, useReducer } from 'react'
+import { TemplateSectionPayload } from '../utils/types'
 
 type ApplicationState = {
+  sections: TemplateSectionPayload[]
   serialNumber: string | null
 }
 
@@ -8,6 +10,10 @@ export type ApplicationActions =
   | {
       type: 'setSerialNumber'
       serialNumber: string
+    }
+  | {
+      type: 'setSections'
+      sections: TemplateSectionPayload[]
     }
   | {
       type: 'reset'
@@ -23,6 +29,12 @@ const reducer = (state: ApplicationState, action: ApplicationActions) => {
         ...state,
         serialNumber,
       }
+    case 'setSections':
+      const { sections } = action
+      return {
+        ...state,
+        sections,
+      }
     case 'reset':
       return initialState
     default:
@@ -31,6 +43,7 @@ const reducer = (state: ApplicationState, action: ApplicationActions) => {
 }
 
 const initialState: ApplicationState = {
+  sections: [],
   serialNumber: null,
 }
 

--- a/src/contexts/ApplicationState.tsx
+++ b/src/contexts/ApplicationState.tsx
@@ -1,8 +1,6 @@
 import React, { createContext, useContext, useReducer } from 'react'
-import { TemplateSectionPayload } from '../utils/types'
 
 type ApplicationState = {
-  sections: TemplateSectionPayload[]
   serialNumber: string | null
 }
 
@@ -10,10 +8,6 @@ export type ApplicationActions =
   | {
       type: 'setSerialNumber'
       serialNumber: string
-    }
-  | {
-      type: 'setSections'
-      sections: TemplateSectionPayload[]
     }
   | {
       type: 'reset'
@@ -29,12 +23,6 @@ const reducer = (state: ApplicationState, action: ApplicationActions) => {
         ...state,
         serialNumber,
       }
-    case 'setSections':
-      const { sections } = action
-      return {
-        ...state,
-        sections,
-      }
     case 'reset':
       return initialState
     default:
@@ -43,7 +31,6 @@ const reducer = (state: ApplicationState, action: ApplicationActions) => {
 }
 
 const initialState: ApplicationState = {
-  sections: [],
   serialNumber: null,
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,13 +2,14 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import App from './containers/App'
 import * as config from './config.json'
+import cache from './cache'
 import '../semantic/src/semantic.less'
 
-import { ApolloClient, InMemoryCache, NormalizedCacheObject, ApolloProvider } from '@apollo/client'
+import { ApolloClient, NormalizedCacheObject, ApolloProvider } from '@apollo/client'
 
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
   uri: config.server,
-  cache: new InMemoryCache(),
+  cache,
 })
 
 ReactDOM.render(

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -16727,7 +16727,7 @@ export type GetTemplateQuery = (
         { __typename?: 'TemplateSectionsConnection' }
         & { nodes: Array<Maybe<(
           { __typename?: 'TemplateSection' }
-          & Pick<TemplateSection, 'id' | 'code' | 'title'>
+          & Pick<TemplateSection, 'id' | 'code' | 'title' | 'index'>
           & { templateElementsBySectionId: (
             { __typename?: 'TemplateElementsConnection' }
             & { nodes: Array<Maybe<(
@@ -17136,6 +17136,7 @@ export const GetTemplateDocument = gql`
           id
           code
           title
+          index
           templateElementsBySectionId {
             nodes {
               code

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -16732,7 +16732,7 @@ export type GetTemplateQuery = (
             { __typename?: 'TemplateElementsConnection' }
             & { nodes: Array<Maybe<(
               { __typename?: 'TemplateElement' }
-              & Pick<TemplateElement, 'code' | 'elementTypePluginCode' | 'id' | 'parameters' | 'sectionId' | 'title' | 'visibilityCondition'>
+              & Pick<TemplateElement, 'code' | 'category' | 'elementTypePluginCode' | 'id' | 'parameters' | 'sectionId' | 'title' | 'visibilityCondition'>
             )>> }
           ) }
         )>> }
@@ -17139,6 +17139,7 @@ export const GetTemplateDocument = gql`
           templateElementsBySectionId {
             nodes {
               code
+              category
               elementTypePluginCode
               id
               parameters

--- a/src/utils/graphql/queries/getTemplate.query.ts
+++ b/src/utils/graphql/queries/getTemplate.query.ts
@@ -12,6 +12,7 @@ export default gql`
             id
             code
             title
+            index
             templateElementsBySectionId {
               nodes {
                   code

--- a/src/utils/graphql/queries/getTemplate.query.ts
+++ b/src/utils/graphql/queries/getTemplate.query.ts
@@ -15,6 +15,7 @@ export default gql`
             templateElementsBySectionId {
               nodes {
                   code
+                  category
                   elementTypePluginCode
                   id
                   parameters

--- a/src/utils/helpers/getSectionsPayload.tsx
+++ b/src/utils/helpers/getSectionsPayload.tsx
@@ -1,0 +1,39 @@
+import {
+  ApplicationSection,
+  ApplicationSectionsConnection,
+  TemplateElement,
+  TemplateSection,
+  TemplateSectionsConnection,
+} from '../generated/graphql'
+import { TemplateSectionPayload } from '../types'
+
+export const getTemplateSections = (sectionsConnection: TemplateSectionsConnection) => {
+  const sections = sectionsConnection?.nodes as TemplateSection[]
+  return getSectionsPayload(sections)
+}
+
+export const getApplicationSections = (sectionsConnection: ApplicationSectionsConnection) => {
+  const applicationSections = sectionsConnection?.nodes as ApplicationSection[]
+  const sections = applicationSections.map(
+    ({ templateSection }: ApplicationSection) => templateSection as TemplateSection
+  )
+  return getSectionsPayload(sections)
+}
+
+const getSectionsPayload = (sectionsList: TemplateSection[]) =>
+  sectionsList.map((section) => {
+    const { id, code, title, index, templateElementsBySectionId } = section as TemplateSection
+    const elements = templateElementsBySectionId.nodes as TemplateElement[]
+    const pageBreaks = elements.filter(
+      ({ elementTypePluginCode }) => elementTypePluginCode === 'pageBreak'
+    )
+    const pagesCount = pageBreaks.length + 1
+
+    return {
+      id,
+      code: code as string,
+      title: title as string,
+      index: index as number,
+      pagesCount,
+    } as TemplateSectionPayload
+  })

--- a/src/utils/hooks/useGetElementsInPage.tsx
+++ b/src/utils/hooks/useGetElementsInPage.tsx
@@ -3,7 +3,7 @@ import { TemplateElement, useGetSectionElementsQuery } from '../generated/graphq
 
 interface useGetElementsInPageProps {
   sectionTemplateId: number
-  pageIndexInSection?: number
+  currentPageIndex: number
 }
 
 interface SectionPages {
@@ -11,8 +11,8 @@ interface SectionPages {
 }
 
 const useGetElementsInPage = (props: useGetElementsInPageProps) => {
-  const { sectionTemplateId, pageIndexInSection } = props
-  const [elements, setElements] = useState<TemplateElement[]>([])
+  const { sectionTemplateId, currentPageIndex } = props
+  const [currentPageElements, setElements] = useState<TemplateElement[]>([])
 
   const { data, loading, error } = useGetSectionElementsQuery({
     variables: {
@@ -28,25 +28,20 @@ const useGetElementsInPage = (props: useGetElementsInPageProps) => {
       let countPage = 0
       elementsByPage[countPage] = [] as TemplateElement[]
 
-      // TODO: Order element by ( index and section.index )
       templateElements.forEach((element) => {
         const { elementTypePluginCode: code } = element
         if (code === 'pageBreak') elementsByPage[++countPage] = [] as TemplateElement[]
         else elementsByPage[countPage].push(element)
       })
-
-      console.log('elementsByPage', elementsByPage, pageIndexInSection)
-
-      const pageIndex = pageIndexInSection ? pageIndexInSection : 0
-      const elementsInPage = elementsByPage[pageIndex]
+      const elementsInPage = elementsByPage[currentPageIndex]
       setElements(elementsInPage)
     }
-  }, [data, error])
+  }, [data, error, currentPageIndex])
 
   return {
     errorElements: error,
     loadingElements: loading,
-    elements,
+    elements: currentPageElements,
   }
 }
 

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Application, useGetApplicationQuery } from '../../utils/generated/graphql'
+import { getApplicationSections } from '../helpers/getSectionsPayload'
+import { TemplateSectionPayload } from '../types'
 
 interface useLoadApplicationProps {
   serialNumber: string
@@ -8,6 +10,7 @@ interface useLoadApplicationProps {
 const useLoadApplication = (props: useLoadApplicationProps) => {
   const { serialNumber } = props
   const [applicationName, setName] = useState<string>('')
+  const [templateSections, setSections] = useState<TemplateSectionPayload[]>([])
 
   const { data, loading, error } = useGetApplicationQuery({
     variables: {
@@ -22,6 +25,9 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
         console.log('More than one application returned. Only one expected!')
       const application = data.applications.nodes[0] as Application
       setName(application.name as string)
+
+      const sections = getApplicationSections(application.applicationSections)
+      setSections(sections)
     }
   }, [data, error])
 
@@ -29,6 +35,7 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
     error,
     loading,
     applicationName,
+    templateSections,
   }
 }
 

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -5,58 +5,14 @@ import {
   TemplateElement,
   useGetApplicationQuery,
 } from '../../utils/generated/graphql'
-import { SectionPages, SectionPageDetails } from '../types'
 
 interface useLoadApplicationProps {
   serialNumber: string
 }
 
-// const useLoadApplication = (props: useLoadApplicationProps) => {
-//   const { serialNumber } = props
-//   const [currentSection, setCurrentSection] = useState<string | null>(null)
-
-//   const { data, loading, error } = useGetApplicationQuery({
-//     variables: {
-//       serial: serialNumber,
-//     },
-//   })
-
-//   useEffect(() => {
-//     if (data && data.applications) {
-//       if (data.applications.nodes.length === 0) return
-//       if (data.applications.nodes.length > 1)
-//         console.log('More than one application returned. Only one expected!')
-//       const application = data.applications.nodes[0] as Application
-
-//       // Check the return application has sections
-//       if (!application.applicationSections || application.applicationSections.nodes.length === 0)
-//         return
-
-//       // Find title of first section in application
-//       const section = application.applicationSections.nodes[0] as ApplicationSection
-//       const { templateSection } = section
-//       if (!templateSection) return
-
-//       // TODO: Remove elements not visible in the current stage...
-
-//       const { code } = templateSection
-//       setCurrentSection(code as string)
-//     }
-//   }, [data, error])
-
-//   return {
-//     error,
-//     loading,
-//     currentSection,
-//   }
-// }
-
-// export default useLoadApplication
-
 const useLoadApplication = (props: useLoadApplicationProps) => {
   const { serialNumber } = props
   const [applicationName, setName] = useState<string>('')
-  const [applicationSections, setSections] = useState<SectionPages>({})
 
   const { data, loading, error } = useGetApplicationQuery({
     variables: {
@@ -71,35 +27,6 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
         console.log('More than one application returned. Only one expected!')
       const application = data.applications.nodes[0] as Application
       setName(application.name as string)
-
-      // Find each section page details in application
-      const sections = application?.applicationSections?.nodes as ApplicationSection[]
-
-      const mapSectionsDetails: SectionPages = {}
-      let startPage = 1 // Always start on page 1
-      let previousStartPage = startPage
-      sections.forEach((section) => {
-        const { templateSection } = section
-        if (templateSection) {
-          const { id, code, title, index } = templateSection
-          const elements = templateSection.templateElementsBySectionId.nodes as TemplateElement[]
-          let totalPages = 1
-          elements.forEach((element) => {
-            if (element.elementTypePluginCode === 'PageBreak') totalPages++
-          })
-          const sectionPayload: SectionPageDetails = {
-            id,
-            code: code as string,
-            title: title as string,
-            index: index as number,
-            startPage, // TODO: Remove,
-            totalPages, // TODO: Remove
-          }
-          mapSectionsDetails[code as string] = sectionPayload
-          startPage = previousStartPage + totalPages // Update the next section start page
-        }
-      })
-      setSections(mapSectionsDetails)
     }
   }, [data, error])
 
@@ -107,7 +34,6 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
     error,
     loading,
     applicationName,
-    applicationSections,
   }
 }
 

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -3,7 +3,6 @@ import {
   GetTemplateQuery,
   Template,
   TemplateElement,
-  TemplateElementCategory,
   TemplateSection,
   useGetTemplateQuery,
 } from '../generated/graphql'
@@ -49,22 +48,20 @@ const useLoadTemplate = (props: useLoadTemplateProps) => {
     const { id, code, name, templateSections } = template
 
     const sections = templateSections.nodes.map((section) => {
-      const { id, code, title, templateElementsBySectionId } = section as TemplateSection
+      const { id, code, title, index, templateElementsBySectionId } = section as TemplateSection
       const elements = templateElementsBySectionId.nodes as TemplateElement[]
       const pageBreaks = elements.filter(
         ({ elementTypePluginCode }) => elementTypePluginCode === 'pageBreak'
       )
       const pagesCount = pageBreaks.length + 1
-      const elementsCount = elements.filter(
-        ({ category }) => category === TemplateElementCategory.Question
-      ).length
       const templateSection: TemplateSectionPayload = {
         id,
         code: code as string,
         title: title as string,
+        index: index as number,
         pagesCount,
-        elementsCount,
       }
+
       return templateSection
     })
 

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useState } from 'react'
-import {
-  GetTemplateQuery,
-  Template,
-  TemplateElement,
-  TemplateSection,
-  useGetTemplateQuery,
-} from '../generated/graphql'
+import { GetTemplateQuery, Template, useGetTemplateQuery } from '../generated/graphql'
+import { getTemplateSections } from '../helpers/getSectionsPayload'
 import { TemplateTypePayload, TemplateSectionPayload } from '../types'
 
 interface useLoadTemplateProps {
@@ -47,24 +42,6 @@ const useLoadTemplate = (props: useLoadTemplateProps) => {
 
     const { id, code, name, templateSections } = template
 
-    const sections = templateSections.nodes.map((section) => {
-      const { id, code, title, index, templateElementsBySectionId } = section as TemplateSection
-      const elements = templateElementsBySectionId.nodes as TemplateElement[]
-      const pageBreaks = elements.filter(
-        ({ elementTypePluginCode }) => elementTypePluginCode === 'pageBreak'
-      )
-      const pagesCount = pageBreaks.length + 1
-      const templateSection: TemplateSectionPayload = {
-        id,
-        code: code as string,
-        title: title as string,
-        index: index as number,
-        pagesCount,
-      }
-
-      return templateSection
-    })
-
     setTemplateType({
       id,
       code,
@@ -72,7 +49,10 @@ const useLoadTemplate = (props: useLoadTemplateProps) => {
       description: 'Include some description for this template',
       documents: Array<string>(),
     })
+
+    const sections = getTemplateSections(templateSections)
     setTemplateSections(sections)
+
     setLoading(false)
   }, [data, apolloError])
 

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -55,12 +55,9 @@ const useLoadTemplate = (props: useLoadTemplateProps) => {
         ({ elementTypePluginCode }) => elementTypePluginCode === 'pageBreak'
       )
       const pagesCount = pageBreaks.length + 1
-      const elementsCount = elements.filter(({ category }) => {
-        console.log(category)
-
-        return true
-        // category as TemplateElementCategory === 'Question'
-      }).length
+      const elementsCount = elements.filter(
+        ({ category }) => category === TemplateElementCategory.Question
+      ).length
       const templateSection: TemplateSectionPayload = {
         id,
         code: code as string,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -3,9 +3,6 @@ import { TemplateElement } from './generated/graphql'
 export {
   ResponsePayload,
   SectionPayload,
-  Sections,
-  SectionPages,
-  SectionPageDetails,
   TemplateTypePayload,
   TemplateSectionPayload,
   Response,
@@ -22,20 +19,6 @@ interface SectionPayload {
   templateSections: (number | null)[]
 }
 
-type Sections = TemplateSectionPayload[]
-interface SectionPages {
-  [code: string]: SectionPageDetails
-}
-
-interface SectionPageDetails {
-  id: number
-  code: string
-  title: string
-  index: number
-  startPage: number
-  totalPages: number
-}
-
 interface TemplateTypePayload {
   id: number
   name: string
@@ -48,8 +31,8 @@ interface TemplateSectionPayload {
   id: number
   code: string
   title: string
+  index: number
   pagesCount: number
-  elementsCount: number
 }
 
 type Response = {


### PR DESCRIPTION
Fixes #58.

**Important**: Run using back-end on https://github.com/openmsupply/application-manager-server/pull/83

## Changes:
- Change from using `goBack` for previous page to having a handler for the previous button.
- Elements to be displayed on the `ApplicationPage` are selected by index. 
- Next button logic also changed to consider:
  - Each section starts from `page1`
  - Go to the next section based on `section.index`
- The `useLoadTemplate` hook currently is finding the number of pages per section which is stored in the **ApplicationState**
- The `useLoadApplication` logic to find each section pages is removed.