### PR TITLE
#67 Links from Application list and Re-directs

### DIFF
--- a/src/containers/Application/ApplicationList.tsx
+++ b/src/containers/Application/ApplicationList.tsx
@@ -34,13 +34,13 @@ const ApplicationList: React.FC = () => {
           </Table.Header>
           <Table.Body>
             {applications.map((application, index) => (
-              <Table.Row key={`/${application.serial}`}>
+              <Table.Row key={`${application.serial}`}>
                 {Object.entries(application).map(([key, value]) => {
                   switch (key) {
                     case 'name':
                       return (
                         <Table.Cell key={`app_${index}_${key}`}>
-                          <Link to={`${pathname}/${application.serial}`}>{value}</Link>
+                          <Link to={`/applications/${application.serial}`}>{value}</Link>
                         </Table.Cell>
                       )
                     default:

--- a/src/containers/Application/ApplicationList.tsx
+++ b/src/containers/Application/ApplicationList.tsx
@@ -2,10 +2,11 @@ import React from 'react'
 import { Container, Table, List, Label } from 'semantic-ui-react'
 import { Loading, FilterList } from '../../components'
 import { useRouter } from '../../utils/hooks/useRouter'
+import { Link } from 'react-router-dom'
 import useListApplication from '../../utils/hooks/useListApplications'
 
 const ApplicationList: React.FC = () => {
-  const { query } = useRouter()
+  const { query, pathname } = useRouter()
   const { error, loading, applications } = useListApplication()
 
   return error ? (
@@ -33,10 +34,19 @@ const ApplicationList: React.FC = () => {
           </Table.Header>
           <Table.Body>
             {applications.map((application, index) => (
-              <Table.Row key={application.serial}>
-                {Object.values(application).map((value) => (
-                  <Table.Cell key={`app_${index}_${value}`}>{value}</Table.Cell>
-                ))}
+              <Table.Row key={`/${application.serial}`}>
+                {Object.entries(application).map(([key, value]) => {
+                  switch (key) {
+                    case 'name':
+                      return (
+                        <Table.Cell key={`app_${index}_${key}`}>
+                          <Link to={`${pathname}/${application.serial}`}>{value}</Link>
+                        </Table.Cell>
+                      )
+                    default:
+                      return <Table.Cell key={`app_${index}_${key}`}>{value}</Table.Cell>
+                  }
+                })}
               </Table.Row>
             ))}
           </Table.Body>

--- a/src/containers/Application/ApplicationOverview.tsx
+++ b/src/containers/Application/ApplicationOverview.tsx
@@ -12,7 +12,6 @@ const ApplicationOverview: React.FC = () => {
 
   const { error, loading, application, templateSections } = useLoadApplication({
     serialNumber: serialNumber as string,
-    skip: false,
   })
 
   const [applicationSubmitMutation] = useUpdateApplicationMutation({

--- a/src/containers/Application/ApplicationOverview.tsx
+++ b/src/containers/Application/ApplicationOverview.tsx
@@ -12,6 +12,7 @@ const ApplicationOverview: React.FC = () => {
 
   const { error, loading, application, templateSections } = useLoadApplication({
     serialNumber: serialNumber as string,
+    skip: false,
   })
 
   const [applicationSubmitMutation] = useUpdateApplicationMutation({

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -20,8 +20,7 @@ const ApplicationPageWrapper: React.FC = () => {
   })
 
   if (isReady) {
-    console.log(appStatus)
-    processRedirect({ ...appStatus, serialNumber, sectionCode, page, push })
+    processRedirect({ ...appStatus, serialNumber, sectionCode, page, templateSections, push })
   }
 
   const {
@@ -190,9 +189,24 @@ function nextPageButtonHandler({
 
 function processRedirect(appState: any): void {
   // All logic for re-directing/configuring page based on application state, permissions, roles, etc. should go here.
-  console.log('State', appState)
-  const { stage, status, outcome, serialNumber, sectionCode, page, push } = appState
-  if (status !== 'DRAFT') push('summary')
+  const {
+    stage,
+    status,
+    outcome,
+    serialNumber,
+    sectionCode,
+    page,
+    templateSections,
+    push,
+  } = appState
+  if (status !== 'DRAFT') {
+    push(`/applications/${serialNumber}/summary`)
+    return
+  }
+  if (!sectionCode || !page) {
+    const firstSection = templateSections[0].code
+    push(`/applications/${serialNumber}/${firstSection}/page1`)
+  }
 }
 
 export default ApplicationPageWrapper

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -11,7 +11,7 @@ import { useApplicationState } from '../../contexts/ApplicationState'
 const ApplicationPageWrapper: React.FC = () => {
   const { setApplicationState } = useApplicationState()
   const [isReady, setIsReady] = useState(false)
-  const { query, push } = useRouter()
+  const { query, push, replace } = useRouter()
   const { mode, serialNumber, sectionCode, page } = query
 
   const { error, loading, application, templateSections, appStatus } = useLoadApplication({
@@ -48,6 +48,7 @@ const ApplicationPageWrapper: React.FC = () => {
     currentPage: Number(page),
     sections: templateSections,
     push,
+    replace,
   }
 
   const checkPagePayload = {
@@ -198,14 +199,15 @@ function processRedirect(appState: any): void {
     page,
     templateSections,
     push,
+    replace,
   } = appState
   if (status !== 'DRAFT') {
-    push(`/applications/${serialNumber}/summary`)
+    replace(`/applications/${serialNumber}/summary`)
     return
   }
   if (!sectionCode || !page) {
     const firstSection = templateSections[0].code
-    push(`/applications/${serialNumber}/${firstSection}/page1`)
+    replace(`/applications/${serialNumber}/${firstSection}/page1`)
   }
 }
 

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useRouter } from '../../utils/hooks/useRouter'
 import { ApplicationHeader, Loading } from '../../components'
 import { Container, Grid, Label, Segment } from 'semantic-ui-react'
@@ -7,16 +7,23 @@ import useGetResponsesAndElementState from '../../utils/hooks/useGetResponsesAnd
 import { TemplateSectionPayload } from '../../utils/types'
 import ElementsArea from './ElementsArea'
 import { useApplicationState } from '../../contexts/ApplicationState'
-import evaluateExpression from '@openmsupply/expression-evaluator'
 
 const ApplicationPageWrapper: React.FC = () => {
   const { setApplicationState } = useApplicationState()
+  const [isReady, setIsReady] = useState(false)
   const { query, push } = useRouter()
   const { mode, serialNumber, sectionCode, page } = query
 
-  const { error, loading, application, templateSections } = useLoadApplication({
+  const { error, loading, application, templateSections, appStatus } = useLoadApplication({
     serialNumber: serialNumber as string,
+    skip: isReady,
   })
+
+  if (isReady) {
+    console.log('Were ready')
+    console.log(appStatus)
+    processRedirect()
+  }
 
   const {
     error: responsesError,
@@ -29,7 +36,10 @@ const ApplicationPageWrapper: React.FC = () => {
   })
 
   useEffect(() => {
-    if (application) setApplicationState({ type: 'setApplicationId', id: application.id })
+    if (application) {
+      setApplicationState({ type: 'setApplicationId', id: application.id })
+      setIsReady(true)
+    }
   }, [application])
 
   const currentSection = templateSections.find(({ code }) => code == sectionCode)
@@ -177,6 +187,10 @@ function nextPageButtonHandler({
   } else {
     push(`../../${serialNumber}/${sectionCode}/page${nextPage}`)
   }
+}
+
+function processRedirect(): void {
+  // All logic for re-directing/configuring page based on application state, permissions, roles, etc. should go here.
 }
 
 export default ApplicationPageWrapper

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -10,18 +10,12 @@ import { useApplicationState } from '../../contexts/ApplicationState'
 
 const ApplicationPageWrapper: React.FC = () => {
   const { setApplicationState } = useApplicationState()
-  const [isReady, setIsReady] = useState(false)
   const { query, push, replace } = useRouter()
   const { mode, serialNumber, sectionCode, page } = query
 
   const { error, loading, application, templateSections, appStatus } = useLoadApplication({
     serialNumber: serialNumber as string,
-    skip: isReady,
   })
-
-  if (isReady) {
-    processRedirect({ ...appStatus, serialNumber, sectionCode, page, templateSections, push })
-  }
 
   const {
     error: responsesError,
@@ -36,7 +30,15 @@ const ApplicationPageWrapper: React.FC = () => {
   useEffect(() => {
     if (application) {
       setApplicationState({ type: 'setApplicationId', id: application.id })
-      setIsReady(true)
+      processRedirect({
+        ...appStatus,
+        serialNumber,
+        sectionCode,
+        page,
+        templateSections,
+        push,
+        replace,
+      })
     }
   }, [application])
 
@@ -48,7 +50,6 @@ const ApplicationPageWrapper: React.FC = () => {
     currentPage: Number(page),
     sections: templateSections,
     push,
-    replace,
   }
 
   const checkPagePayload = {

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -20,9 +20,8 @@ const ApplicationPageWrapper: React.FC = () => {
   })
 
   if (isReady) {
-    console.log('Were ready')
     console.log(appStatus)
-    processRedirect()
+    processRedirect({ ...appStatus, serialNumber, sectionCode, page, push })
   }
 
   const {
@@ -189,8 +188,11 @@ function nextPageButtonHandler({
   }
 }
 
-function processRedirect(): void {
+function processRedirect(appState: any): void {
   // All logic for re-directing/configuring page based on application state, permissions, roles, etc. should go here.
+  console.log('State', appState)
+  const { stage, status, outcome, serialNumber, sectionCode, page, push } = appState
+  if (status !== 'DRAFT') push('summary')
 }
 
 export default ApplicationPageWrapper

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -1218,8 +1218,8 @@ export enum ActionQueuesOrderBy {
   SequenceDesc = 'SEQUENCE_DESC',
   ActionCodeAsc = 'ACTION_CODE_ASC',
   ActionCodeDesc = 'ACTION_CODE_DESC',
-  TriggerPayloadAsc = 'TRIGGER_PAYLOAD_ASC',
-  TriggerPayloadDesc = 'TRIGGER_PAYLOAD_DESC',
+  ApplicationDataAsc = 'APPLICATION_DATA_ASC',
+  ApplicationDataDesc = 'APPLICATION_DATA_DESC',
   ParameterQueriesAsc = 'PARAMETER_QUERIES_ASC',
   ParameterQueriesDesc = 'PARAMETER_QUERIES_DESC',
   ParametersEvaluatedAsc = 'PARAMETERS_EVALUATED_ASC',
@@ -1252,8 +1252,8 @@ export type ActionQueueCondition = {
   sequence?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `actionCode` field. */
   actionCode?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `triggerPayload` field. */
-  triggerPayload?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `applicationData` field. */
+  applicationData?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `parameterQueries` field. */
   parameterQueries?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `parametersEvaluated` field. */
@@ -1294,8 +1294,8 @@ export type ActionQueueFilter = {
   sequence?: Maybe<IntFilter>;
   /** Filter by the object’s `actionCode` field. */
   actionCode?: Maybe<StringFilter>;
-  /** Filter by the object’s `triggerPayload` field. */
-  triggerPayload?: Maybe<JsonFilter>;
+  /** Filter by the object’s `applicationData` field. */
+  applicationData?: Maybe<JsonFilter>;
   /** Filter by the object’s `parameterQueries` field. */
   parameterQueries?: Maybe<JsonFilter>;
   /** Filter by the object’s `parametersEvaluated` field. */
@@ -1454,8 +1454,6 @@ export type TriggerQueueFilter = {
   recordId?: Maybe<IntFilter>;
   /** Filter by the object’s `timestamp` field. */
   timestamp?: Maybe<DatetimeFilter>;
-  /** Filter by the object’s `payload` field. */
-  payload?: Maybe<JsonFilter>;
   /** Filter by the object’s `status` field. */
   status?: Maybe<TriggerQueueStatusFilter>;
   /** Filter by the object’s `log` field. */
@@ -3114,7 +3112,7 @@ export type ActionQueue = Node & {
   templateId?: Maybe<Scalars['Int']>;
   sequence?: Maybe<Scalars['Int']>;
   actionCode?: Maybe<Scalars['String']>;
-  triggerPayload?: Maybe<Scalars['JSON']>;
+  applicationData?: Maybe<Scalars['JSON']>;
   parameterQueries?: Maybe<Scalars['JSON']>;
   parametersEvaluated?: Maybe<Scalars['JSON']>;
   status?: Maybe<ActionQueueStatus>;
@@ -3138,7 +3136,6 @@ export type TriggerQueue = Node & {
   table?: Maybe<Scalars['String']>;
   recordId?: Maybe<Scalars['Int']>;
   timestamp?: Maybe<Scalars['Datetime']>;
-  payload?: Maybe<Scalars['JSON']>;
   status?: Maybe<TriggerQueueStatus>;
   log?: Maybe<Scalars['JSON']>;
   /** Reads and enables pagination through a set of `ActionQueue`. */
@@ -5674,8 +5671,6 @@ export enum TriggerQueuesOrderBy {
   RecordIdDesc = 'RECORD_ID_DESC',
   TimestampAsc = 'TIMESTAMP_ASC',
   TimestampDesc = 'TIMESTAMP_DESC',
-  PayloadAsc = 'PAYLOAD_ASC',
-  PayloadDesc = 'PAYLOAD_DESC',
   StatusAsc = 'STATUS_ASC',
   StatusDesc = 'STATUS_DESC',
   LogAsc = 'LOG_ASC',
@@ -5696,8 +5691,6 @@ export type TriggerQueueCondition = {
   recordId?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `timestamp` field. */
   timestamp?: Maybe<Scalars['Datetime']>;
-  /** Checks for equality with the object’s `payload` field. */
-  payload?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `status` field. */
   status?: Maybe<TriggerQueueStatus>;
   /** Checks for equality with the object’s `log` field. */
@@ -7041,7 +7034,7 @@ export type ActionQueueInput = {
   templateId?: Maybe<Scalars['Int']>;
   sequence?: Maybe<Scalars['Int']>;
   actionCode?: Maybe<Scalars['String']>;
-  triggerPayload?: Maybe<Scalars['JSON']>;
+  applicationData?: Maybe<Scalars['JSON']>;
   parameterQueries?: Maybe<Scalars['JSON']>;
   parametersEvaluated?: Maybe<Scalars['JSON']>;
   status?: Maybe<ActionQueueStatus>;
@@ -7108,7 +7101,6 @@ export type UpdateTriggerQueueOnActionQueueForActionQueueTriggerEventFkeyPatch =
   table?: Maybe<Scalars['String']>;
   recordId?: Maybe<Scalars['Int']>;
   timestamp?: Maybe<Scalars['Datetime']>;
-  payload?: Maybe<Scalars['JSON']>;
   status?: Maybe<TriggerQueueStatus>;
   log?: Maybe<Scalars['JSON']>;
   actionQueuesUsingId?: Maybe<ActionQueueTriggerEventFkeyInverseInput>;
@@ -7169,7 +7161,7 @@ export type UpdateActionQueueOnActionQueueForActionQueueTriggerEventFkeyPatch = 
   templateId?: Maybe<Scalars['Int']>;
   sequence?: Maybe<Scalars['Int']>;
   actionCode?: Maybe<Scalars['String']>;
-  triggerPayload?: Maybe<Scalars['JSON']>;
+  applicationData?: Maybe<Scalars['JSON']>;
   parameterQueries?: Maybe<Scalars['JSON']>;
   parametersEvaluated?: Maybe<Scalars['JSON']>;
   status?: Maybe<ActionQueueStatus>;
@@ -8353,7 +8345,7 @@ export type UpdateActionQueueOnActionQueueForActionQueueTemplateIdFkeyPatch = {
   triggerEvent?: Maybe<Scalars['Int']>;
   sequence?: Maybe<Scalars['Int']>;
   actionCode?: Maybe<Scalars['String']>;
-  triggerPayload?: Maybe<Scalars['JSON']>;
+  applicationData?: Maybe<Scalars['JSON']>;
   parameterQueries?: Maybe<Scalars['JSON']>;
   parametersEvaluated?: Maybe<Scalars['JSON']>;
   status?: Maybe<ActionQueueStatus>;
@@ -8381,7 +8373,7 @@ export type ActionQueuePatch = {
   templateId?: Maybe<Scalars['Int']>;
   sequence?: Maybe<Scalars['Int']>;
   actionCode?: Maybe<Scalars['String']>;
-  triggerPayload?: Maybe<Scalars['JSON']>;
+  applicationData?: Maybe<Scalars['JSON']>;
   parameterQueries?: Maybe<Scalars['JSON']>;
   parametersEvaluated?: Maybe<Scalars['JSON']>;
   status?: Maybe<ActionQueueStatus>;
@@ -8400,7 +8392,7 @@ export type ActionQueueTemplateIdFkeyActionQueueCreateInput = {
   triggerEvent?: Maybe<Scalars['Int']>;
   sequence?: Maybe<Scalars['Int']>;
   actionCode?: Maybe<Scalars['String']>;
-  triggerPayload?: Maybe<Scalars['JSON']>;
+  applicationData?: Maybe<Scalars['JSON']>;
   parameterQueries?: Maybe<Scalars['JSON']>;
   parametersEvaluated?: Maybe<Scalars['JSON']>;
   status?: Maybe<ActionQueueStatus>;
@@ -13213,7 +13205,7 @@ export type ActionQueueTriggerEventFkeyActionQueueCreateInput = {
   templateId?: Maybe<Scalars['Int']>;
   sequence?: Maybe<Scalars['Int']>;
   actionCode?: Maybe<Scalars['String']>;
-  triggerPayload?: Maybe<Scalars['JSON']>;
+  applicationData?: Maybe<Scalars['JSON']>;
   parameterQueries?: Maybe<Scalars['JSON']>;
   parametersEvaluated?: Maybe<Scalars['JSON']>;
   status?: Maybe<ActionQueueStatus>;
@@ -13241,7 +13233,6 @@ export type TriggerQueuePatch = {
   table?: Maybe<Scalars['String']>;
   recordId?: Maybe<Scalars['Int']>;
   timestamp?: Maybe<Scalars['Datetime']>;
-  payload?: Maybe<Scalars['JSON']>;
   status?: Maybe<TriggerQueueStatus>;
   log?: Maybe<Scalars['JSON']>;
   actionQueuesUsingId?: Maybe<ActionQueueTriggerEventFkeyInverseInput>;
@@ -13254,7 +13245,6 @@ export type ActionQueueTriggerEventFkeyTriggerQueueCreateInput = {
   table?: Maybe<Scalars['String']>;
   recordId?: Maybe<Scalars['Int']>;
   timestamp?: Maybe<Scalars['Datetime']>;
-  payload?: Maybe<Scalars['JSON']>;
   status?: Maybe<TriggerQueueStatus>;
   log?: Maybe<Scalars['JSON']>;
   actionQueuesUsingId?: Maybe<ActionQueueTriggerEventFkeyInverseInput>;
@@ -14324,7 +14314,6 @@ export type TriggerQueueInput = {
   table?: Maybe<Scalars['String']>;
   recordId?: Maybe<Scalars['Int']>;
   timestamp?: Maybe<Scalars['Datetime']>;
-  payload?: Maybe<Scalars['JSON']>;
   status?: Maybe<TriggerQueueStatus>;
   log?: Maybe<Scalars['JSON']>;
   actionQueuesUsingId?: Maybe<ActionQueueTriggerEventFkeyInverseInput>;
@@ -16926,7 +16915,7 @@ export type GetApplicationQuery = (
     { __typename?: 'ApplicationsConnection' }
     & { nodes: Array<Maybe<(
       { __typename?: 'Application' }
-      & Pick<Application, 'id' | 'serial' | 'name' | 'outcome'>
+      & Pick<Application, 'id' | 'serial' | 'name' | 'outcome' | 'stage' | 'status'>
       & { template?: Maybe<(
         { __typename?: 'Template' }
         & Pick<Template, 'code' | 'id' | 'name'>
@@ -17375,6 +17364,8 @@ export const GetApplicationDocument = gql`
       serial
       name
       outcome
+      stage
+      status
       template {
         code
         id

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -40,8 +40,8 @@ export type Query = Node & {
   applicationSections?: Maybe<ApplicationSectionsConnection>;
   /** Reads and enables pagination through a set of `ApplicationStageHistory`. */
   applicationStageHistories?: Maybe<ApplicationStageHistoriesConnection>;
-  /** Reads and enables pagination through a set of `ApplicationStageStatus`. */
-  applicationStageStatuses?: Maybe<ApplicationStageStatusesConnection>;
+  /** Reads and enables pagination through a set of `ApplicationStageStatusAll`. */
+  applicationStageStatusAlls?: Maybe<ApplicationStageStatusAllsConnection>;
   /** Reads and enables pagination through a set of `ApplicationStatusHistory`. */
   applicationStatusHistories?: Maybe<ApplicationStatusHistoriesConnection>;
   /** Reads and enables pagination through a set of `ElementTypePlugin`. */
@@ -118,6 +118,7 @@ export type Query = Node & {
   triggerQueue?: Maybe<TriggerQueue>;
   user?: Maybe<User>;
   userOrganisation?: Maybe<UserOrganisation>;
+  applicationStatusHistoryApplicationId?: Maybe<Scalars['Int']>;
   jwtCheckPolicy?: Maybe<Scalars['Boolean']>;
   jwtGetKey?: Maybe<Scalars['String']>;
   jwtGetPolicyLinksAsSetofText?: Maybe<JwtGetPolicyLinksAsSetofTextConnection>;
@@ -268,15 +269,15 @@ export type QueryApplicationStageHistoriesArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryApplicationStageStatusesArgs = {
+export type QueryApplicationStageStatusAllsArgs = {
   first?: Maybe<Scalars['Int']>;
   last?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
   before?: Maybe<Scalars['Cursor']>;
   after?: Maybe<Scalars['Cursor']>;
-  orderBy?: Maybe<Array<ApplicationStageStatusesOrderBy>>;
-  condition?: Maybe<ApplicationStageStatusCondition>;
-  filter?: Maybe<ApplicationStageStatusFilter>;
+  orderBy?: Maybe<Array<ApplicationStageStatusAllsOrderBy>>;
+  condition?: Maybe<ApplicationStageStatusAllCondition>;
+  filter?: Maybe<ApplicationStageStatusAllFilter>;
 };
 
 
@@ -760,6 +761,12 @@ export type QueryUserOrganisationArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
+export type QueryApplicationStatusHistoryApplicationIdArgs = {
+  applicationStageHistoryId?: Maybe<Scalars['Int']>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
 export type QueryJwtCheckPolicyArgs = {
   policyName?: Maybe<Scalars['String']>;
 };
@@ -1225,6 +1232,8 @@ export enum ActionQueuesOrderBy {
   TimeQueuedDesc = 'TIME_QUEUED_DESC',
   TimeCompletedAsc = 'TIME_COMPLETED_ASC',
   TimeCompletedDesc = 'TIME_COMPLETED_DESC',
+  TimeScheduledAsc = 'TIME_SCHEDULED_ASC',
+  TimeScheduledDesc = 'TIME_SCHEDULED_DESC',
   ErrorLogAsc = 'ERROR_LOG_ASC',
   ErrorLogDesc = 'ERROR_LOG_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
@@ -1257,6 +1266,8 @@ export type ActionQueueCondition = {
   timeQueued?: Maybe<Scalars['Datetime']>;
   /** Checks for equality with the object’s `timeCompleted` field. */
   timeCompleted?: Maybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `timeScheduled` field. */
+  timeScheduled?: Maybe<Scalars['Datetime']>;
   /** Checks for equality with the object’s `errorLog` field. */
   errorLog?: Maybe<Scalars['String']>;
 };
@@ -1297,6 +1308,8 @@ export type ActionQueueFilter = {
   timeQueued?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `timeCompleted` field. */
   timeCompleted?: Maybe<DatetimeFilter>;
+  /** Filter by the object’s `timeScheduled` field. */
+  timeScheduled?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `errorLog` field. */
   errorLog?: Maybe<StringFilter>;
   /** Filter by the object’s `triggerQueueByTriggerEvent` relation. */
@@ -1747,6 +1760,8 @@ export type ApplicationStatusHistoryFilter = {
   timeCreated?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `isCurrent` field. */
   isCurrent?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `applicationId` field. */
+  applicationId?: Maybe<IntFilter>;
   /** Filter by the object’s `applicationStageHistory` relation. */
   applicationStageHistory?: Maybe<ApplicationStageHistoryFilter>;
   /** A related `applicationStageHistory` exists. */
@@ -1791,7 +1806,8 @@ export enum ApplicationStatus {
   Submitted = 'SUBMITTED',
   ChangesRequired = 'CHANGES_REQUIRED',
   ReSubmitted = 'RE_SUBMITTED',
-  Completed = 'COMPLETED'
+  Completed = 'COMPLETED',
+  Expired = 'EXPIRED'
 }
 
 /** A filter to be used against many `ReviewSectionAssignment` object types. All fields are combined with a logical ‘and.’ */
@@ -3105,6 +3121,7 @@ export type ActionQueue = Node & {
   output?: Maybe<Scalars['JSON']>;
   timeQueued?: Maybe<Scalars['Datetime']>;
   timeCompleted?: Maybe<Scalars['Datetime']>;
+  timeScheduled?: Maybe<Scalars['Datetime']>;
   errorLog?: Maybe<Scalars['String']>;
   /** Reads a single `TriggerQueue` that is related to this `ActionQueue`. */
   triggerQueueByTriggerEvent?: Maybe<TriggerQueue>;
@@ -4992,6 +5009,8 @@ export enum ApplicationStatusHistoriesOrderBy {
   TimeCreatedDesc = 'TIME_CREATED_DESC',
   IsCurrentAsc = 'IS_CURRENT_ASC',
   IsCurrentDesc = 'IS_CURRENT_DESC',
+  ApplicationIdAsc = 'APPLICATION_ID_ASC',
+  ApplicationIdDesc = 'APPLICATION_ID_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
   PrimaryKeyDesc = 'PRIMARY_KEY_DESC'
 }
@@ -5008,6 +5027,8 @@ export type ApplicationStatusHistoryCondition = {
   timeCreated?: Maybe<Scalars['Datetime']>;
   /** Checks for equality with the object’s `isCurrent` field. */
   isCurrent?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `applicationId` field. */
+  applicationId?: Maybe<Scalars['Int']>;
 };
 
 /** A connection to a list of `ApplicationStatusHistory` values. */
@@ -5032,6 +5053,7 @@ export type ApplicationStatusHistory = Node & {
   status?: Maybe<ApplicationStatus>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   isCurrent?: Maybe<Scalars['Boolean']>;
+  applicationId?: Maybe<Scalars['Int']>;
   /** Reads a single `ApplicationStageHistory` that is related to this `ApplicationStatusHistory`. */
   applicationStageHistory?: Maybe<ApplicationStageHistory>;
 };
@@ -5201,84 +5223,133 @@ export type ActionQueuesEdge = {
   node?: Maybe<ActionQueue>;
 };
 
-/** Methods to use when ordering `ApplicationStageStatus`. */
-export enum ApplicationStageStatusesOrderBy {
+/** Methods to use when ordering `ApplicationStageStatusAll`. */
+export enum ApplicationStageStatusAllsOrderBy {
   Natural = 'NATURAL',
-  IdAsc = 'ID_ASC',
-  IdDesc = 'ID_DESC',
-  NameAsc = 'NAME_ASC',
-  NameDesc = 'NAME_DESC',
+  ApplicationIdAsc = 'APPLICATION_ID_ASC',
+  ApplicationIdDesc = 'APPLICATION_ID_DESC',
+  TemplateIdAsc = 'TEMPLATE_ID_ASC',
+  TemplateIdDesc = 'TEMPLATE_ID_DESC',
+  StageIdAsc = 'STAGE_ID_ASC',
+  StageIdDesc = 'STAGE_ID_DESC',
   StageNumberAsc = 'STAGE_NUMBER_ASC',
   StageNumberDesc = 'STAGE_NUMBER_DESC',
   StageAsc = 'STAGE_ASC',
   StageDesc = 'STAGE_DESC',
+  StageHistoryIdAsc = 'STAGE_HISTORY_ID_ASC',
+  StageHistoryIdDesc = 'STAGE_HISTORY_ID_DESC',
+  StageHistoryTimeCreatedAsc = 'STAGE_HISTORY_TIME_CREATED_ASC',
+  StageHistoryTimeCreatedDesc = 'STAGE_HISTORY_TIME_CREATED_DESC',
+  StageIsCurrentAsc = 'STAGE_IS_CURRENT_ASC',
+  StageIsCurrentDesc = 'STAGE_IS_CURRENT_DESC',
+  StatusHistoryIdAsc = 'STATUS_HISTORY_ID_ASC',
+  StatusHistoryIdDesc = 'STATUS_HISTORY_ID_DESC',
   StatusAsc = 'STATUS_ASC',
-  StatusDesc = 'STATUS_DESC'
+  StatusDesc = 'STATUS_DESC',
+  StatusHistoryTimeCreatedAsc = 'STATUS_HISTORY_TIME_CREATED_ASC',
+  StatusHistoryTimeCreatedDesc = 'STATUS_HISTORY_TIME_CREATED_DESC',
+  StatusIsCurrentAsc = 'STATUS_IS_CURRENT_ASC',
+  StatusIsCurrentDesc = 'STATUS_IS_CURRENT_DESC'
 }
 
-/** A condition to be used against `ApplicationStageStatus` object types. All fields are tested for equality and combined with a logical ‘and.’ */
-export type ApplicationStageStatusCondition = {
-  /** Checks for equality with the object’s `id` field. */
-  id?: Maybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `name` field. */
-  name?: Maybe<Scalars['String']>;
+/** A condition to be used against `ApplicationStageStatusAll` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type ApplicationStageStatusAllCondition = {
+  /** Checks for equality with the object’s `applicationId` field. */
+  applicationId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `templateId` field. */
+  templateId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `stageId` field. */
+  stageId?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `stageNumber` field. */
   stageNumber?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `stage` field. */
   stage?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `stageHistoryId` field. */
+  stageHistoryId?: Maybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `stageHistoryTimeCreated` field. */
+  stageHistoryTimeCreated?: Maybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `stageIsCurrent` field. */
+  stageIsCurrent?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `statusHistoryId` field. */
+  statusHistoryId?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `status` field. */
   status?: Maybe<ApplicationStatus>;
+  /** Checks for equality with the object’s `statusHistoryTimeCreated` field. */
+  statusHistoryTimeCreated?: Maybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `statusIsCurrent` field. */
+  statusIsCurrent?: Maybe<Scalars['Boolean']>;
 };
 
-/** A filter to be used against `ApplicationStageStatus` object types. All fields are combined with a logical ‘and.’ */
-export type ApplicationStageStatusFilter = {
-  /** Filter by the object’s `id` field. */
-  id?: Maybe<IntFilter>;
-  /** Filter by the object’s `name` field. */
-  name?: Maybe<StringFilter>;
+/** A filter to be used against `ApplicationStageStatusAll` object types. All fields are combined with a logical ‘and.’ */
+export type ApplicationStageStatusAllFilter = {
+  /** Filter by the object’s `applicationId` field. */
+  applicationId?: Maybe<IntFilter>;
+  /** Filter by the object’s `templateId` field. */
+  templateId?: Maybe<IntFilter>;
+  /** Filter by the object’s `stageId` field. */
+  stageId?: Maybe<IntFilter>;
   /** Filter by the object’s `stageNumber` field. */
   stageNumber?: Maybe<IntFilter>;
   /** Filter by the object’s `stage` field. */
   stage?: Maybe<StringFilter>;
+  /** Filter by the object’s `stageHistoryId` field. */
+  stageHistoryId?: Maybe<IntFilter>;
+  /** Filter by the object’s `stageHistoryTimeCreated` field. */
+  stageHistoryTimeCreated?: Maybe<DatetimeFilter>;
+  /** Filter by the object’s `stageIsCurrent` field. */
+  stageIsCurrent?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `statusHistoryId` field. */
+  statusHistoryId?: Maybe<IntFilter>;
   /** Filter by the object’s `status` field. */
   status?: Maybe<ApplicationStatusFilter>;
+  /** Filter by the object’s `statusHistoryTimeCreated` field. */
+  statusHistoryTimeCreated?: Maybe<DatetimeFilter>;
+  /** Filter by the object’s `statusIsCurrent` field. */
+  statusIsCurrent?: Maybe<BooleanFilter>;
   /** Checks for all expressions in this list. */
-  and?: Maybe<Array<ApplicationStageStatusFilter>>;
+  and?: Maybe<Array<ApplicationStageStatusAllFilter>>;
   /** Checks for any expressions in this list. */
-  or?: Maybe<Array<ApplicationStageStatusFilter>>;
+  or?: Maybe<Array<ApplicationStageStatusAllFilter>>;
   /** Negates the expression. */
-  not?: Maybe<ApplicationStageStatusFilter>;
+  not?: Maybe<ApplicationStageStatusAllFilter>;
 };
 
-/** A connection to a list of `ApplicationStageStatus` values. */
-export type ApplicationStageStatusesConnection = {
-  __typename?: 'ApplicationStageStatusesConnection';
-  /** A list of `ApplicationStageStatus` objects. */
-  nodes: Array<Maybe<ApplicationStageStatus>>;
-  /** A list of edges which contains the `ApplicationStageStatus` and cursor to aid in pagination. */
-  edges: Array<ApplicationStageStatusesEdge>;
+/** A connection to a list of `ApplicationStageStatusAll` values. */
+export type ApplicationStageStatusAllsConnection = {
+  __typename?: 'ApplicationStageStatusAllsConnection';
+  /** A list of `ApplicationStageStatusAll` objects. */
+  nodes: Array<Maybe<ApplicationStageStatusAll>>;
+  /** A list of edges which contains the `ApplicationStageStatusAll` and cursor to aid in pagination. */
+  edges: Array<ApplicationStageStatusAllsEdge>;
   /** Information to aid in pagination. */
   pageInfo: PageInfo;
-  /** The count of *all* `ApplicationStageStatus` you could get from the connection. */
+  /** The count of *all* `ApplicationStageStatusAll` you could get from the connection. */
   totalCount: Scalars['Int'];
 };
 
-export type ApplicationStageStatus = {
-  __typename?: 'ApplicationStageStatus';
-  id?: Maybe<Scalars['Int']>;
-  name?: Maybe<Scalars['String']>;
+export type ApplicationStageStatusAll = {
+  __typename?: 'ApplicationStageStatusAll';
+  applicationId?: Maybe<Scalars['Int']>;
+  templateId?: Maybe<Scalars['Int']>;
+  stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
   stage?: Maybe<Scalars['String']>;
+  stageHistoryId?: Maybe<Scalars['Int']>;
+  stageHistoryTimeCreated?: Maybe<Scalars['Datetime']>;
+  stageIsCurrent?: Maybe<Scalars['Boolean']>;
+  statusHistoryId?: Maybe<Scalars['Int']>;
   status?: Maybe<ApplicationStatus>;
+  statusHistoryTimeCreated?: Maybe<Scalars['Datetime']>;
+  statusIsCurrent?: Maybe<Scalars['Boolean']>;
 };
 
-/** A `ApplicationStageStatus` edge in the connection. */
-export type ApplicationStageStatusesEdge = {
-  __typename?: 'ApplicationStageStatusesEdge';
+/** A `ApplicationStageStatusAll` edge in the connection. */
+export type ApplicationStageStatusAllsEdge = {
+  __typename?: 'ApplicationStageStatusAllsEdge';
   /** A cursor for use in pagination. */
   cursor?: Maybe<Scalars['Cursor']>;
-  /** The `ApplicationStageStatus` at the end of the edge. */
-  node?: Maybe<ApplicationStageStatus>;
+  /** The `ApplicationStageStatusAll` at the end of the edge. */
+  node?: Maybe<ApplicationStageStatusAll>;
 };
 
 /** Methods to use when ordering `ElementTypePlugin`. */
@@ -6977,6 +7048,7 @@ export type ActionQueueInput = {
   output?: Maybe<Scalars['JSON']>;
   timeQueued?: Maybe<Scalars['Datetime']>;
   timeCompleted?: Maybe<Scalars['Datetime']>;
+  timeScheduled?: Maybe<Scalars['Datetime']>;
   errorLog?: Maybe<Scalars['String']>;
   triggerQueueToTriggerEvent?: Maybe<ActionQueueTriggerEventFkeyInput>;
   templateToTemplateId?: Maybe<ActionQueueTemplateIdFkeyInput>;
@@ -7104,6 +7176,7 @@ export type UpdateActionQueueOnActionQueueForActionQueueTriggerEventFkeyPatch = 
   output?: Maybe<Scalars['JSON']>;
   timeQueued?: Maybe<Scalars['Datetime']>;
   timeCompleted?: Maybe<Scalars['Datetime']>;
+  timeScheduled?: Maybe<Scalars['Datetime']>;
   errorLog?: Maybe<Scalars['String']>;
   triggerQueueToTriggerEvent?: Maybe<ActionQueueTriggerEventFkeyInput>;
   templateToTemplateId?: Maybe<ActionQueueTemplateIdFkeyInput>;
@@ -8287,6 +8360,7 @@ export type UpdateActionQueueOnActionQueueForActionQueueTemplateIdFkeyPatch = {
   output?: Maybe<Scalars['JSON']>;
   timeQueued?: Maybe<Scalars['Datetime']>;
   timeCompleted?: Maybe<Scalars['Datetime']>;
+  timeScheduled?: Maybe<Scalars['Datetime']>;
   errorLog?: Maybe<Scalars['String']>;
   triggerQueueToTriggerEvent?: Maybe<ActionQueueTriggerEventFkeyInput>;
   templateToTemplateId?: Maybe<ActionQueueTemplateIdFkeyInput>;
@@ -8314,6 +8388,7 @@ export type ActionQueuePatch = {
   output?: Maybe<Scalars['JSON']>;
   timeQueued?: Maybe<Scalars['Datetime']>;
   timeCompleted?: Maybe<Scalars['Datetime']>;
+  timeScheduled?: Maybe<Scalars['Datetime']>;
   errorLog?: Maybe<Scalars['String']>;
   triggerQueueToTriggerEvent?: Maybe<ActionQueueTriggerEventFkeyInput>;
   templateToTemplateId?: Maybe<ActionQueueTemplateIdFkeyInput>;
@@ -8332,6 +8407,7 @@ export type ActionQueueTemplateIdFkeyActionQueueCreateInput = {
   output?: Maybe<Scalars['JSON']>;
   timeQueued?: Maybe<Scalars['Datetime']>;
   timeCompleted?: Maybe<Scalars['Datetime']>;
+  timeScheduled?: Maybe<Scalars['Datetime']>;
   errorLog?: Maybe<Scalars['String']>;
   triggerQueueToTriggerEvent?: Maybe<ActionQueueTriggerEventFkeyInput>;
   templateToTemplateId?: Maybe<ActionQueueTemplateIdFkeyInput>;
@@ -10825,6 +10901,7 @@ export type UpdateApplicationStatusHistoryOnApplicationStatusHistoryForApplicati
   status?: Maybe<ApplicationStatus>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   isCurrent?: Maybe<Scalars['Boolean']>;
+  applicationId?: Maybe<Scalars['Int']>;
   applicationStageHistoryToApplicationStageHistoryId?: Maybe<ApplicationStatusHistoryApplicationStageHistoryIdFkeyInput>;
 };
 
@@ -11583,6 +11660,7 @@ export type ApplicationStatusHistoryPatch = {
   status?: Maybe<ApplicationStatus>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   isCurrent?: Maybe<Scalars['Boolean']>;
+  applicationId?: Maybe<Scalars['Int']>;
   applicationStageHistoryToApplicationStageHistoryId?: Maybe<ApplicationStatusHistoryApplicationStageHistoryIdFkeyInput>;
 };
 
@@ -11592,6 +11670,7 @@ export type ApplicationStatusHistoryApplicationStageHistoryIdFkeyApplicationStat
   status?: Maybe<ApplicationStatus>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   isCurrent?: Maybe<Scalars['Boolean']>;
+  applicationId?: Maybe<Scalars['Int']>;
   applicationStageHistoryToApplicationStageHistoryId?: Maybe<ApplicationStatusHistoryApplicationStageHistoryIdFkeyInput>;
 };
 
@@ -13141,6 +13220,7 @@ export type ActionQueueTriggerEventFkeyActionQueueCreateInput = {
   output?: Maybe<Scalars['JSON']>;
   timeQueued?: Maybe<Scalars['Datetime']>;
   timeCompleted?: Maybe<Scalars['Datetime']>;
+  timeScheduled?: Maybe<Scalars['Datetime']>;
   errorLog?: Maybe<Scalars['String']>;
   triggerQueueToTriggerEvent?: Maybe<ActionQueueTriggerEventFkeyInput>;
   templateToTemplateId?: Maybe<ActionQueueTemplateIdFkeyInput>;
@@ -13398,6 +13478,7 @@ export type ApplicationStatusHistoryInput = {
   status?: Maybe<ApplicationStatus>;
   timeCreated?: Maybe<Scalars['Datetime']>;
   isCurrent?: Maybe<Scalars['Boolean']>;
+  applicationId?: Maybe<Scalars['Int']>;
   applicationStageHistoryToApplicationStageHistoryId?: Maybe<ApplicationStatusHistoryApplicationStageHistoryIdFkeyInput>;
 };
 

--- a/src/utils/graphql/queries/getApplication.query.ts
+++ b/src/utils/graphql/queries/getApplication.query.ts
@@ -8,6 +8,8 @@ export default gql`
         serial
         name
         outcome
+        stage
+        status
         template {
           code
           id

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -5,7 +5,6 @@ import { TemplateSectionPayload } from '../types'
 
 interface useLoadApplicationProps {
   serialNumber: string
-  skip: boolean
 }
 
 interface ApplicationDetails {
@@ -14,16 +13,17 @@ interface ApplicationDetails {
 }
 
 const useLoadApplication = (props: useLoadApplicationProps) => {
-  const { serialNumber, skip } = props
+  const { serialNumber } = props
   const [application, setApplication] = useState<ApplicationDetails | undefined>()
   const [templateSections, setSections] = useState<TemplateSectionPayload[]>([])
   const [appStatus, setAppStatus] = useState({})
+  const [isReady, setIsReady] = useState(false)
 
   const { data, loading, error } = useGetApplicationQuery({
     variables: {
       serial: serialNumber,
     },
-    skip: skip,
+    skip: isReady,
   })
 
   useEffect(() => {
@@ -42,6 +42,7 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
         status: application?.status,
         outcome: application?.outcome,
       })
+      setIsReady(true)
     }
   }, [data, loading, error])
 

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -5,6 +5,7 @@ import { TemplateSectionPayload } from '../types'
 
 interface useLoadApplicationProps {
   serialNumber: string
+  skip: boolean
 }
 
 interface ApplicationDetails {
@@ -13,14 +14,16 @@ interface ApplicationDetails {
 }
 
 const useLoadApplication = (props: useLoadApplicationProps) => {
-  const { serialNumber } = props
+  const { serialNumber, skip } = props
   const [application, setApplication] = useState<ApplicationDetails | undefined>()
   const [templateSections, setSections] = useState<TemplateSectionPayload[]>([])
+  const [appStatus, setAppStatus] = useState({})
 
   const { data, loading, error } = useGetApplicationQuery({
     variables: {
       serial: serialNumber,
     },
+    skip: skip,
   })
 
   useEffect(() => {
@@ -33,6 +36,12 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
 
       const sections = getApplicationSections(application.applicationSections)
       setSections(sections)
+
+      setAppStatus({
+        stage: application?.stage,
+        status: application?.status,
+        outcome: application?.outcome,
+      })
     }
   }, [data, loading, error])
 
@@ -41,6 +50,7 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
     loading,
     application,
     templateSections,
+    appStatus,
   }
 }
 


### PR DESCRIPTION
This should address #67 and #103 (and maybe #68?), although there might be more to do if I've misunderstood the issue requirements.

Please test with back-end branch `#96-more-data-for-trigger-payload` (in PR #98), as this includes a fix for the stage/status computed columns,  which you'll need to see updated statuses in the Application list.

**Changes**:

- Each application in Application List is click-able (on Title field) and goes to `/applications/{serialNo}`
- `useLoadApplication` query also returns current stage and status
- Implemented `isReady` boolean to wait for `useLoadApplication` (and skip that query subsequently) and perform some re-direct logic after application is loaded. (We discussed this way of handling waiting for initial Hooks -- hopefully it's implmented as envisaged)
- Some simple re-direct logic, with the idea that we can add more complexity in this method (`processRedirect`) as we go along. Currently it does:
   - If application status is NOT "DRAFT", re-direct to `/applications/{serialNo}/summary`
   - If no sectionCode or Page (i.e. URL is just `/applications/{serialNo}` with no query params), re-direct to Section 1, Page 1

**Note:**
 - there is some errors when loading the summary page of the pre-loaded applications but newly created ones work fine. I assume this is due to missing/inconsistent data in the dummy applications -- will investigate at some point.
 - because #104 is not done yet, newly created applications might show up as "Draft" in the list and when loading the application, as the back-end has changed status to "Completed" but front-end is using cached data. In order to make the application page know that status has changed, I had to manually delete my Local Storage cache and refresh. This should be addressed in a later issue