### PR TITLE
#114 Bug fixes 13/11

### DIFF
--- a/src/components/Application/ApplicationSummary.tsx
+++ b/src/components/Application/ApplicationSummary.tsx
@@ -25,10 +25,6 @@ const ApplicationSummary: React.FC<ApplicationSummaryProps> = ({
     sectionIds: sections.map(({ id }) => id),
   })
 
-  console.log('sectionElements', sectionElements)
-  console.log('loading', loading)
-  console.log('error', error)
-
   const getQuestion = (question: TemplateElement, response: ApplicationResponse | null) => {
     return question.category === TemplateElementCategory.Question ? (
       <Form.Field>

--- a/src/components/Application/ApplicationSummary.tsx
+++ b/src/components/Application/ApplicationSummary.tsx
@@ -25,12 +25,16 @@ const ApplicationSummary: React.FC<ApplicationSummaryProps> = ({
     sectionIds: sections.map(({ id }) => id),
   })
 
+  console.log('sectionElements', sectionElements)
+  console.log('loading', loading)
+  console.log('error', error)
+
   const getQuestion = (question: TemplateElement, response: ApplicationResponse | null) => {
     return question.category === TemplateElementCategory.Question ? (
       <Form.Field>
         <Header as="h3" content={question.title} />
         <Input disabled error={!response}>
-          {response?.value}
+          {response?.value?.text}
         </Input>
       </Form.Field>
     ) : question.elementTypePluginCode !== 'pageBreak' ? (

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -10,7 +10,14 @@ const ApplicationPageWrapper: React.FC = () => {
   const { query, push, replace } = useRouter()
   const { mode, serialNumber, sectionCode, page } = query
 
-  const { error, loading, application, templateSections, appStatus, isReady } = useLoadApplication({
+  const {
+    error,
+    loading,
+    application,
+    templateSections,
+    appStatus,
+    isApplicationLoaded,
+  } = useLoadApplication({
     serialNumber: serialNumber as string,
   })
 
@@ -22,7 +29,7 @@ const ApplicationPageWrapper: React.FC = () => {
     elementsState,
   } = useGetResponsesAndElementState({
     serialNumber: serialNumber as string,
-    isReady,
+    isApplicationLoaded,
   })
 
   useEffect(() => {

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -28,11 +28,11 @@ const ApplicationPageWrapper: React.FC = () => {
     isReady,
   })
 
-  console.log('appStatus', appStatus)
-  console.log('responsesError', responsesError)
-  console.log('responsesLoading', responsesLoading)
-  console.log('responsesByCode', responsesByCode)
-  console.log('elementsState', elementsState)
+  // console.log('appStatus', appStatus)
+  // console.log('responsesError', responsesError)
+  // console.log('responsesLoading', responsesLoading)
+  // console.log('responsesByCode', responsesByCode)
+  // console.log('elementsState', elementsState)
 
   useEffect(() => {
     if (application) {

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -32,6 +32,7 @@ const ApplicationPageWrapper: React.FC = () => {
   console.log('responsesError', responsesError)
   console.log('responsesLoading', responsesLoading)
   console.log('responsesByCode', responsesByCode)
+  console.log('elementsState', elementsState)
 
   useEffect(() => {
     if (application) {
@@ -53,7 +54,11 @@ const ApplicationPageWrapper: React.FC = () => {
     <Message error header="Problem to load application" />
   ) : loading || responsesLoading ? (
     <Loading />
-  ) : application && templateSections && serialNumber && currentSection ? (
+  ) : application &&
+    templateSections &&
+    serialNumber &&
+    currentSection &&
+    Object.keys(elementsState).length !== 0 ? (
     <Segment.Group>
       <Grid stackable>
         <Grid.Column width={4}>

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -81,8 +81,6 @@ const ApplicationPageWrapper: React.FC = () => {
 
 function processRedirect(appState: any): void {
   // All logic for re-directing/configuring page based on application state, permissions, roles, etc. should go here.
-  console.log('Redirect check...')
-  console.log('AppState', appState)
   const {
     stage,
     status,

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -14,6 +14,10 @@ const ApplicationPageWrapper: React.FC = () => {
     serialNumber: serialNumber as string,
   })
 
+  // console.log('error', error)
+  // console.log('loading', loading)
+  // console.log('appStatus', appStatus)
+
   const {
     error: responsesError,
     loading: responsesLoading,
@@ -40,7 +44,7 @@ const ApplicationPageWrapper: React.FC = () => {
 
   const currentSection = templateSections.find(({ code }) => code == sectionCode)
 
-  return error ? (
+  return error || responsesError ? (
     <Message error header="Problem to load application" />
   ) : loading || responsesLoading ? (
     <Loading />

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -10,13 +10,12 @@ const ApplicationPageWrapper: React.FC = () => {
   const { query, push, replace } = useRouter()
   const { mode, serialNumber, sectionCode, page } = query
 
-  const { error, loading, application, templateSections, appStatus } = useLoadApplication({
+  const { error, loading, application, templateSections, appStatus, isReady } = useLoadApplication({
     serialNumber: serialNumber as string,
   })
 
   // console.log('error', error)
   // console.log('loading', loading)
-  // console.log('appStatus', appStatus)
 
   const {
     error: responsesError,
@@ -26,7 +25,13 @@ const ApplicationPageWrapper: React.FC = () => {
     elementsState,
   } = useGetResponsesAndElementState({
     serialNumber: serialNumber as string,
+    isReady,
   })
+
+  console.log('appStatus', appStatus)
+  console.log('responsesError', responsesError)
+  console.log('responsesLoading', responsesLoading)
+  console.log('responsesByCode', responsesByCode)
 
   useEffect(() => {
     if (application) {
@@ -44,7 +49,7 @@ const ApplicationPageWrapper: React.FC = () => {
 
   const currentSection = templateSections.find(({ code }) => code == sectionCode)
 
-  return error || responsesError ? (
+  return error ? (
     <Message error header="Problem to load application" />
   ) : loading || responsesLoading ? (
     <Loading />

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -90,6 +90,8 @@ const ApplicationPageWrapper: React.FC = () => {
 
 function processRedirect(appState: any): void {
   // All logic for re-directing/configuring page based on application state, permissions, roles, etc. should go here.
+  console.log('Redirect check...')
+  console.log('AppState', appState)
   const {
     stage,
     status,

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -48,15 +48,11 @@ const ApplicationPageWrapper: React.FC = () => {
 
   const currentSection = templateSections.find(({ code }) => code == sectionCode)
 
-  return error ? (
+  return error || responsesError ? (
     <Message error header="Problem to load application" />
   ) : loading || responsesLoading ? (
     <Loading />
-  ) : application &&
-    templateSections &&
-    serialNumber &&
-    currentSection &&
-    Object.keys(elementsState).length !== 0 ? (
+  ) : application && templateSections && serialNumber && currentSection ? (
     <Segment.Group>
       <Grid stackable>
         <Grid.Column width={4}>

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -14,9 +14,6 @@ const ApplicationPageWrapper: React.FC = () => {
     serialNumber: serialNumber as string,
   })
 
-  // console.log('error', error)
-  // console.log('loading', loading)
-
   const {
     error: responsesError,
     loading: responsesLoading,
@@ -27,12 +24,6 @@ const ApplicationPageWrapper: React.FC = () => {
     serialNumber: serialNumber as string,
     isReady,
   })
-
-  // console.log('appStatus', appStatus)
-  // console.log('responsesError', responsesError)
-  // console.log('responsesLoading', responsesLoading)
-  // console.log('responsesByCode', responsesByCode)
-  // console.log('elementsState', elementsState)
 
   useEffect(() => {
     if (application) {

--- a/src/elementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/elementPlugins/shortText/src/ApplicationView.tsx
@@ -11,7 +11,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   allResponses,
 }) => {
   const [validationMessage, setValidationMessage] = useState('')
-  const [value, setValue] = useState(initialValue)
+  const [value, setValue] = useState(initialValue?.text)
 
   return (
     <Form.Input

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -5246,6 +5246,8 @@ export enum ApplicationStageStatusAllsOrderBy {
   SerialDesc = 'SERIAL_DESC',
   NameAsc = 'NAME_ASC',
   NameDesc = 'NAME_DESC',
+  UserIdAsc = 'USER_ID_ASC',
+  UserIdDesc = 'USER_ID_DESC',
   StageIdAsc = 'STAGE_ID_ASC',
   StageIdDesc = 'STAGE_ID_DESC',
   StageNumberAsc = 'STAGE_NUMBER_ASC',
@@ -5278,6 +5280,8 @@ export type ApplicationStageStatusAllCondition = {
   serial?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `name` field. */
   name?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `userId` field. */
+  userId?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `stageId` field. */
   stageId?: Maybe<Scalars['Int']>;
   /** Checks for equality with the object’s `stageNumber` field. */
@@ -5310,6 +5314,8 @@ export type ApplicationStageStatusAllFilter = {
   serial?: Maybe<StringFilter>;
   /** Filter by the object’s `name` field. */
   name?: Maybe<StringFilter>;
+  /** Filter by the object’s `userId` field. */
+  userId?: Maybe<IntFilter>;
   /** Filter by the object’s `stageId` field. */
   stageId?: Maybe<IntFilter>;
   /** Filter by the object’s `stageNumber` field. */
@@ -5357,6 +5363,7 @@ export type ApplicationStageStatusAll = {
   templateId?: Maybe<Scalars['Int']>;
   serial?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
+  userId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
   stage?: Maybe<Scalars['String']>;

--- a/src/utils/hooks/useGetResponsesAndElementState.tsx
+++ b/src/utils/hooks/useGetResponsesAndElementState.tsx
@@ -15,7 +15,11 @@ import {
 } from '../types'
 import evaluateExpression from '@openmsupply/expression-evaluator'
 
-const useGetResponsesAndElementState = (props: { serialNumber: string; isReady: boolean }) => {
+interface useGetResponsesAndElementStateProps {
+   serialNumber: string
+   isReady: boolean 
+}
+const useGetResponsesAndElementState = ({ serialNumber, isReady } : useGetResponsesAndElementStateProps) => {
   const { serialNumber, isReady } = props
   const [responsesByCode, setResponsesByCode] = useState({})
   const [responsesFullByCode, setResponsesFullByCode] = useState({})

--- a/src/utils/hooks/useGetResponsesAndElementState.tsx
+++ b/src/utils/hooks/useGetResponsesAndElementState.tsx
@@ -16,11 +16,12 @@ import {
 import evaluateExpression from '@openmsupply/expression-evaluator'
 
 interface useGetResponsesAndElementStateProps {
-   serialNumber: string
-   isReady: boolean 
+  serialNumber: string
+  isApplicationLoaded: boolean
 }
-const useGetResponsesAndElementState = ({ serialNumber, isReady } : useGetResponsesAndElementStateProps) => {
-  const { serialNumber, isReady } = props
+
+const useGetResponsesAndElementState = (props: useGetResponsesAndElementStateProps) => {
+  const { serialNumber, isApplicationLoaded } = props
   const [responsesByCode, setResponsesByCode] = useState({})
   const [responsesFullByCode, setResponsesFullByCode] = useState({})
   const [elementsExpressions, setElementsExpressions] = useState<TemplateElementState[]>([])
@@ -29,7 +30,7 @@ const useGetResponsesAndElementState = ({ serialNumber, isReady } : useGetRespon
   const [loading, setLoading] = useState(true)
   const { data, loading: apolloLoading, error: apolloError } = useGetElementsAndResponsesQuery({
     variables: { serial: serialNumber },
-    skip: !isReady,
+    skip: !isApplicationLoaded,
   })
 
   useEffect(() => {

--- a/src/utils/hooks/useGetResponsesAndElementState.tsx
+++ b/src/utils/hooks/useGetResponsesAndElementState.tsx
@@ -34,6 +34,10 @@ const useGetResponsesAndElementState = (props: useGetResponsesAndElementStatePro
   })
 
   useEffect(() => {
+    if (!isApplicationLoaded) {
+      return
+    }
+
     const error = checkForApplicationErrors(data)
 
     if (error) {

--- a/src/utils/hooks/useGetResponsesAndElementState.tsx
+++ b/src/utils/hooks/useGetResponsesAndElementState.tsx
@@ -15,8 +15,8 @@ import {
 } from '../types'
 import evaluateExpression from '@openmsupply/expression-evaluator'
 
-const useGetResponsesAndElementState = (props: { serialNumber: string }) => {
-  const { serialNumber } = props
+const useGetResponsesAndElementState = (props: { serialNumber: string; isReady: boolean }) => {
+  const { serialNumber, isReady } = props
   const [responsesByCode, setResponsesByCode] = useState({})
   const [responsesFullByCode, setResponsesFullByCode] = useState({})
   const [elementsExpressions, setElementsExpressions] = useState<TemplateElementState[]>([])
@@ -25,6 +25,7 @@ const useGetResponsesAndElementState = (props: { serialNumber: string }) => {
   const [loading, setLoading] = useState(true)
   const { data, loading: apolloLoading, error: apolloError } = useGetElementsAndResponsesQuery({
     variables: { serial: serialNumber },
+    skip: !isReady,
   })
 
   useEffect(() => {
@@ -70,7 +71,7 @@ const useGetResponsesAndElementState = (props: { serialNumber: string }) => {
   }, [data, apolloError])
 
   useEffect(() => {
-    if (responsesByCode)
+    if (responsesByCode && Object.keys(responsesByCode).length > 0)
       evaluateElementExpressions().then((result) => {
         setElementsState(result)
         setLoading(false)

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -30,7 +30,7 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
       serial: serialNumber,
     },
     skip: triggerProcessing,
-    fetchPolicy: 'network-only',
+    fetchPolicy: 'cache-and-network',
   })
 
   useEffect(() => {

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -29,11 +29,9 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
     variables: {
       serial: serialNumber,
     },
-    skip: triggerProcessing,
+    skip: triggerProcessing || isApplicationLoaded,
     fetchPolicy: 'cache-and-network',
   })
-
-  console.log('Re-loading application')
 
   useEffect(() => {
     if (data && data.applications) {

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -25,12 +25,17 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
     trigger: 'applicationTrigger',
   })
 
+  // console.log('triggerProcessing', triggerProcessing)
+  // console.log('triggerError', triggerError)
+
   const { data, loading, error } = useGetApplicationQuery({
     variables: {
       serial: serialNumber,
     },
     skip: triggerProcessing,
   })
+
+  console.log('data', data)
 
   useEffect(() => {
     if (data && data.applications) {

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -25,17 +25,12 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
     trigger: 'applicationTrigger',
   })
 
-  // console.log('triggerProcessing', triggerProcessing)
-  // console.log('triggerError', triggerError)
-
   const { data, loading, error } = useGetApplicationQuery({
     variables: {
       serial: serialNumber,
     },
     skip: triggerProcessing,
   })
-
-  console.log('data', data)
 
   useEffect(() => {
     if (data && data.applications) {
@@ -63,6 +58,7 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
     application,
     templateSections,
     appStatus,
+    isReady,
   }
 }
 

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -30,6 +30,7 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
       serial: serialNumber,
     },
     skip: triggerProcessing,
+    fetchPolicy: 'network-only',
   })
 
   useEffect(() => {

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -18,7 +18,7 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
   const [application, setApplication] = useState<ApplicationDetails | undefined>()
   const [templateSections, setSections] = useState<TemplateSectionPayload[]>([])
   const [appStatus, setAppStatus] = useState({})
-  const [isReady, setIsReady] = useState(false)
+  const [isApplicationLoaded, setIsApplicationLoaded] = useState(false)
 
   const { triggerProcessing, error: triggerError } = useTriggerProcessing({
     serialNumber,
@@ -32,6 +32,8 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
     skip: triggerProcessing,
     fetchPolicy: 'cache-and-network',
   })
+
+  console.log('Re-loading application')
 
   useEffect(() => {
     if (data && data.applications) {
@@ -49,7 +51,7 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
         status: application?.status,
         outcome: application?.outcome,
       })
-      setIsReady(true)
+      setIsApplicationLoaded(true)
     }
   }, [data, loading, error])
 
@@ -59,7 +61,7 @@ const useLoadApplication = (props: useLoadApplicationProps) => {
     application,
     templateSections,
     appStatus,
-    isReady,
+    isApplicationLoaded,
   }
 }
 

--- a/src/utils/hooks/useTriggerProcessing.tsx
+++ b/src/utils/hooks/useTriggerProcessing.tsx
@@ -17,21 +17,20 @@ const useTriggerProcessing = (props: { serialNumber: string; trigger: triggerTyp
     fetchPolicy: 'no-cache',
   })
 
-  console.log('serialNumber', serialNumber)
-  console.log('data', data)
-  console.log('loading', loading)
-  console.log('error', error)
-  console.log('triggerError', triggerError)
+  // console.log('serialNumber', serialNumber)
+  // console.log('data', data)
+  // console.log('loading', loading)
+  // console.log('error', error)
+  // console.log('triggerError', triggerError)
 
   useEffect((): any => {
     if (data?.applicationTriggerStates?.nodes[0]) {
       const triggerRequested = data?.applicationTriggerStates?.nodes[0][trigger]
       if (triggerRequested === null) setIsProcessing(false)
-    } else {
-      if (!data && !loading) {
-        setIsProcessing(false)
-        setTriggerError(true)
-      }
+    }
+    if (error) {
+      setIsProcessing(false)
+      setTriggerError(true)
     }
   }, [data, loading, error])
 

--- a/src/utils/hooks/useTriggerProcessing.tsx
+++ b/src/utils/hooks/useTriggerProcessing.tsx
@@ -17,12 +17,6 @@ const useTriggerProcessing = (props: { serialNumber: string; trigger: triggerTyp
     fetchPolicy: 'no-cache',
   })
 
-  // console.log('serialNumber', serialNumber)
-  // console.log('data', data)
-  // console.log('loading', loading)
-  // console.log('error', error)
-  // console.log('triggerError', triggerError)
-
   useEffect((): any => {
     if (data?.applicationTriggerStates?.nodes[0]) {
       const triggerRequested = data?.applicationTriggerStates?.nodes[0][trigger]

--- a/src/utils/hooks/useTriggerProcessing.tsx
+++ b/src/utils/hooks/useTriggerProcessing.tsx
@@ -17,13 +17,21 @@ const useTriggerProcessing = (props: { serialNumber: string; trigger: triggerTyp
     fetchPolicy: 'no-cache',
   })
 
+  console.log('serialNumber', serialNumber)
+  console.log('data', data)
+  console.log('loading', loading)
+  console.log('error', error)
+  console.log('triggerError', triggerError)
+
   useEffect((): any => {
     if (data?.applicationTriggerStates?.nodes[0]) {
       const triggerRequested = data?.applicationTriggerStates?.nodes[0][trigger]
       if (triggerRequested === null) setIsProcessing(false)
     } else {
-      setIsProcessing(false)
-      setTriggerError(true)
+      if (!data && !loading) {
+        setIsProcessing(false)
+        setTriggerError(true)
+      }
     }
   }, [data, loading, error])
 


### PR DESCRIPTION
Note: Requires branch from https://github.com/openmsupply/application-manager-server/pull/102
Please `database_init` and restart server before testing.

This fixes most of the main loading/display bugs introduced during the last couple of days' merges:

- each loading hook should wait until data from previous hooks is available
- correct response object shape used throughout (incl back-end). Expects actual response value to be in `.text` field of response
- set `useLoadApplication` to use `network-and-cache` fetch policy -- this ensures that applications that have already been loaded will get their new status updated from server when re-displaying. (Important when, after submitting, you go back to the Application List and click on it -- it needs to know the status is no longer "Draft")
- better error handling for trigger check hook

There are still some warnings which show up, which I'll try and fix and push to this PR if we have time. But I'd rather get these fixes in as the new "base" for merging other PRs into.