### PR TITLE
#116 update evaluator

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.1.4",
-    "@openmsupply/expression-evaluator": "^1.1.1",
+    "@openmsupply/expression-evaluator": "^1.2.1",
     "apollo3-cache-persist": "^0.8.0",
     "graphql": "^15.3.0",
     "query-string": "^6.13.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,10 +773,10 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@openmsupply/expression-evaluator@^1.1.1":
-  version "1.1.1"
-  resolved "https://npm.pkg.github.com/download/@openmsupply/expression-evaluator/1.1.1/106eb86673f3e3bb638dbc1df0691de026d577c25574935cb530ba721e6761fa#2420db0a3b5a4dfdb40ec75f8b66a17f481034e6"
-  integrity sha512-d5o4XRm2kRs378hVAeM6Iy9nO3khsvLO5tisyK/lslaZd4X45NRvztpYyBMwOegQe9jauW60+qRN21gb8C+BQg==
+"@openmsupply/expression-evaluator@^1.2.1":
+  version "1.2.1"
+  resolved "https://npm.pkg.github.com/download/@openmsupply/expression-evaluator/1.2.1/cfb52b96af1dc0fc0f6ce52f9ac6905d4241ba6fde1b4b7e4a5b5c62680a3153#fa247757a6893f9a563ca1cd2975097ae9e0dbc7"
+  integrity sha512-tBbMvCHpP2IstLNvxoig8jJFBTN+8u0sU/5T9+GaR/1kFoMS4s0zPAmNL0gy17vCGSJsdaNNVX2uMPzwiR70hA==
 
 "@reach/router@^1.3.4":
   version "1.3.4"


### PR DESCRIPTION
Fix [back-end issue 116](https://github.com/orgs/openmsupply/projects/6#card-49472471) (Should have been front-end issue.)
Bump evaluator version based on [latest fixes](https://github.com/openmsupply/application-manager-server/pull/122).

Don't forget to `yarn install` to import latest version