### PR TITLE
#153 #155 Bug fixes

### DIFF
--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -82,6 +82,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
             onUpdate={onUpdate}
             onSave={onSave}
             validationState={validationState || { isValid: true }}
+            // TO-DO: ensure validationState gets calculated BEFORE rendering this child, so we don't need this fallback.
             {...props}
           />
         }

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -81,7 +81,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
           <ApplicationView
             onUpdate={onUpdate}
             onSave={onSave}
-            validationState={validationState}
+            validationState={validationState || { isValid: true }}
             {...props}
           />
         }

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -17,7 +17,8 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   useEffect(() => {
     onUpdate(value)
-    if (!initialValue && defaultIndex) onSave({ text: value, optionIndex: options.indexOf(value) })
+    if (!initialValue && defaultIndex !== undefined)
+      onSave({ text: value, optionIndex: options.indexOf(value) })
   }, [])
 
   function handleChange(e: any, data: any) {
@@ -42,11 +43,9 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       <Dropdown
         fluid
         selection
-        // defaultValue={options[defaultIndex]}
         placeholder={placeholder}
         options={dropdownOptions}
         onChange={handleChange}
-        // onBlur={handleLoseFocus}
         value={value}
         disabled={!isEditable}
       />


### PR DESCRIPTION
2 small fixes -- #153 & #155

**NOTE**: If it's not already merged, this should go with back-end PR: https://github.com/openmsupply/application-manager-server/pull/130

#153 was due to the old "0 === false" trap in javascript. Needed to change to an explicit `defaultIndex !== undefined` check, because "defaultIndex" can often be 0, which would return false. :(

#155 There's probably a more thorough fix involving making sure `validationState` is properly calculated before rendering the child plugin. However, for now, having a fall-back (`isValid: true`) options will do the trick.