### PR TITLE
#124 Dynamic parameters in template elements

### DIFF
--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -92,7 +92,7 @@ const ApplicationPageWrapper: React.FC = () => {
     })
 
     setPageElements(elements)
-  }, [responsesLoading, currentSection, page])
+  }, [responsesLoading, currentSection, page, elementsState])
 
   const validateCurrentPage = (): boolean => {
     if (!application || !currentSection || !page) {

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -145,7 +145,6 @@ export async function evaluateDynamicParameters(
     evaluateExpression(expression, evaluatorParameters)
   )
   const evaluatedExpressions: any = await Promise.all(expressions)
-  console.log('evaluatedExpressions', evaluatedExpressions)
   const evaluatedParameters: ElementPluginParameters = {}
   for (let i = 0; i < fields.length; i++) {
     evaluatedParameters[fields[i]] = evaluatedExpressions[i]

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -66,6 +66,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
       setParametersLoaded(true)
     })
   }, [allResponses])
+
   useEffect(() => {
     if (forceValidation) onUpdate(currentResponse?.text)
   }, [currentResponse, forceValidation])
@@ -140,12 +141,13 @@ export async function evaluateDynamicParameters(
 ) {
   if (!dynamicExpressions) return {}
   const fields = Object.keys(dynamicExpressions)
-  const expressions = Object.values(dynamicExpressions).map(
-    (expression: ElementPluginParameterValue) => {
-      evaluateExpression(expression, evaluatorParameters)
-    }
+  const expressions = Object.values(
+    dynamicExpressions
+  ).map((expression: ElementPluginParameterValue) =>
+    evaluateExpression(expression, evaluatorParameters)
   )
   const evaluatedExpressions: any = await Promise.all(expressions)
+  console.log('evaluatedExpressions', evaluatedExpressions)
   const evaluatedParameters: ElementPluginParameters = {}
   for (let i = 0; i < fields.length; i++) {
     evaluatedParameters[fields[i]] = evaluatedExpressions[i]

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -2,7 +2,13 @@ import React, { useEffect, useState } from 'react'
 import { ErrorBoundary, pluginProvider } from '.'
 import { ApplicationViewWrapperProps, PluginComponents, ValidationState } from './types'
 import { useUpdateResponseMutation } from '../utils/generated/graphql'
-import { EvaluatorParameters, LooseString, ResponseFull } from '../utils/types'
+import {
+  EvaluatorParameters,
+  LooseString,
+  ResponseFull,
+  ElementPluginParameters,
+  ElementPluginParameterValue,
+} from '../utils/types'
 import { defaultValidate } from './defaultValidate'
 import evaluateExpression from '@openmsupply/expression-evaluator'
 import { IQueryNode } from '@openmsupply/expression-evaluator/lib/types'
@@ -55,7 +61,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
     evaluateDynamicParameters(dynamicExpressions, {
       objects: [allResponses],
       APIfetch: fetch,
-    }).then((result: any) => {
+    }).then((result: ElementPluginParameters) => {
       setEvaluatedParameters(result)
       setParametersLoaded(true)
     })
@@ -114,8 +120,8 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
 
 export default ApplicationViewWrapper
 
-export function extractDynamicExpressions(fields: string[], parameters: any) {
-  const expressionObject: any = {}
+export function extractDynamicExpressions(fields: string[], parameters: ElementPluginParameters) {
+  const expressionObject: ElementPluginParameters = {}
   fields.forEach((field) => {
     expressionObject[field] = parameters[field]
   })
@@ -123,16 +129,18 @@ export function extractDynamicExpressions(fields: string[], parameters: any) {
 }
 
 export async function evaluateDynamicParameters(
-  dynamicExpressions: any,
+  dynamicExpressions: ElementPluginParameters,
   evaluatorParameters: EvaluatorParameters
 ) {
   if (!dynamicExpressions) return {}
   const fields = Object.keys(dynamicExpressions)
-  const expressions = Object.values(dynamicExpressions).map((expression: any) =>
-    evaluateExpression(expression, evaluatorParameters)
+  const expressions = Object.values(dynamicExpressions).map(
+    (expression: ElementPluginParameterValue) => {
+      evaluateExpression(expression, evaluatorParameters)
+    }
   )
-  const evaluatedExpressions = await Promise.all(expressions)
-  const evaluatedParameters: any = {}
+  const evaluatedExpressions: any = await Promise.all(expressions)
+  const evaluatedParameters: ElementPluginParameters = {}
   for (let i = 0; i < fields.length; i++) {
     evaluatedParameters[fields[i]] = evaluatedExpressions[i]
   }

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -39,10 +39,9 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
   const [evaluatedParameters, setEvaluatedParameters] = useState({})
   const [parametersLoaded, setParametersLoaded] = useState(false)
 
-  const {
-    ApplicationView,
-    config: { dynamicParameters },
-  }: PluginComponents = pluginProvider.getPluginElement(pluginCode)
+  const { ApplicationView, config }: PluginComponents = pluginProvider.getPluginElement(pluginCode)
+
+  const dynamicParameters = config?.dynamicParameters
 
   const dynamicExpressions =
     dynamicParameters && extractDynamicExpressions(dynamicParameters, parameters)
@@ -59,7 +58,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
 
   // Update dynamic parameters when responses change
   useEffect(() => {
-    evaluateDynamicParameters(dynamicExpressions, {
+    evaluateDynamicParameters(dynamicExpressions as ElementPluginParameters, {
       objects: [allResponses],
       APIfetch: fetch,
     }).then((result: ElementPluginParameters) => {

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -12,7 +12,6 @@ import {
 } from '../utils/types'
 import { defaultValidate } from './defaultValidate'
 import evaluateExpression from '@openmsupply/expression-evaluator'
-import { IQueryNode } from '@openmsupply/expression-evaluator/lib/types'
 import { Form } from 'semantic-ui-react'
 
 const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) => {
@@ -42,7 +41,6 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
   const { ApplicationView, config }: PluginComponents = pluginProvider.getPluginElement(pluginCode)
 
   const dynamicParameters = config?.dynamicParameters
-
   const dynamicExpressions =
     dynamicParameters && extractDynamicExpressions(dynamicParameters, parameters)
   const [value, setValue] = useState<string>(initialValue?.text)

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -36,7 +36,9 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
   })
   const [validationState, setValidationState] = useState<ValidationState>({} as ValidationState)
   const [evaluatedParameters, setEvaluatedParameters] = useState({})
-  const [parametersLoaded, setParametersLoaded] = useState(false)
+
+  // This value prevents the plugin component from rendering until parameters have been evaluated, otherwise React throws an error when trying to pass an Object in as a prop value
+  const [parametersReady, setParametersReady] = useState(false)
 
   const { ApplicationView, config }: PluginComponents = pluginProvider.getPluginElement(pluginCode)
 
@@ -61,7 +63,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
       APIfetch: fetch,
     }).then((result: ElementPluginParameters) => {
       setEvaluatedParameters(result)
-      setParametersLoaded(true)
+      setParametersReady(true)
     })
   }, [allResponses])
 
@@ -117,7 +119,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
   return (
     <ErrorBoundary pluginCode={pluginCode}>
       <React.Suspense fallback="Loading Plugin">
-        {parametersLoaded && <Form.Field required={isRequired}>{PluginComponent}</Form.Field>}
+        {parametersReady && <Form.Field required={isRequired}>{PluginComponent}</Form.Field>}
       </React.Suspense>
     </ErrorBoundary>
   )

--- a/src/formElementPlugins/SummaryViewWrapper.tsx
+++ b/src/formElementPlugins/SummaryViewWrapper.tsx
@@ -5,7 +5,6 @@ import { SummaryViewWrapperProps, PluginComponents, ValidationState } from './ty
 import { TemplateElementCategory } from '../utils/generated/graphql'
 import { defaultValidate } from './defaultValidate'
 import { ElementPluginParameters, EvaluatorParameters, ValidateObject } from '../utils/types'
-import { IQueryNode } from '@openmsupply/expression-evaluator/lib/types'
 import { extractDynamicExpressions, evaluateDynamicParameters } from './ApplicationViewWrapper'
 
 const SummaryViewWrapper: React.FC<SummaryViewWrapperProps> = (props) => {
@@ -27,7 +26,6 @@ const SummaryViewWrapper: React.FC<SummaryViewWrapperProps> = (props) => {
   const { SummaryView, config }: PluginComponents = pluginProvider.getPluginElement(pluginCode)
 
   const dynamicParameters = config?.dynamicParameters
-
   const dynamicExpressions =
     dynamicParameters && extractDynamicExpressions(dynamicParameters, parameters)
 

--- a/src/formElementPlugins/SummaryViewWrapper.tsx
+++ b/src/formElementPlugins/SummaryViewWrapper.tsx
@@ -4,7 +4,7 @@ import { Grid, Icon, Form, Input } from 'semantic-ui-react'
 import { SummaryViewWrapperProps, PluginComponents, ValidationState } from './types'
 import { TemplateElementCategory } from '../utils/generated/graphql'
 import { defaultValidate } from './defaultValidate'
-import { EvaluatorParameters } from '../utils/types'
+import { ElementPluginParameters, EvaluatorParameters } from '../utils/types'
 import { IQueryNode } from '@openmsupply/expression-evaluator/lib/types'
 import { extractDynamicExpressions, evaluateDynamicParameters } from './ApplicationViewWrapper'
 
@@ -45,7 +45,7 @@ const SummaryViewWrapper: React.FC<SummaryViewWrapperProps> = (props) => {
     evaluateDynamicParameters(dynamicExpressions, {
       objects: [allResponses],
       APIfetch: fetch,
-    }).then((result: any) => {
+    }).then((result: ElementPluginParameters) => {
       setEvaluatedParameters(result)
       setParametersLoaded(true)
     })

--- a/src/formElementPlugins/SummaryViewWrapper.tsx
+++ b/src/formElementPlugins/SummaryViewWrapper.tsx
@@ -24,10 +24,9 @@ const SummaryViewWrapper: React.FC<SummaryViewWrapperProps> = (props) => {
       }),
   })
 
-  const {
-    SummaryView,
-    config: { dynamicParameters },
-  }: PluginComponents = pluginProvider.getPluginElement(pluginCode)
+  const { SummaryView, config }: PluginComponents = pluginProvider.getPluginElement(pluginCode)
+
+  const dynamicParameters = config?.dynamicParameters
 
   const dynamicExpressions =
     dynamicParameters && extractDynamicExpressions(dynamicParameters, parameters)
@@ -39,7 +38,7 @@ const SummaryViewWrapper: React.FC<SummaryViewWrapperProps> = (props) => {
     setPluginMethods({
       validate: defaultValidate,
     })
-    evaluateDynamicParameters(dynamicExpressions, {
+    evaluateDynamicParameters(dynamicExpressions as ElementPluginParameters, {
       objects: [allResponses],
       APIfetch: fetch,
     }).then((result: ElementPluginParameters) => {

--- a/src/formElementPlugins/dropdownChoice/pluginConfig.json
+++ b/src/formElementPlugins/dropdownChoice/pluginConfig.json
@@ -2,6 +2,7 @@
   "isCore": true,
   "code": "dropdownChoice",
   "displayName": "Drop-down Selector",
+  "dynamicParameters": ["label", "options"],
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"
 }

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -17,7 +17,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   useEffect(() => {
     onUpdate(value)
-    if (!initialValue && defaultIndex !== undefined)
+    if (!initialValue.text && defaultIndex !== undefined)
       onSave({ text: value, optionIndex: options.indexOf(value) })
   }, [])
 

--- a/src/formElementPlugins/pluginProvider.tsx
+++ b/src/formElementPlugins/pluginProvider.tsx
@@ -63,6 +63,7 @@ class pluginProvider {
 
 function getLocalElementPlugin(folderName: string) {
   const result: PluginComponents = {}
+  result.config = require(`./${folderName}/pluginConfig.json`)
   // TO-DO: optimize so it only imports the component type (Application, Template, Summary) that is required
   PLUGIN_COMPONENTS.forEach((componentName) => {
     result[componentName] = React.lazy(

--- a/src/formElementPlugins/pluginProvider.tsx
+++ b/src/formElementPlugins/pluginProvider.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { PluginManifest, PluginComponents, Plugins } from './types'
 
-const PLUGIN_COMPONENTS = ['ApplicationView', 'TemplateView', 'SummaryView']
+type ComponentKeys = 'ApplicationView' | 'TemplateView' | 'SummaryView'
+
+const PLUGIN_COMPONENTS: ComponentKeys[] = ['ApplicationView', 'TemplateView', 'SummaryView']
 const PLUGIN_ERRORS = {
   PLUGIN_NOT_IN_MANIFEST: 'Plugin is not present in plugin manifest',
   PLUGINS_NOT_LOADED: 'Plugins are not loaded, check connection with server',
@@ -23,18 +25,21 @@ class pluginProvider {
     // TODO
     this.pluginManifest = {
       shortText: {
+        code: 'shortText',
         displayName: 'Basic Text Input',
         isCore: true,
         folderName: 'shortText',
         category: 'Input',
       },
       textInfo: {
+        code: 'textInfo',
         isCore: true,
         displayName: 'Static Text',
-        folderName: 'textInfo',
+        folderName: '',
         category: 'Informative',
       },
       dropdownChoice: {
+        code: 'dropdownChoice',
         isCore: true,
         displayName: 'Drop-down Selector',
         folderName: 'dropdownChoice',
@@ -62,7 +67,7 @@ class pluginProvider {
 }
 
 function getLocalElementPlugin(folderName: string) {
-  const result: PluginComponents = {}
+  const result: PluginComponents = {} as PluginComponents
   result.config = require(`./${folderName}/pluginConfig.json`)
   // TO-DO: optimize so it only imports the component type (Application, Template, Summary) that is required
   PLUGIN_COMPONENTS.forEach((componentName) => {
@@ -80,7 +85,7 @@ function getLocalElementPlugin(folderName: string) {
 // Since the interface for getPluginElement should always return { pluginComponents }
 // this helper will return a reject with an error
 function returnWithError(error: Error) {
-  const result: PluginComponents = {}
+  const result: PluginComponents = {} as PluginComponents
   PLUGIN_COMPONENTS.forEach(
     (componentName) =>
       (result[componentName] = React.lazy(async () => {
@@ -92,7 +97,7 @@ function returnWithError(error: Error) {
 }
 
 function getRemoteElementPlugin(code: string) {
-  const result: PluginComponents = {}
+  const result: PluginComponents = {} as PluginComponents
   PLUGIN_COMPONENTS.forEach((componentName) => {
     // TODO will be added in another PR
     result[componentName] = () => <div>Not Implemented</div>

--- a/src/formElementPlugins/pluginProvider.tsx
+++ b/src/formElementPlugins/pluginProvider.tsx
@@ -35,7 +35,7 @@ class pluginProvider {
         code: 'textInfo',
         isCore: true,
         displayName: 'Static Text',
-        folderName: '',
+        folderName: 'textInfo',
         category: 'Informative',
       },
       dropdownChoice: {

--- a/src/formElementPlugins/shortText/pluginConfig.json
+++ b/src/formElementPlugins/shortText/pluginConfig.json
@@ -2,6 +2,7 @@
   "isCore": true,
   "code": "shortText",
   "displayName": "Basic Text Input",
+  "dynamicParameters": ["label"],
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"
 }

--- a/src/formElementPlugins/textInfo/pluginConfig.json
+++ b/src/formElementPlugins/textInfo/pluginConfig.json
@@ -2,6 +2,7 @@
   "isCore": true,
   "code": "textInfo",
   "displayName": "Static Text",
+  "dynamicParameters": ["title", "text"],
   "//": "categories types: 'Input'|'Informative'",
   "category": "Informative"
 }

--- a/src/formElementPlugins/types.ts
+++ b/src/formElementPlugins/types.ts
@@ -79,6 +79,7 @@ interface PluginComponents {
   [key: string]: React.FunctionComponent<
     ApplicationViewProps | TemplateViewProps | SummaryViewProps
   >
+  config?: any
 }
 
 interface Plugins {

--- a/src/formElementPlugins/types.ts
+++ b/src/formElementPlugins/types.ts
@@ -84,9 +84,6 @@ interface PluginComponents {
   ApplicationView: React.FunctionComponent<ApplicationViewProps>
   SummaryView: React.FunctionComponent<SummaryViewProps>
   TemplateView: React.FunctionComponent<TemplateViewProps>
-  // [key: string]: React.FunctionComponent<
-  //   ApplicationViewProps | TemplateViewProps | SummaryViewProps
-  // >
   config?: PluginConfig
 }
 

--- a/src/formElementPlugins/types.ts
+++ b/src/formElementPlugins/types.ts
@@ -72,7 +72,7 @@ interface PluginConfig {
   code: string
   folderName: string
   displayName: string
-  dynamicParameters: string[]
+  dynamicParameters?: string[]
   category: 'Input' | 'Informative'
 }
 
@@ -81,9 +81,12 @@ interface PluginManifest {
 }
 
 interface PluginComponents {
-  [key: string]: React.FunctionComponent<
-    ApplicationViewProps | TemplateViewProps | SummaryViewProps
-  >
+  ApplicationView: React.FunctionComponent<ApplicationViewProps>
+  SummaryView: React.FunctionComponent<SummaryViewProps>
+  TemplateView: React.FunctionComponent<TemplateViewProps>
+  // [key: string]: React.FunctionComponent<
+  //   ApplicationViewProps | TemplateViewProps | SummaryViewProps
+  // >
   config?: PluginConfig
 }
 

--- a/src/formElementPlugins/types.ts
+++ b/src/formElementPlugins/types.ts
@@ -66,8 +66,10 @@ interface TemplateViewProps {
 
 interface PluginConfig {
   isCore?: boolean
+  code: string
   folderName: string
   displayName: string
+  dynamicParameters: string[]
   category: 'Input' | 'Informative'
 }
 
@@ -79,7 +81,7 @@ interface PluginComponents {
   [key: string]: React.FunctionComponent<
     ApplicationViewProps | TemplateViewProps | SummaryViewProps
   >
-  config?: any
+  config?: PluginConfig
 }
 
 interface Plugins {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -6,6 +6,8 @@ export {
   ApplicationDetails,
   ApplicationElementStates,
   AppStatus,
+  ElementPluginParameterValue,
+  ElementPluginParameters,
   ElementState,
   EvaluatorParameters,
   FullUserPermissions,
@@ -46,6 +48,11 @@ interface AppStatus {
   stage: string
   status: string
   outcome: string
+}
+
+type ElementPluginParameterValue = string | number | string[] | IQueryNode
+interface ElementPluginParameters {
+  [key: string]: ElementPluginParameterValue
 }
 
 interface ElementBase {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,4 +1,4 @@
-import { ApplicationResponse, TemplateElement, TemplateElementCategory } from './generated/graphql'
+import { TemplateElement, TemplateElementCategory } from './generated/graphql'
 
 import { IQueryNode } from '@openmsupply/expression-evaluator/lib/types'
 
@@ -54,6 +54,7 @@ interface AppStatus {
 }
 
 type ElementPluginParameterValue = string | number | string[] | IQueryNode
+
 interface ElementPluginParameters {
   [key: string]: ElementPluginParameterValue
 }


### PR DESCRIPTION
Implements #124, specifically [this comment](https://github.com/openmsupply/application-manager-web-app/issues/124#issuecomment-736943099)

Note: please review with back-end [PR #124F](https://github.com/openmsupply/application-manager-server/pull/134) as it provides template changes to demonstrate the features here.

The only difference from the solution described in #124 is that the dynamic values are only re-evaluated on losing focus rather than on every keystroke. This can be changed if it's deemed necessary.

Have set the following fields to be dynamically evaluated:

- **textInfo**: `title, text`
- **shortText**: `label`
- **dropdownChoice**: `label, options`

After re-initialising the database with the changes in 124F, start a new "Test Register" application to see demonstration of dynamic parameters:

**Page 1**
- "Last name" question label shows response to Q1
- Additional Text Box showing concatenation of names responses
- Dynamic choice list, the choices being previous responses on this page

**Page 2**
- Dynamic choice list using an external API lookup (https://jsonplaceholder.typicode.com/users)
- Text box showing selection from previous lookup, including the index number (field made visible with "magicword" response"

### Additional notes:

- I've added an additional field, "config" to the `PluginComponents` object return by the pluginProvider, containing the contents of the pluginConfig.json file. Not sure this the best way to get this info, but we can handle it better when we make [needed improvements to the pluginProvider](https://github.com/orgs/openmsupply/projects/6#card-50691093).
- Small additional bug fix: visibility_condition was not being dynamically updated properly, due to a missing variable (`elementsState`) in the useEffect dependency array in ApplicationViewWrapper
- Tidied up some types to do with `pluginComponents`, `pluginConfig`, `ElementPluginParameters`