### PR TITLE
#200 Review routing and placeholder components

### DIFF
--- a/documentation/internal/Overview-of-Navigation-&-URL-structure.md
+++ b/documentation/internal/Overview-of-Navigation-&-URL-structure.md
@@ -71,7 +71,7 @@ A standard page for creating a new application.
 
 This page can support query string to specify the application type (or application category) that shows selected in the dropdown menu.
 
-E.g. `/applications/new?type=drug-registration`
+E.g. `/application/new?type=drug-registration`
 
 On clicking the “Start application” button of this form, a new “application” record is created in the database. And the page for in-progress application is loaded.
 

--- a/documentation/internal/Overview-of-Navigation-&-URL-structure.md
+++ b/documentation/internal/Overview-of-Navigation-&-URL-structure.md
@@ -63,7 +63,7 @@ Example: [https://balsamiq.cloud/scs7giw/ponj59g/r4C62](https://balsamiq.cloud/s
 
 ---
 
-## `/applications/new`
+## `/application/new`
 
 ### New application launcher
 
@@ -83,7 +83,7 @@ Example: [https://balsamiq.cloud/scs7giw/ponj59g/r1D2B](https://balsamiq.cloud/s
 
 ---
 
-## `/applications/[appId]/[sectionName]/page[page]`
+## `/application/[serialNum]/[sectionName]/page[page]`
 
 ### In-progress Application
 
@@ -108,7 +108,7 @@ Example: [https://balsamiq.cloud/scs7giw/ponj59g/r1FFB](https://balsamiq.cloud/s
 
 ---
 
-## `/applications/[appId]/summary`
+## `/application/[serialNum]/summary`
 
 ### Application summary page
 
@@ -130,7 +130,7 @@ Example: [https://balsamiq.cloud/scs7giw/ponj59g/r189E](https://balsamiq.cloud/s
 
 ---
 
-## `/applications/[appId]`
+## `/application/[serialNum]`
 
 ### Application home page
 
@@ -163,27 +163,27 @@ Example: [https://balsamiq.cloud/scs7giw/ponj59g/rD5AC](https://balsamiq.cloud/s
 
 ---
 
-## `/review/[appId]`
+## `/application/[serialNum]/review`
 
 Overview/Start page for reviews associated with specific Application. User will see different content depending on permissions. For Reviewers who have assigned content to review, they will have the option to "Start" review, which will create a Review in the database and re-direct to the specific review page.
 
-## `/review/[appId]/[reviewId]`
+## `/application/[serialNum]/review/[reviewId]`
 
 Specific Review page. Assigned Reviewer(s) can mark questions as "Conform" or "Non-conform" and add comments.
 
 ---
 
-## `/consolidate/[appId]`
+## `/application/[serialNum]/consolidation`
 
 Consolidation page. Shows all reviews relevant to current stage. Consolidator can start consolidation.
 
-## `/consolidate/[appId]/[consolidateId]`
+## `/application/[serialNum]/consolidation/[consolidateId]`
 
 Specific Consolidation page. Further details TBC.
 
 ---
 
-## `/applications/[appId]?mode=assignment`
+## `/application/[serialNum]/assignment`
 
 _Assigment URLs to be decided_
 
@@ -197,7 +197,7 @@ Example: [https://balsamiq.cloud/scs7giw/ponj59g/r3DC3](https://balsamiq.cloud/s
 
 ---
 
-## `/approval/[appId]`
+## `/application/[serialNum]/approval`
 
 ### Application approval page
 
@@ -323,7 +323,7 @@ A list (basically an Inbox) of all notifications, with some limited filters (Unr
 
 URL also updates with query string, so (for example) links elsewhere can link to the Inbox for everything associated with a specific application:
 
-E.g. `/notifications?appid=123454678`
+E.g. `/notifications?serialNum=123454678`
 
 Example: [https://balsamiq.cloud/scs7giw/ponj59g/rEFAE](https://balsamiq.cloud/scs7giw/ponj59g/rEFAE)
 

--- a/documentation/internal/Overview-of-Navigation-&-URL-structure.md
+++ b/documentation/internal/Overview-of-Navigation-&-URL-structure.md
@@ -8,13 +8,13 @@ When trying to access any URL, if not already authenticated, user is redirected 
 
 Example: [https://balsamiq.cloud/scs7giw/ponj59g/r2278](https://balsamiq.cloud/scs7giw/ponj59g/r2278)
 
-(Note: requested URL should be remembered, so that after successful login, user is redirected straight to that page)
+(Note: requested URL is remembered, so that after successful login, user is redirected straight to that page)
 
 ---
 
 ## `/`
 
-### Home
+### Home (Dashboard)
 
 “Welcome” page showing a summary of activities in progress, e.g. incomplete applications, incomplete reviews, new notifications, etc.
 
@@ -124,7 +124,7 @@ Example: [https://balsamiq.cloud/scs7giw/ponj59g/rD624](https://balsamiq.cloud/s
 
 ### Reviewer
 
-Sees the list of responses in the sections they are assigned to. The decision and the comment next to each question, and the overall status per section. The comment per section can be edited in here, maybe the comment per question too.
+~~Sees the list of responses in the sections they are assigned to. The decision and the comment next to each question, and the overall status per section. The comment per section can be edited in here, maybe the comment per question too.~~
 
 Example: [https://balsamiq.cloud/scs7giw/ponj59g/r189E](https://balsamiq.cloud/scs7giw/ponj59g/r189E)
 
@@ -163,7 +163,29 @@ Example: [https://balsamiq.cloud/scs7giw/ponj59g/rD5AC](https://balsamiq.cloud/s
 
 ---
 
+## `/review/[appId]`
+
+Overview/Start page for reviews associated with specific Application. User will see different content depending on permissions. For Reviewers who have assigned content to review, they will have the option to "Start" review, which will create a Review in the database and re-direct to the specific review page.
+
+## `/review/[appId]/[reviewId]`
+
+Specific Review page. Assigned Reviewer(s) can mark questions as "Conform" or "Non-conform" and add comments.
+
+---
+
+## `/consolidate/[appId]`
+
+Consolidation page. Shows all reviews relevant to current stage. Consolidator can start consolidation.
+
+## `/consolidate/[appId]/[consolidateId]`
+
+Specific Consolidation page. Further details TBC.
+
+---
+
 ## `/applications/[appId]?mode=assignment`
+
+_Assigment URLs to be decided_
 
 ### Application assignment mode
 
@@ -175,35 +197,7 @@ Example: [https://balsamiq.cloud/scs7giw/ponj59g/r3DC3](https://balsamiq.cloud/s
 
 ---
 
-## `/applications/[appId]?mode=consolidation`
-
-### Application consolidation mode
-
-The “home page” of a specific application during consolidation of reviewers.
-
-The Supervisor or Chief user (Consolidator) can select the LOQ (List of questions) to be sent back to the Applicant. Edit the comments or the status of a reviewed question is allowed.
-
-On clicking the 'Save changes' button will save it for later and the 'Continue' button will load the Consolidation summary page.
-
-Example: [https://balsamiq.cloud/scs7giw/ponj59g/r5273](https://balsamiq.cloud/scs7giw/ponj59g/r5273)
-
----
-
-## `/applications/[appId]/summary?mode=consolidation`
-
-### Application consolidation mode summary page
-
-The summary page for a Consolidation.
-
-Shows the LOQ (List of questions) within the section, question number, status and comments. The user making the consolidation can select their decision and an overall comment.
-
-The preview of the message to be sent to the Applicant is shown based on final decision.
-
-Example: [https://balsamiq.cloud/scs7giw/ponj59g/rD7FD](https://balsamiq.cloud/scs7giw/ponj59g/rD7FD)
-
----
-
-## `/applications/[appId]/approval`
+## `/approval/[appId]`
 
 ### Application approval page
 

--- a/src/components/Application/ProgressBar.tsx
+++ b/src/components/Application/ProgressBar.tsx
@@ -146,8 +146,8 @@ const attemptChangeToPage = ({
 }: attemptChangePageProps) => {
   if (canNavigate || validateCurrentPage()) {
     sectionCode && pageCode
-      ? push(`/applications/${serialNumber}/${sectionCode}/${pageCode}`)
-      : push(`/applications/${serialNumber}/summary`)
+      ? push(`/application/${serialNumber}/${sectionCode}/${pageCode}`)
+      : push(`/application/${serialNumber}/summary`)
   }
 }
 

--- a/src/components/Application/SectionSummary.tsx
+++ b/src/components/Application/SectionSummary.tsx
@@ -51,7 +51,7 @@ const SectionSummary: React.FC<SectionSummaryProps> = ({
                             <Button
                               size="small"
                               as={Link}
-                              to={`/applications/${serialNumber}/${section.code}/${pageCode}`}
+                              to={`/application/${serialNumber}/${section.code}/${pageCode}`}
                             >
                               Edit
                             </Button>

--- a/src/containers/Application/ApplicationList.tsx
+++ b/src/containers/Application/ApplicationList.tsx
@@ -40,7 +40,7 @@ const ApplicationList: React.FC = () => {
                     case 'name':
                       return (
                         <Table.Cell key={`app_row_${index}_${key}`}>
-                          <Link to={`/applications/${application.serial}`}>{value}</Link>
+                          <Link to={`/application/${application.serial}`}>{value}</Link>
                         </Table.Cell>
                       )
                     default:

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -199,12 +199,12 @@ function processRedirect(appState: any): void {
     replace,
   } = appState
   if (status !== 'DRAFT') {
-    replace(`/applications/${serialNumber}/summary`)
+    replace(`/application/${serialNumber}/summary`)
     return
   }
   if (!sectionCode || !page) {
     const firstSection = templateSections[0].code
-    replace(`/applications/${serialNumber}/${firstSection}/page1`)
+    replace(`/application/${serialNumber}/${firstSection}/page1`)
   }
 }
 

--- a/src/containers/Application/NavigationBox.tsx
+++ b/src/containers/Application/NavigationBox.tsx
@@ -44,8 +44,8 @@ const NavigationBox: React.FC<NavigationBoxProps> = ({ templateSections, validat
     currentSection: currentSection as TemplateSectionPayload,
     templateSections,
     sendToPage: (section: string, page: number) =>
-      push(`/applications/${serialNumber}/${section}/Page${page}`),
-    sendToSummary: () => push(`/applications/${serialNumber}/summary`),
+      push(`/application/${serialNumber}/${section}/Page${page}`),
+    sendToSummary: () => push(`/application/${serialNumber}/summary`),
     validateCurrentPage,
   }
 

--- a/src/containers/Main/SiteLayout.tsx
+++ b/src/containers/Main/SiteLayout.tsx
@@ -23,6 +23,7 @@ import {
   Template,
 } from '../../components'
 import { ApplicationCreate, ApplicationList, ApplicationPageWrapper } from '../Application'
+import { ReviewOverview, ReviewPageWrapper } from '../Review'
 import UserRegister from '../User/UserRegister'
 import { ApplicationProvider } from '../../contexts/ApplicationState'
 import ApplicationOverview from '../Application/ApplicationOverview'
@@ -68,6 +69,12 @@ const SiteLayout: React.FC = () => {
               </Route>
               <Route exact path="/applications/:serialNumber/:sectionCode/Page:page">
                 <ApplicationPageWrapper />
+              </Route>
+              <Route exact path="/review/:serialNumber/">
+                <ReviewOverview />
+              </Route>
+              <Route exact path="/review/:serialNumber/:reviewId">
+                <ReviewPageWrapper />
               </Route>
               <Route exact path="/applications/:serialNumber/summary">
                 <ApplicationOverview />

--- a/src/containers/Main/SiteLayout.tsx
+++ b/src/containers/Main/SiteLayout.tsx
@@ -37,10 +37,10 @@ const SiteLayout: React.FC = () => {
             items={[
               ['Home', '/'],
               ['Applications List', '/applications'],
-              ['Register', '/applications/new?type=UserRegistration'],
-              ['Company Registration', '/applications/new?type=CompRego1'],
-              ['Review Test form', '/applications/new?type=ReviewTest'],
-              ['Feature Showcase form', '/applications/new?type=TestRego'],
+              ['Register', '/application/new?type=UserRegistration'],
+              ['Company Registration', '/application/new?type=CompRego1'],
+              ['Review Test form', '/application/new?type=ReviewTest'],
+              ['Feature Showcase form', '/application/new?type=TestRego'],
             ]}
           />
         </Grid.Column>
@@ -59,33 +59,33 @@ const SiteLayout: React.FC = () => {
               <Route exact path="/applications">
                 <ApplicationList />
               </Route>
-              <Route exact path="/applications/new">
+              <Route exact path="/application/new">
                 <ApplicationProvider>
                   <ApplicationCreate />
                 </ApplicationProvider>
               </Route>
-              <Route exact path="/applications/:serialNumber">
+              <Route exact path="/application/:serialNumber">
                 <ApplicationPageWrapper />
               </Route>
-              <Route exact path="/applications/:serialNumber/:sectionCode/Page:page">
+              <Route exact path="/application/:serialNumber/:sectionCode/Page:page">
                 <ApplicationPageWrapper />
               </Route>
-              <Route exact path="/applications/:serialNumber/summary">
+              <Route exact path="/application/:serialNumber/summary">
                 <ApplicationOverview />
               </Route>
-              <Route exact path="/review/:serialNumber/">
+              <Route exact path="/application/:serialNumber/review">
                 <ReviewOverview />
               </Route>
-              <Route exact path="/review/:serialNumber/:reviewId">
+              <Route exact path="/application/:serialNumber/review/:reviewId">
                 <ReviewPageWrapper />
               </Route>
-              <Route exact path="/consolidate/:serialNumber/">
+              <Route exact path="/application/:serialNumber/consolidation/">
                 <NoMatch />
               </Route>
-              <Route exact path="/consolidate/:serialNumber/:consolidationId">
+              <Route exact path="/application/:serialNumber/consolidation/:consolidationId">
                 <NoMatch />
               </Route>
-              <Route exact path="/approval/:serialNumber">
+              <Route exact path="/application/:serialNumber/approval">
                 <Approval />
               </Route>
               <Route exact path="/admin">

--- a/src/containers/Main/SiteLayout.tsx
+++ b/src/containers/Main/SiteLayout.tsx
@@ -70,16 +70,22 @@ const SiteLayout: React.FC = () => {
               <Route exact path="/applications/:serialNumber/:sectionCode/Page:page">
                 <ApplicationPageWrapper />
               </Route>
+              <Route exact path="/applications/:serialNumber/summary">
+                <ApplicationOverview />
+              </Route>
               <Route exact path="/review/:serialNumber/">
                 <ReviewOverview />
               </Route>
               <Route exact path="/review/:serialNumber/:reviewId">
                 <ReviewPageWrapper />
               </Route>
-              <Route exact path="/applications/:serialNumber/summary">
-                <ApplicationOverview />
+              <Route exact path="/consolidate/:serialNumber/">
+                <NoMatch />
               </Route>
-              <Route exact path="/applications/:serialNumber/approval">
+              <Route exact path="/consolidate/:serialNumber/:consolidationId">
+                <NoMatch />
+              </Route>
+              <Route exact path="/approval/:serialNumber">
                 <Approval />
               </Route>
               <Route exact path="/admin">

--- a/src/containers/Review/ReviewOverview.tsx
+++ b/src/containers/Review/ReviewOverview.tsx
@@ -6,7 +6,12 @@ const ReviewOverview: React.FC = () => {
   // Logic for what this page will show:
   // https://github.com/openmsupply/application-manager-web-app/issues/200#issuecomment-741432161
 
-  // Hook will fetch Review info (if it exists). If user is supposed to start a new review, there will be some information about what Sections/Questions they've been assigned to.
+  // Hooks (suggested):
+  // - useLoadApplication
+  // - useGetResponsesAndElementState
+  // - new Hook to get existing Review information
+
+  // Hook(s) will fetch Application & Review info (if it exists). If user is supposed to start a new review, there will be some information about what Sections/Questions they've been assigned to.
   // And there will be a "Start Review" button. On clicking it, a new Review will be created, its ID returned, and this page will re-direct to the new Review URL.
 
   const {

--- a/src/containers/Review/ReviewOverview.tsx
+++ b/src/containers/Review/ReviewOverview.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { useRouter } from '../../utils/hooks/useRouter'
+
+const ReviewOverview: React.FC = () => {
+  // Logic for what this page will show:
+  // https://github.com/openmsupply/application-manager-web-app/issues/200#issuecomment-741432161
+
+  // Hook will fetch Review info (if it exists). If user is supposed to start a new review, there will be some information about what Sections/Questions they've been assigned to.
+  // And there will be a "Start Review" button. On clicking it, a new Review will be created, its ID returned, and this page will re-direct to the new Review URL.
+
+  const {
+    params: { serialNumber },
+  } = useRouter()
+
+  return (
+    <div>
+      <p>This is the Overview/Start page for Reviews of Application {serialNumber}.</p>
+      <p>Overview components will go here.</p>
+      <p>
+        See{' '}
+        <Link to="https://github.com/openmsupply/application-manager-web-app/issues/200#issuecomment-741432161">
+          here
+        </Link>{' '}
+        for explanation.
+      </p>
+    </div>
+  )
+}
+
+export default ReviewOverview

--- a/src/containers/Review/ReviewPageWrapper.tsx
+++ b/src/containers/Review/ReviewPageWrapper.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react'
+import { useRouter } from '../../utils/hooks/useRouter'
+
+const ReviewPageWrapper: React.FC = () => {
+  // Page will present the list of visible questions in Summary view, with additional "Reviewing" controls beneath each question.
+  // Will also need to useGetTriggers hook to wait until Review(Assignment) and Application records have Null triggers before loading
+
+  const {
+    params: { serialNumber, reviewId },
+  } = useRouter()
+
+  return (
+    <div>
+      <p>
+        This is the Review page for Review ID#{reviewId} of Application {serialNumber}
+      </p>
+    </div>
+  )
+}
+
+export default ReviewPageWrapper

--- a/src/containers/Review/index.ts
+++ b/src/containers/Review/index.ts
@@ -1,0 +1,4 @@
+import ReviewOverview from './ReviewOverview'
+import ReviewPageWrapper from './ReviewPageWrapper'
+
+export { ReviewOverview, ReviewPageWrapper }

--- a/src/containers/User/UserRegister.tsx
+++ b/src/containers/User/UserRegister.tsx
@@ -13,7 +13,7 @@ const UserRegister: React.FC = () => {
       console.log('Result', loginResult)
       localStorage.setItem('persistJWT', loginResult.JWT)
       localStorage.setItem('username', loginResult.username)
-      push('/applications/new?type=UserRegistration')
+      push('/application/new?type=UserRegistration')
     })
     .catch((err) => {
       setNetworkError(err.message)


### PR DESCRIPTION
Implements #200 -- routes and basic parameter parsing for Review pages.

Some URLs to try:
- http://localhost:3000/review/6250
- http://localhost:3000/review/6250/1234

Have added Consolidation (and Approval) routes, but just linked to `<NoMatch>` component for now.

Still working on docs, but publishing PR now so you can review it if you want.