### PR TITLE
#135 Redirect application to first incomplete page

### DIFF
--- a/src/containers/Application/ApplicationOverview.tsx
+++ b/src/containers/Application/ApplicationOverview.tsx
@@ -167,6 +167,7 @@ function getFirstErrorLocation(
 ) {
   let firstErrorSectionIndex = Infinity
   let firstErrorPage = Infinity
+  console.log('Validity failures', validityFailures)
   validityFailures.forEach((failure: ValidityFailure) => {
     const { code } = failure
     const sectionIndex = elementsState[code].sectionIndex
@@ -178,5 +179,6 @@ function getFirstErrorLocation(
       firstErrorPage =
         sectionIndex === firstErrorSectionIndex && page < firstErrorPage ? page : firstErrorPage
   })
+  console.log('Redirecting to', firstErrorSectionIndex, firstErrorPage)
   return { firstErrorSectionIndex, firstErrorPage }
 }

--- a/src/containers/Application/ApplicationOverview.tsx
+++ b/src/containers/Application/ApplicationOverview.tsx
@@ -7,7 +7,7 @@ import useGetResponsesAndElementState from '../../utils/hooks/useGetResponsesAnd
 import useLoadApplication from '../../utils/hooks/useLoadApplication'
 import { useRouter } from '../../utils/hooks/useRouter'
 import useUpdateApplication from '../../utils/hooks/useUpdateApplication'
-import { ApplicationElementStates, ValidityFailure, SectionElementStates } from '../../utils/types'
+import { ApplicationElementStates, SectionElementStates } from '../../utils/types'
 import { revalidateAll, getFirstErrorLocation } from '../../utils/helpers/revalidateAll'
 import { useUpdateResponseMutation } from '../../utils/generated/graphql'
 

--- a/src/containers/Application/ApplicationOverview.tsx
+++ b/src/containers/Application/ApplicationOverview.tsx
@@ -160,25 +160,3 @@ const showProcessingModal = (processing: boolean, submitted: boolean) => {
 }
 
 export default ApplicationOverview
-
-function getFirstErrorLocation(
-  validityFailures: ValidityFailure[],
-  elementsState: ApplicationElementStates
-) {
-  let firstErrorSectionIndex = Infinity
-  let firstErrorPage = Infinity
-  console.log('Validity failures', validityFailures)
-  validityFailures.forEach((failure: ValidityFailure) => {
-    const { code } = failure
-    const sectionIndex = elementsState[code].sectionIndex
-    const page = elementsState[code].page
-    if (sectionIndex < firstErrorSectionIndex) {
-      firstErrorSectionIndex = sectionIndex
-      firstErrorPage = page
-    } else
-      firstErrorPage =
-        sectionIndex === firstErrorSectionIndex && page < firstErrorPage ? page : firstErrorPage
-  })
-  console.log('Redirecting to', firstErrorSectionIndex, firstErrorPage)
-  return { firstErrorSectionIndex, firstErrorPage }
-}

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -23,7 +23,7 @@ import validatePage, {
   PROGRESS_STATUS,
 } from '../../utils/helpers/validatePage'
 import getPageElements from '../../utils/helpers/getPageElements'
-import { revalidateAll } from '../../utils/helpers/revalidateAll'
+import { revalidateAll, getFirstErrorLocation } from '../../utils/helpers/revalidateAll'
 import strings from '../../utils/constants'
 import messages from '../../utils/messages'
 
@@ -79,7 +79,7 @@ const ApplicationPageWrapper: React.FC = () => {
   // 1 - ProcessRedirect: Will redirect to summary in case application is SUBMITTED
   // 2 - Set the current section state of the application
   useEffect(() => {
-    if (isApplicationLoaded) {
+    if (elementsState && responsesByCode) {
       processRedirect({
         ...appStatus,
         serialNumber,
@@ -88,12 +88,14 @@ const ApplicationPageWrapper: React.FC = () => {
         templateSections,
         push,
         replace,
+        elementsState,
+        responsesByCode,
       })
 
       if (sectionCode && page)
         setCurrentSection(templateSections.find(({ code }) => code === sectionCode))
     }
-  }, [isApplicationLoaded, sectionCode, page])
+  }, [elementsState, responsesByCode, sectionCode, page])
 
   // Wait for loading (and evaluating elements and responses)
   // or a change of section/page to rebuild the progress bar
@@ -275,7 +277,7 @@ const getPageHasRequiredQuestions = (elements: ElementState[]): boolean =>
       category === TemplateElementCategory.Question && isRequired && isVisible
   )
 
-function processRedirect(appState: any): void {
+async function processRedirect(appState: any) {
   // All logic for re-directing/configuring page based on application state, permissions, roles, etc. should go here.
   const {
     stage,
@@ -287,14 +289,26 @@ function processRedirect(appState: any): void {
     templateSections,
     push,
     replace,
+    elementsState,
+    responsesByCode,
   } = appState
   if (status !== 'DRAFT') {
     replace(`/application/${serialNumber}/summary`)
     return
   }
   if (!sectionCode || !page) {
-    const firstSection = templateSections[0].code
-    replace(`/application/${serialNumber}/${firstSection}/page1`)
+    const revalidate = await revalidateAll(elementsState, responsesByCode)
+
+    if (revalidate.validityFailures.length > 0) {
+      const { firstErrorSectionCode, firstErrorPage } = getFirstErrorLocation(
+        revalidate.validityFailures,
+        elementsState as ApplicationElementStates
+      )
+      push(`/application/${serialNumber}/${firstErrorSectionCode}/Page${firstErrorPage}`)
+    } else {
+      const firstSection = templateSections[0].code
+      replace(`/application/${serialNumber}/${firstSection}/page1`)
+    }
   }
 }
 

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -310,7 +310,7 @@ async function processRedirect(appState: any) {
       push(`/application/${serialNumber}/${firstErrorSectionCode}/Page${firstErrorPage}`)
     } else {
       const firstSection = templateSections[0].code
-      replace(`/application/${serialNumber}/${firstSection}/page1`)
+      replace(`/application/${serialNumber}/${firstSection}/Page1`)
     }
   }
 }

--- a/src/utils/helpers/revalidateAll.tsx
+++ b/src/utils/helpers/revalidateAll.tsx
@@ -28,6 +28,8 @@ export const revalidateAll = async (
           (!strict && responsesByCode[key]?.isValid !== null))
     )
 
+    console.log('Codes to check:', elementCodes)
+
     const validationExpressions = elementCodes.map((code) => elementsState[code].validation)
 
     const evaluatedValidations = []
@@ -40,6 +42,7 @@ export const revalidateAll = async (
           : ''
         : ''
       const responses = { thisResponse, ...responsesByCode }
+      console.log('responses', responses)
       const expression = validationExpressions[i]
       evaluatedValidations.push(
         validate(expression, elementsState[code]?.validationMessage as string, {
@@ -49,7 +52,11 @@ export const revalidateAll = async (
       )
     }
     const resultArray = await Promise.all(evaluatedValidations)
-    // console.log('Result', resultArray)
+    console.log('Result', resultArray)
+    elementCodes.forEach((code, index) => {
+      if (elementsState[code].isRequired && responsesByCode && !responsesByCode[code]?.text)
+        resultArray[index] = { isValid: false }
+    })
     const validityFailures: ValidityFailure[] = []
     if (shouldUpdateDatabase) {
       elementCodes.forEach((code, index) => {

--- a/src/utils/helpers/revalidateAll.tsx
+++ b/src/utils/helpers/revalidateAll.tsx
@@ -45,7 +45,7 @@ export const revalidateAll = async (
     }
     const resultArray = await Promise.all(evaluatedValidations)
 
-    // Also make "" responses invalid for required questions
+    // Also make empty responses invalid for required questions
     elementCodes.forEach((code, index) => {
       if (
         elementsState[code].isRequired &&

--- a/src/utils/helpers/revalidateAll.tsx
+++ b/src/utils/helpers/revalidateAll.tsx
@@ -47,7 +47,6 @@ export const revalidateAll = async (
 
     // Also make "" responses invalid for required questions
     elementCodes.forEach((code, index) => {
-      console.log(code, index)
       if (
         elementsState[code].isRequired &&
         (!responsesByCode[code]?.text ||

--- a/src/utils/helpers/revalidateAll.tsx
+++ b/src/utils/helpers/revalidateAll.tsx
@@ -23,8 +23,6 @@ export const revalidateAll = async (
         ((strict && elementsState[key].isRequired) || responsesByCode[key]?.isValid !== null)
     )
 
-    console.log('Codes to check:', elementCodes)
-
     const validationExpressions = elementCodes.map((code) => elementsState[code].validation)
 
     const evaluatedValidations = []
@@ -46,9 +44,10 @@ export const revalidateAll = async (
       )
     }
     const resultArray = await Promise.all(evaluatedValidations)
+
     // Also make "" responses invalid for required questions
-    console.log('Results', resultArray)
     elementCodes.forEach((code, index) => {
+      console.log(code, index)
       if (
         elementsState[code].isRequired &&
         (!responsesByCode[code]?.text ||
@@ -57,7 +56,6 @@ export const revalidateAll = async (
       )
         resultArray[index].isValid = false
     })
-    console.log('Results', resultArray)
 
     const validityFailures: ValidityFailure[] = shouldUpdateDatabase
       ? elementCodes.reduce((validityFailures: ValidityFailure[], code, index) => {


### PR DESCRIPTION
Implements #135 -- just a fairly small extension to #194 (so you'll need [that PR's back-end branch](https://github.com/openmsupply/application-manager-server/pull/150) to test against, if it's not already merged)

This PR does two additional things:
1. Ensures that any empty response (null, undefined or empty string) all get set to "invalid" (for required questions) when re-validating all (change to `revalidateAll.tsx`). This ensures that when attempting to load Summary, you'll be taken back to first incomplete page (strict check), not just page with an invalid element (loose check).
2. Loading "Draft" application re-directs user to first invalid/incomplete page (instead of section 1, page 1) -- uses the same `revalidateAll` and `firstErrorLocation` functions as #194. (This does NOT write validity back to database, so `null` validations will persist in each element.