### PR TITLE
#206 Fix problem with validation check on progress bar

### DIFF
--- a/src/components/Application/ProgressBar.tsx
+++ b/src/components/Application/ProgressBar.tsx
@@ -1,7 +1,13 @@
 import React from 'react'
 import { Accordion, Container, Grid, Header, Icon, Label, List, Sticky } from 'semantic-ui-react'
-import { ProgressInApplication, ProgressInPage, ProgressStatus } from '../../utils/types'
+import {
+  CurrentPage,
+  ProgressInApplication,
+  ProgressInPage,
+  ProgressStatus,
+} from '../../utils/types'
 import strings from '../../utils/constants'
+import { useRouter } from '../../utils/hooks/useRouter'
 
 interface SectionPage {
   sectionIndex: number
@@ -12,17 +18,18 @@ interface ProgressBarProps {
   serialNumber: string
   currentSectionPage?: SectionPage
   progressStructure: ProgressInApplication
-  push: (path: string) => void
-  validatePreviousPage: (sectionCode: string, page: number) => boolean
+  getPreviousPage: (props: { sectionCode: string; pageNumber: number }) => CurrentPage | undefined
+  validateElementsInPage: (props?: CurrentPage) => boolean
 }
 
 const ProgressBar: React.FC<ProgressBarProps> = ({
   serialNumber,
   currentSectionPage,
   progressStructure,
-  push,
-  validatePreviousPage,
+  getPreviousPage,
+  validateElementsInPage,
 }) => {
+  const { push } = useRouter()
   const getPageIndicator = (status: ProgressStatus | undefined) => {
     const indicator = {
       VALID: <Icon name="check circle" color="green" />,
@@ -30,6 +37,11 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
       INCOMPLETE: <Icon name="circle outline" />,
     }
     return status ? indicator[status] : null
+  }
+
+  const getPreviousPageIsValid = (sectionCode: string, pageNumber: number) => {
+    const previousPage = getPreviousPage({ sectionCode, pageNumber })
+    return previousPage && validateElementsInPage(previousPage)
   }
 
   const pageList = (sectionCode: string, pages: ProgressInPage[]) => {
@@ -44,7 +56,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
               as="a"
               key={`ProgressSection_${sectionCode}_${pageNumber}`}
               onClick={() => {
-                if (canNavigate || validatePreviousPage(sectionCode, pageNumber))
+                if (canNavigate || validateElementsInPage())
                   push(`/application/${serialNumber}/${sectionCode}/Page${pageNumber}`)
               }}
             >
@@ -95,7 +107,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
         },
         onTitleClick: () => {
           const firstPage = 1
-          if (canNavigate || validatePreviousPage(code, firstPage)) {
+          if (canNavigate || getPreviousPageIsValid(code, firstPage)) {
             push(`/application/${serialNumber}/${code}/Page${firstPage}`)
           }
         },

--- a/src/components/Application/ProgressBar.tsx
+++ b/src/components/Application/ProgressBar.tsx
@@ -13,7 +13,7 @@ interface ProgressBarProps {
   currentSectionPage?: SectionPage
   progressStructure: ProgressInApplication
   push: (path: string) => void
-  validateCurrentPage: () => boolean
+  validatePreviousPage: (sectionCode: string, page: number) => boolean
 }
 
 const ProgressBar: React.FC<ProgressBarProps> = ({
@@ -21,7 +21,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
   currentSectionPage,
   progressStructure,
   push,
-  validateCurrentPage,
+  validatePreviousPage,
 }) => {
   const getPageIndicator = (status: ProgressStatus | undefined) => {
     const indicator = {
@@ -36,21 +36,20 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
     return (
       <List style={{ paddingLeft: '50px' }} link>
         {pages.map((page) => {
-          const { canNavigate, isActive, pageName, status } = page
-          const pageCode = pageName?.replace(' ', '')
+          const { canNavigate, isActive, pageNumber, status } = page
 
           return (
             <List.Item
               active={isActive}
               as="a"
-              key={`progress_${pageName}`}
+              key={`ProgressSection_${sectionCode}_${pageNumber}`}
               onClick={() => {
-                if (canNavigate || validateCurrentPage())
-                  push(`/application/${serialNumber}/${sectionCode}/${pageCode}`)
+                if (canNavigate || validatePreviousPage(sectionCode, pageNumber))
+                  push(`/application/${serialNumber}/${sectionCode}/Page${pageNumber}`)
               }}
             >
               {getPageIndicator(status)}
-              {pageName}
+              {`Page ${pageNumber}`}
             </List.Item>
           )
         })}
@@ -95,9 +94,9 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
           ),
         },
         onTitleClick: () => {
-          if (canNavigate || validateCurrentPage()) {
-            const pageCode = 'Page1'
-            push(`/application/${serialNumber}/${code}/${pageCode}`)
+          const firstPage = 1
+          if (canNavigate || validatePreviousPage(code, firstPage)) {
+            push(`/application/${serialNumber}/${code}/Page${firstPage}`)
           }
         },
         content: {

--- a/src/containers/Application/NavigationBox.tsx
+++ b/src/containers/Application/NavigationBox.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react'
-import { Button, Container, Label, ModalProps } from 'semantic-ui-react'
+import React from 'react'
+import { Container, Label, ModalProps } from 'semantic-ui-react'
 import { useRouter } from '../../utils/hooks/useRouter'
-import { TemplateSectionPayload } from '../../utils/types'
+import { CurrentPage, TemplateSectionPayload } from '../../utils/types'
 import messages from '../../utils/messages'
 import strings from '../../utils/constants'
 
@@ -10,7 +10,7 @@ interface NavigationBoxProps {
   currentSection: TemplateSectionPayload
   serialNumber: string
   currentPage: number
-  validatePreviousPage: (sectionCode: string, page: number) => boolean
+  validateElementsInPage: (props?: CurrentPage) => boolean
   showValidationModal: Function
   modalState: { showModal: ModalProps; setShowModal: Function }
 }
@@ -20,7 +20,7 @@ const NavigationBox: React.FC<NavigationBoxProps> = ({
   currentSection,
   serialNumber,
   currentPage,
-  validatePreviousPage,
+  validateElementsInPage,
   modalState: { setShowModal },
 }) => {
   const nextSection = templateSections.find(({ index }) => index === currentSection.index + 1)
@@ -54,7 +54,7 @@ const NavigationBox: React.FC<NavigationBoxProps> = ({
     const page = nextPage > currentSection.totalPages ? 1 : nextPage
 
     // Check if previous page (related to next) is valid
-    const status = validatePreviousPage(section.code, page)
+    const status = validateElementsInPage()
 
     if (!status) setShowModal({ open: true, ...messages.VALIDATION_FAIL })
     else sendToPage(section.code, page)

--- a/src/utils/helpers/getPreviousPage.tsx
+++ b/src/utils/helpers/getPreviousPage.tsx
@@ -1,0 +1,41 @@
+import { CurrentPage, TemplateSectionPayload } from '../types'
+
+interface GetPreviousPageProps {
+  templateSections: TemplateSectionPayload[]
+  sectionCode: string
+  pageNumber: number
+}
+
+const getPreviousPage = ({
+  templateSections,
+  sectionCode,
+  pageNumber,
+}: GetPreviousPageProps): CurrentPage | undefined => {
+  const currentSection = getCurrentSection(templateSections, sectionCode)
+
+  // Check for first page/section, which don't have a previous page
+  if (!currentSection || (currentSection.index === 0 && pageNumber === 1)) return undefined
+
+  const previousPage = pageNumber - 1
+  // Check if previous page is in the same section
+  const section =
+    previousPage > 0 ? currentSection : getPreviousSection(templateSections, currentSection.index)
+
+  if (!section) {
+    console.log('Problem to check previous page - section not found!')
+    return undefined
+  }
+
+  const page = pageNumber - 1 > 0 ? pageNumber - 1 : section.totalPages
+
+  return { section, page }
+}
+
+const getCurrentSection = (templateSections: TemplateSectionPayload[], sectionCode: string) =>
+  templateSections.find(({ code }) => code === sectionCode)
+
+// TODO: If we allow gaps between section index this needs improvement!
+const getPreviousSection = (templateSections: TemplateSectionPayload[], currentIndex: number) =>
+  templateSections.find(({ index }) => index === currentIndex - 1)
+
+export default getPreviousPage

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -7,6 +7,7 @@ export {
   ApplicationElementStates,
   AppStatus,
   AssignmentDetails,
+  CurrentPage,
   ElementPluginParameterValue,
   ElementPluginParameters,
   ElementState,
@@ -63,6 +64,11 @@ interface AssignmentDetails {
   id: number
   review?: ReviewDetails
   questions: ReviewQuestion[]
+}
+
+interface CurrentPage {
+  section: TemplateSectionPayload
+  page: number
 }
 
 type ElementPluginParameterValue = string | number | string[] | IQueryNode

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -117,7 +117,7 @@ interface PageElementsStatuses {
 }
 
 interface ProgressInPage {
-  pageName: string
+  pageNumber: number
   status: ProgressStatus
   canNavigate: boolean
   isActive: boolean


### PR DESCRIPTION
Fix #206

### Changes
- Simply check for the previous page of the **aimed** page the user wants to go. Using the same `validatePreviousPage` in both `NavigationBox` and `ProgressBar` for reusability, although it made the process a bit less clear when click **Next**. 


### Steps to reproduce bug (on `master`):
1. Create a new "Review Test form" application
2. Fill all elements in page 1, loose focus on last on so it will validate
3. Now click on Section 2 **Product Info**, and it will wrongly take you there!