### PR TITLE
#182 Show the start page with title and message defined for template

### DIFF
--- a/src/components/Application/ApplicationStart.tsx
+++ b/src/components/Application/ApplicationStart.tsx
@@ -16,7 +16,11 @@ const ApplicationStart: React.FC<ApplicationStartProps> = (props) => {
 
   return template ? (
     <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>
-      <Button as="href" icon="angle left" label={{ content: name, color: 'grey' }} />
+      <Button
+        as="href"
+        icon="angle left"
+        label={{ content: `${name} ${strings.LABEL_APPLICATIONS}`, color: 'grey' }}
+      />
       <Header textAlign="center">{strings.TITLE_COMPANY_PLACEHOLDER}</Header>
       <Segment
         style={{

--- a/src/components/Application/ApplicationStart.tsx
+++ b/src/components/Application/ApplicationStart.tsx
@@ -1,5 +1,7 @@
+import { type } from 'os'
 import React from 'react'
-import { Button, Container, Header, Label, List, Segment } from 'semantic-ui-react'
+import { Button, Container, Divider, Header, Icon, List, Message, Segment } from 'semantic-ui-react'
+import strings from '../../utils/constants'
 import { TemplateTypePayload, TemplateSectionPayload } from '../../utils/types'
 import ApplicationSelectType from './ApplicationSelectType'
 
@@ -10,26 +12,49 @@ export interface ApplicationStartProps {
 }
 
 const ApplicationStart: React.FC<ApplicationStartProps> = (props) => {
-  const { template: type, sections, handleClick } = props
+  const { template, sections, handleClick } = props
+  const { name, startTitle, startMessage } = template
 
-  return type ? (
+  return template ? (
     <Container text>
-      <Header as="h1" content={type ? type.description : 'Create application page'} />
-      {type && (
-        <Segment>
-          {sections && (
-            <Header as="h2" content={`Number of sections in template: ${sections.length}`} />
-          )}
-          <List>
+      <Header as="h2" textAlign="center">
+        {`${name} ${strings.TITLE_APPLICATION_FORM}`}
+        <Header.Subheader>{strings.TITLE_INTRODUCTION}</Header.Subheader>
+      </Header>
+      {template && (
+        <Segment basic>
+          <Header as="h5">{strings.SUBTITLE_APPLICATION_STEPS}</Header>
+          <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
+          <List divided relaxed>
             {sections &&
               sections.map((section) => (
-                <List.Item key={`list-item-${section.code}`} content={section.title} />
+                <List.Item key={`list-item-${section.code}`}>
+                  <List.Icon name="circle outline" />
+                  <List.Content>{section.title}</List.Content>
+                </List.Item>
               ))}
           </List>
-          <Button content={type.name} onClick={handleClick} />
+          <Divider />
+          {startTitle && (
+            <Message info>
+              <Message.Header>
+                <Icon name="info circle" />
+                {startTitle}
+              </Message.Header>
+              {startMessage && (
+                <Message.List>
+                  {startMessage.split(/\r?\n/).map((str, index) => (
+                    <Message.Item key={`start-item-${index}`}>{str}</Message.Item>
+                  ))}
+                </Message.List>
+              )}
+            </Message>
+          )}
+          <Button color="blue" onClick={handleClick}>
+            {strings.BUTTON_APPLICATION_START}
+          </Button>
         </Segment>
       )}
-      {!type && <Label content="No Application" />}
     </Container>
   ) : (
     <ApplicationSelectType />

--- a/src/components/Application/ApplicationStart.tsx
+++ b/src/components/Application/ApplicationStart.tsx
@@ -12,7 +12,7 @@ export interface ApplicationStartProps {
 
 const ApplicationStart: React.FC<ApplicationStartProps> = (props) => {
   const { template, sections, handleClick } = props
-  const { name, code, startTitle, startMessage } = template
+  const { name, code, startMessage } = template
 
   return template ? (
     <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>
@@ -49,19 +49,12 @@ const ApplicationStart: React.FC<ApplicationStartProps> = (props) => {
                 ))}
             </List>
             <Divider />
-            {startTitle && (
+            {startMessage && (
               <Message info>
                 <Message.Header>
                   <Icon name="info circle" />
-                  {startTitle}
                 </Message.Header>
-                {startMessage && (
-                  <Message.List>
-                    {startMessage.split(/\r?\n/).map((str, index) => (
-                      <Message.Item key={`start-item-${index}`}>{str}</Message.Item>
-                    ))}
-                  </Message.List>
-                )}
+                <p>{startMessage}</p>
               </Message>
             )}
             <Button color="blue" onClick={handleClick}>

--- a/src/components/Application/ApplicationStart.tsx
+++ b/src/components/Application/ApplicationStart.tsx
@@ -1,6 +1,5 @@
-import { type } from 'os'
 import React from 'react'
-import { Button, Container, Divider, Header, Icon, List, Message, Segment } from 'semantic-ui-react'
+import { Button, Divider, Header, Icon, List, Message, Segment } from 'semantic-ui-react'
 import strings from '../../utils/constants'
 import { TemplateTypePayload, TemplateSectionPayload } from '../../utils/types'
 import ApplicationSelectType from './ApplicationSelectType'
@@ -13,49 +12,61 @@ export interface ApplicationStartProps {
 
 const ApplicationStart: React.FC<ApplicationStartProps> = (props) => {
   const { template, sections, handleClick } = props
-  const { name, startTitle, startMessage } = template
+  const { name, code, startTitle, startMessage } = template
 
   return template ? (
-    <Container text>
-      <Header as="h2" textAlign="center">
-        {`${name} ${strings.TITLE_APPLICATION_FORM}`}
-        <Header.Subheader>{strings.TITLE_INTRODUCTION}</Header.Subheader>
-      </Header>
-      {template && (
-        <Segment basic>
-          <Header as="h5">{strings.SUBTITLE_APPLICATION_STEPS}</Header>
-          <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
-          <List divided relaxed>
-            {sections &&
-              sections.map((section) => (
-                <List.Item key={`list-item-${section.code}`}>
-                  <List.Icon name="circle outline" />
-                  <List.Content>{section.title}</List.Content>
-                </List.Item>
-              ))}
-          </List>
-          <Divider />
-          {startTitle && (
-            <Message info>
-              <Message.Header>
-                <Icon name="info circle" />
-                {startTitle}
-              </Message.Header>
-              {startMessage && (
-                <Message.List>
-                  {startMessage.split(/\r?\n/).map((str, index) => (
-                    <Message.Item key={`start-item-${index}`}>{str}</Message.Item>
-                  ))}
-                </Message.List>
-              )}
-            </Message>
-          )}
-          <Button color="blue" onClick={handleClick}>
-            {strings.BUTTON_APPLICATION_START}
-          </Button>
-        </Segment>
-      )}
-    </Container>
+    <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>
+      <Button as="href" icon="angle left" label={{ content: name, color: 'grey' }} />
+      <Header textAlign="center">{strings.TITLE_COMPANY_PLACEHOLDER}</Header>
+      <Segment
+        style={{
+          backgroundColor: 'white',
+          padding: 10,
+          margin: '0px 50px',
+          minHeight: 500,
+          flex: 1,
+        }}
+      >
+        <Header as="h2" textAlign="center">
+          {`${name} ${strings.TITLE_APPLICATION_FORM}`}
+          <Header.Subheader>{strings.TITLE_INTRODUCTION}</Header.Subheader>
+        </Header>
+        {template && (
+          <Segment basic>
+            <Header as="h5">{strings.SUBTITLE_APPLICATION_STEPS}</Header>
+            <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
+            <List divided relaxed>
+              {sections &&
+                sections.map((section) => (
+                  <List.Item key={`list-item-${section.code}`}>
+                    <List.Icon name="circle outline" />
+                    <List.Content>{section.title}</List.Content>
+                  </List.Item>
+                ))}
+            </List>
+            <Divider />
+            {startTitle && (
+              <Message info>
+                <Message.Header>
+                  <Icon name="info circle" />
+                  {startTitle}
+                </Message.Header>
+                {startMessage && (
+                  <Message.List>
+                    {startMessage.split(/\r?\n/).map((str, index) => (
+                      <Message.Item key={`start-item-${index}`}>{str}</Message.Item>
+                    ))}
+                  </Message.List>
+                )}
+              </Message>
+            )}
+            <Button color="blue" onClick={handleClick}>
+              {strings.BUTTON_APPLICATION_START}
+            </Button>
+          </Segment>
+        )}
+      </Segment>
+    </Segment.Group>
   ) : (
     <ApplicationSelectType />
   )

--- a/src/components/Application/ProgressBar.tsx
+++ b/src/components/Application/ProgressBar.tsx
@@ -121,7 +121,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
   return (
     <Sticky as={Container}>
       <Header as="h5" style={{ paddingLeft: 30 }}>
-        {strings.TITLE_PROGRESS}
+        {strings.TITLE_INTRODUCTION}
       </Header>
       <Accordion
         activeIndex={currentSectionPage ? currentSectionPage.sectionIndex : 0} //TODO: Change to get active from structure

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,6 +20,7 @@ export default {
   ERROR_REVIEW_PAGE: 'Problem to load review',
   ERROR_REVIEW_OVERVIEW: 'Problem to load review homepage',
   ERROR_LOGIN_PASSWORD: 'Oops! Problem with username or password',
+  LABEL_APPLICATIONS: 'applications',
   LABEL_ASSIGNED_TO_YOU: 'Assigned to you',
   LABEL_ASSIGNED_TO_OTHER: 'Assigned to another reviewer',
   LABEL_LOGIN_PASSWORD: 'Password',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -35,6 +35,6 @@ export default {
   TITLE_STEPS: 'Steps to complete',
   STAGE_PLACEHOLDER: 'Assessment',
   SUBTITLE_APPLICATION_STEPS:
-    'The following sterps will need to be completed before the form can be submitted',
+    'The following steps will need to be completed before the form can be submitted',
   SUBTITLE_REVIEW: 'Please complete the sections that have been assigned to you',
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,5 @@
 export default {
+  BUTTON_APPLICATION_START: 'Get started',
   BUTTON_NEXT: 'Next',
   BUTTON_PREVIOUS: 'Previous',
   BUTTON_REVIEW_APPROVE_ALL: 'Approve all ',
@@ -25,10 +26,14 @@ export default {
   LABEL_LOGIN_USERNAME: 'Username',
   LABEL_WELCOME: 'Welcome to IRIMS Application Manager',
   LINK_LOGIN_USER: 'Create new account',
+  TITLE_APPLICATION_FORM: 'application form',
   TITLE_APPLICATION_SUBMIT: 'Review & Submit',
   TITLE_COMPANY_PLACEHOLDER: 'ABC Company',
+  TITLE_INTRODUCTION: 'Introduction',
   TITLE_REVIEW_SUMMARY: 'Review Summary',
-  TITLE_PROGRESS: 'Introduction',
+  TITLE_STEPS: 'Steps to complete',
   STAGE_PLACEHOLDER: 'Assessment',
+  SUBTITLE_APPLICATION_STEPS:
+    'The following sterps will need to be completed before the form can be submitted',
   SUBTITLE_REVIEW: 'Please complete the sections that have been assigned to you',
 }

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -1562,14 +1562,12 @@ export type TemplateFilter = {
   code?: Maybe<StringFilter>;
   /** Filter by the object’s `isLinear` field. */
   isLinear?: Maybe<BooleanFilter>;
-  /** Filter by the object’s `startTitle` field. */
-  startTitle?: Maybe<StringFilter>;
   /** Filter by the object’s `startMessage` field. */
-  startMessage?: Maybe<StringFilter>;
+  startMessage?: Maybe<JsonFilter>;
   /** Filter by the object’s `status` field. */
   status?: Maybe<TemplateStatusFilter>;
   /** Filter by the object’s `submissionMessage` field. */
-  submissionMessage?: Maybe<StringFilter>;
+  submissionMessage?: Maybe<JsonFilter>;
   /** Filter by the object’s `versionTimestamp` field. */
   versionTimestamp?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `templateStages` relation. */
@@ -3192,10 +3190,9 @@ export type Template = Node & {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   /** Reads and enables pagination through a set of `TemplateStage`. */
   templateStages: TemplateStagesConnection;
@@ -5749,8 +5746,6 @@ export enum TemplatesOrderBy {
   CodeDesc = 'CODE_DESC',
   IsLinearAsc = 'IS_LINEAR_ASC',
   IsLinearDesc = 'IS_LINEAR_DESC',
-  StartTitleAsc = 'START_TITLE_ASC',
-  StartTitleDesc = 'START_TITLE_DESC',
   StartMessageAsc = 'START_MESSAGE_ASC',
   StartMessageDesc = 'START_MESSAGE_DESC',
   StatusAsc = 'STATUS_ASC',
@@ -5773,14 +5768,12 @@ export type TemplateCondition = {
   code?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `isLinear` field. */
   isLinear?: Maybe<Scalars['Boolean']>;
-  /** Checks for equality with the object’s `startTitle` field. */
-  startTitle?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `startMessage` field. */
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `status` field. */
   status?: Maybe<TemplateStatus>;
   /** Checks for equality with the object’s `submissionMessage` field. */
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `versionTimestamp` field. */
   versionTimestamp?: Maybe<Scalars['Datetime']>;
 };
@@ -7336,10 +7329,9 @@ export type UpdateTemplateOnActionQueueForActionQueueTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -7439,10 +7431,9 @@ export type UpdateTemplateOnTemplateStageForTemplateStageTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -7544,10 +7535,9 @@ export type UpdateTemplateOnTemplateSectionForTemplateSectionTemplateIdFkeyPatch
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8303,10 +8293,9 @@ export type UpdateTemplateOnTemplatePermissionForTemplatePermissionTemplateIdFke
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8432,10 +8421,9 @@ export type UpdateTemplateOnApplicationForApplicationTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8629,10 +8617,9 @@ export type UpdateTemplateOnTemplateActionForTemplateActionTemplateIdFkeyPatch =
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8656,10 +8643,9 @@ export type TemplatePatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8675,10 +8661,9 @@ export type TemplateActionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8733,10 +8718,9 @@ export type ApplicationTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13237,10 +13221,9 @@ export type TemplatePermissionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13606,10 +13589,9 @@ export type TemplateSectionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13653,10 +13635,9 @@ export type TemplateStageTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13698,10 +13679,9 @@ export type ActionQueueTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -14548,10 +14528,9 @@ export type TemplateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  startTitle?: Maybe<Scalars['String']>;
-  startMessage?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
-  submissionMessage?: Maybe<Scalars['String']>;
+  submissionMessage?: Maybe<Scalars['JSON']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -17215,7 +17194,7 @@ export type SectionFragment = (
 
 export type TemplateFragment = (
   { __typename?: 'Template' }
-  & Pick<Template, 'code' | 'id' | 'name' | 'isLinear' | 'startTitle' | 'startMessage' | 'submissionMessage'>
+  & Pick<Template, 'code' | 'id' | 'name' | 'isLinear' | 'startMessage' | 'submissionMessage'>
 );
 
 export type CreateApplicationMutationVariables = Exact<{
@@ -17650,7 +17629,6 @@ export const TemplateFragmentDoc = gql`
   id
   name
   isLinear
-  startTitle
   startMessage
   submissionMessage
 }

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -1562,8 +1562,14 @@ export type TemplateFilter = {
   code?: Maybe<StringFilter>;
   /** Filter by the object’s `isLinear` field. */
   isLinear?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `startTitle` field. */
+  startTitle?: Maybe<StringFilter>;
+  /** Filter by the object’s `startMessage` field. */
+  startMessage?: Maybe<StringFilter>;
   /** Filter by the object’s `status` field. */
   status?: Maybe<TemplateStatusFilter>;
+  /** Filter by the object’s `submissionMessage` field. */
+  submissionMessage?: Maybe<StringFilter>;
   /** Filter by the object’s `versionTimestamp` field. */
   versionTimestamp?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `templateStages` relation. */
@@ -3186,7 +3192,10 @@ export type Template = Node & {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   /** Reads and enables pagination through a set of `TemplateStage`. */
   templateStages: TemplateStagesConnection;
@@ -5740,8 +5749,14 @@ export enum TemplatesOrderBy {
   CodeDesc = 'CODE_DESC',
   IsLinearAsc = 'IS_LINEAR_ASC',
   IsLinearDesc = 'IS_LINEAR_DESC',
+  StartTitleAsc = 'START_TITLE_ASC',
+  StartTitleDesc = 'START_TITLE_DESC',
+  StartMessageAsc = 'START_MESSAGE_ASC',
+  StartMessageDesc = 'START_MESSAGE_DESC',
   StatusAsc = 'STATUS_ASC',
   StatusDesc = 'STATUS_DESC',
+  SubmissionMessageAsc = 'SUBMISSION_MESSAGE_ASC',
+  SubmissionMessageDesc = 'SUBMISSION_MESSAGE_DESC',
   VersionTimestampAsc = 'VERSION_TIMESTAMP_ASC',
   VersionTimestampDesc = 'VERSION_TIMESTAMP_DESC',
   PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
@@ -5758,8 +5773,14 @@ export type TemplateCondition = {
   code?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `isLinear` field. */
   isLinear?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `startTitle` field. */
+  startTitle?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `startMessage` field. */
+  startMessage?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `status` field. */
   status?: Maybe<TemplateStatus>;
+  /** Checks for equality with the object’s `submissionMessage` field. */
+  submissionMessage?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `versionTimestamp` field. */
   versionTimestamp?: Maybe<Scalars['Datetime']>;
 };
@@ -7315,7 +7336,10 @@ export type UpdateTemplateOnActionQueueForActionQueueTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -7415,7 +7439,10 @@ export type UpdateTemplateOnTemplateStageForTemplateStageTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -7517,7 +7544,10 @@ export type UpdateTemplateOnTemplateSectionForTemplateSectionTemplateIdFkeyPatch
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8273,7 +8303,10 @@ export type UpdateTemplateOnTemplatePermissionForTemplatePermissionTemplateIdFke
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8399,7 +8432,10 @@ export type UpdateTemplateOnApplicationForApplicationTemplateIdFkeyPatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8593,7 +8629,10 @@ export type UpdateTemplateOnTemplateActionForTemplateActionTemplateIdFkeyPatch =
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8617,7 +8656,10 @@ export type TemplatePatch = {
   name?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8633,7 +8675,10 @@ export type TemplateActionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -8688,7 +8733,10 @@ export type ApplicationTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13189,7 +13237,10 @@ export type TemplatePermissionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13555,7 +13606,10 @@ export type TemplateSectionTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13599,7 +13653,10 @@ export type TemplateStageTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -13641,7 +13698,10 @@ export type ActionQueueTemplateIdFkeyTemplateCreateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -14488,7 +14548,10 @@ export type TemplateInput = {
   name?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  startTitle?: Maybe<Scalars['String']>;
+  startMessage?: Maybe<Scalars['String']>;
   status?: Maybe<TemplateStatus>;
+  submissionMessage?: Maybe<Scalars['String']>;
   versionTimestamp?: Maybe<Scalars['Datetime']>;
   templateStagesUsingId?: Maybe<TemplateStageTemplateIdFkeyInverseInput>;
   templateSectionsUsingId?: Maybe<TemplateSectionTemplateIdFkeyInverseInput>;
@@ -17152,7 +17215,7 @@ export type SectionFragment = (
 
 export type TemplateFragment = (
   { __typename?: 'Template' }
-  & Pick<Template, 'code' | 'id' | 'name' | 'isLinear'>
+  & Pick<Template, 'code' | 'id' | 'name' | 'isLinear' | 'startTitle' | 'startMessage' | 'submissionMessage'>
 );
 
 export type CreateApplicationMutationVariables = Exact<{
@@ -17587,6 +17650,9 @@ export const TemplateFragmentDoc = gql`
   id
   name
   isLinear
+  startTitle
+  startMessage
+  submissionMessage
 }
     `;
 export const CreateApplicationDocument = gql`

--- a/src/utils/graphql/fragments/template.fragment.ts
+++ b/src/utils/graphql/fragments/template.fragment.ts
@@ -6,7 +6,6 @@ export default gql`
     id
     name
     isLinear
-    startTitle
     startMessage
     submissionMessage
   }

--- a/src/utils/graphql/fragments/template.fragment.ts
+++ b/src/utils/graphql/fragments/template.fragment.ts
@@ -6,5 +6,8 @@ export default gql`
     id
     name
     isLinear
+    startTitle
+    startMessage
+    submissionMessage
   }
 `

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -46,21 +46,12 @@ const useLoadTemplate = (props: useLoadTemplateProps) => {
       return
     }
 
-    const {
-      id,
-      code,
-      name,
-      startTitle,
-      startMessage,
-      submissionMessage,
-      templateSections,
-    } = template
+    const { id, code, name, startMessage, submissionMessage, templateSections } = template
 
     setTemplateType({
       id,
       code,
       name: name as string,
-      startTitle: startTitle ? startTitle : undefined,
       startMessage: startMessage ? startMessage : undefined,
       submissionMessage: submissionMessage as string,
     })

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -46,14 +46,23 @@ const useLoadTemplate = (props: useLoadTemplateProps) => {
       return
     }
 
-    const { id, code, name, templateSections } = template
+    const {
+      id,
+      code,
+      name,
+      startTitle,
+      startMessage,
+      submissionMessage,
+      templateSections,
+    } = template
 
     setTemplateType({
       id,
       code,
-      name: name ? name : 'Undefined name',
-      description: 'Include some description for this template',
-      documents: Array<string>(),
+      name: name as string,
+      startTitle: startTitle ? startTitle : undefined,
+      startMessage: startMessage ? startMessage : undefined,
+      submissionMessage: submissionMessage as string,
     })
 
     const sections = getTemplateSections(templateSections)

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -203,8 +203,9 @@ interface TemplateTypePayload {
   id: number
   name: string
   code: string
-  description: string
-  documents: Array<string>
+  startTitle?: string
+  startMessage?: string
+  submissionMessage: string
 }
 
 interface TemplateSectionPayload {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -203,7 +203,6 @@ interface TemplateTypePayload {
   id: number
   name: string
   code: string
-  startTitle?: string
   startMessage?: string
   submissionMessage: string
 }


### PR DESCRIPTION
Fix #182 

Using [Backend-#182F](https://github.com/openmsupply/application-manager-server/pull/162).

## Changes
- Layout on start application page
- Fetches `startTitle` and `startMessage` for template to be displayed on start application page.
- Add every string as constant to the constants file.
- Show application page if start message is defined.
- [Existing behaviour] Create the application when 'Get started' button is pressed.

## To do next:
- [#232] If `startTitle` or `startMessage` not defined - go straight to start page OR last invalid (or incomplete) page.
- [#236] Show progress on start page of Draft application:
  - Show progress on each section and validation icons.
  - Hide 'Get started' button when application already exists.
  - Show 'Resume' button on the last section with invalid (or incomplete) questions.