### PR TITLE
#86 Markdown for plugins

### DIFF
--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -16,6 +16,7 @@ import { useUserState } from '../contexts/UserState'
 import { defaultValidate } from './defaultValidate'
 import evaluateExpression from '@openmsupply/expression-evaluator'
 import { Form } from 'semantic-ui-react'
+import Markdown from '../utils/helpers/semanticReactMarkdown'
 
 const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) => {
   const {
@@ -138,6 +139,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
       value={value}
       setValue={setValue}
       setIsActive={setIsActive}
+      Markdown={Markdown}
       validationState={validationState || { isValid: true }}
       // TO-DO: ensure validationState gets calculated BEFORE rendering this child, so we don't need this fallback.
     />

--- a/src/formElementPlugins/SummaryViewWrapper.tsx
+++ b/src/formElementPlugins/SummaryViewWrapper.tsx
@@ -6,6 +6,7 @@ import { TemplateElementCategory } from '../utils/generated/graphql'
 import { ElementPluginParameters, User } from '../utils/types'
 import { extractDynamicExpressions, evaluateDynamicParameters } from './ApplicationViewWrapper'
 import { useUserState } from '../contexts/UserState'
+import Markdown from '../utils/helpers/semanticReactMarkdown'
 
 const SummaryViewWrapper: React.FC<SummaryViewWrapperProps> = (props) => {
   const { element, response, allResponses } = props
@@ -41,14 +42,22 @@ const SummaryViewWrapper: React.FC<SummaryViewWrapperProps> = (props) => {
     const combinedParams = { ...parameters, ...evaluatedParameters }
     return (
       <Form.Field required={isRequired}>
-        {parametersLoaded && <label style={{ color: 'black' }}>{combinedParams.label}</label>}
+        {parametersLoaded && (
+          <label style={{ color: 'black' }}>
+            <Markdown text={combinedParams.label} semanticComponent="noParagraph" />
+          </label>
+        )}
         <Input fluid readOnly transparent value={response ? response?.text : ''} />
       </Form.Field>
     )
   }
 
   const PluginComponent = (
-    <SummaryView parameters={{ ...parameters, ...evaluatedParameters }} response={response} />
+    <SummaryView
+      parameters={{ ...parameters, ...evaluatedParameters }}
+      response={response}
+      Markdown={Markdown}
+    />
   )
 
   return (

--- a/src/formElementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/shortText/src/ApplicationView.tsx
@@ -12,6 +12,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   currentResponse,
   validationState,
   onSave,
+  Markdown,
 }) => {
   const { placeholder, maskedInput, label } = parameters
 
@@ -31,7 +32,9 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>{label}</label>
+      <label>
+        <Markdown text={label} semanticComponent="noParagraph" />
+      </label>
       <Form.Input
         fluid
         placeholder={placeholder}

--- a/src/formElementPlugins/textInfo/src/ApplicationView.tsx
+++ b/src/formElementPlugins/textInfo/src/ApplicationView.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import { Message } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
-import Markdown from '../../../utils/helpers/semanticReactMarkdown'
 
-const ApplicationView: React.FC<ApplicationViewProps> = ({ parameters }) => {
+const ApplicationView: React.FC<ApplicationViewProps> = ({ parameters, Markdown }) => {
   return (
     <Message>
       <Message.Header>{parameters.title}</Message.Header>

--- a/src/formElementPlugins/types.ts
+++ b/src/formElementPlugins/types.ts
@@ -39,11 +39,13 @@ interface ApplicationViewProps extends ApplicationViewWrapperProps {
   setValue: (text: string) => void // TO update the value on the ApplicationViewWrapper
   setIsActive: () => void
   validationState: ValidationState
+  Markdown: any
 }
 
 interface SummaryViewProps {
   parameters: BasicObject
   response: ResponseFull | null
+  Markdown: any
 }
 
 interface SummaryViewWrapperProps {

--- a/src/utils/helpers/semanticReactMarkdown.tsx
+++ b/src/utils/helpers/semanticReactMarkdown.tsx
@@ -31,7 +31,7 @@ const MarkdownBlock: React.FC<MarkdownBlockProps> = (props) => {
         return <Message children={input.children} info={info} error={error} />
       },
       heading: ({ node: { children }, level }: any) => {
-        const headingText = children[0].value
+        const headingText = children?.[0]?.value
         return (
           <Message.Header>
             {info && <Icon name="info circle" />}
@@ -44,7 +44,7 @@ const MarkdownBlock: React.FC<MarkdownBlockProps> = (props) => {
     // Prevents returned HTML from being wrapped in <p></p> tags
     noParagraph: {
       paragraph: ({ node: { children } }: any) => {
-        return <span>{children[0].value}</span>
+        return <span>{children?.[0]?.value}</span>
       },
     },
   }

--- a/src/utils/helpers/semanticReactMarkdown.tsx
+++ b/src/utils/helpers/semanticReactMarkdown.tsx
@@ -7,7 +7,7 @@ import React from 'react'
 import ReactMarkdown, { ReactMarkdownProps } from 'react-markdown'
 import { Message, Icon } from 'semantic-ui-react'
 
-type SemanticComponent = 'Message' // Enum for available renderers
+type SemanticComponent = 'Message' | 'noParagraph' // Enum for available renderers
 interface MarkdownBlockProps {
   text: string
   semanticComponent?: SemanticComponent
@@ -39,6 +39,12 @@ const MarkdownBlock: React.FC<MarkdownBlockProps> = (props) => {
             {headingText}
           </Message.Header>
         )
+      },
+    },
+    // Prevents returned HTML from being wrapped in <p></p> tags
+    noParagraph: {
+      paragraph: ({ node: { children } }: any) => {
+        return <span>{children[0].value}</span>
       },
     },
   }


### PR DESCRIPTION
Implements #86.

Already had Markdown display for TextInfo plugin, but I've moved the import to the Wrapper(s) and the component is passed to plugin components as a prop (as discussed).
- applied Markdown interpreter to `label` elements in Application and Summary views.
- added new 'noParagraph' renderer to Markdown module -- this prevents labels being returned wrapped in `<p></p>` tags, which messes up the label display.