### PR TITLE
#208 Search application list

### DIFF
--- a/src/containers/List/ListWrapper.tsx
+++ b/src/containers/List/ListWrapper.tsx
@@ -81,14 +81,14 @@ const ListWrapper: React.FC = () => {
             <Grid.Column width={3}>
               <Search
                 // size="large"
-                placeholder="Search Applications"
+                placeholder={strings.PLACEHOLDER_SEARCH}
                 onSearchChange={handleSearchChange}
                 open={false}
                 value={searchText}
               />
             </Grid.Column>
             <Grid.Column textAlign="left" verticalAlign="middle">
-              <Button content={'Clear search'} onClick={() => setSearchText('')} />
+              <Button content={strings.BUTTON_CLEAR_SEARCH} onClick={() => setSearchText('')} />
             </Grid.Column>
             <Grid.Column textAlign="right" verticalAlign="middle" floated="right">
               <Button

--- a/src/containers/List/ListWrapper.tsx
+++ b/src/containers/List/ListWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Container, List, Label, Segment, Button } from 'semantic-ui-react'
+import { Container, List, Label, Segment, Button, Form } from 'semantic-ui-react'
 import { Loading, FilterList } from '../../components'
 import { useRouter } from '../../utils/hooks/useRouter'
 import useListApplications from '../../utils/hooks/useListApplications'
@@ -14,12 +14,13 @@ import ApplicationsList from '../../components/List/ApplicationsList'
 import { ApplicationList } from '../../utils/generated/graphql'
 
 const ListWrapper: React.FC = () => {
-  const { query, push } = useRouter()
+  const { query, push, history, queryString, restoreKebabCaseKeys } = useRouter()
   const { type, userRole } = query
   const {
     userState: { templatePermissions },
   } = useUserState()
   const [columns, setColumns] = useState<ColumnDetails[]>([])
+  const [searchText, setSearchText] = useState('')
   const [applicationsRows, setApplicationsRows] = useState<ApplicationList[] | undefined>()
   const { error, loading, applications } = useListApplications(query)
 
@@ -40,6 +41,13 @@ const ListWrapper: React.FC = () => {
     }
   }, [loading, applications])
 
+  useEffect(() => {
+    const newQuery = { ...query }
+    if (searchText === '') delete newQuery.search
+    else newQuery.search = searchText
+    history.push({ search: queryString.stringify(restoreKebabCaseKeys(newQuery), { sort: false }) })
+  }, [searchText])
+
   const redirectToDefault = () => {
     const redirectType = type || Object.keys(templatePermissions)[0]
     const redirectUserRole = userRole || getDefaultUserRole(templatePermissions, redirectType)
@@ -48,6 +56,10 @@ const ListWrapper: React.FC = () => {
     else {
       // To-Do: Show 404 if no default found
     }
+  }
+
+  const handleSearchChange = (e: any) => {
+    setSearchText(e.target.value)
   }
 
   return error ? (
@@ -69,6 +81,17 @@ const ListWrapper: React.FC = () => {
           to={`/application/new?type=${type}`}
           content={strings.BUTTON_APPLICATION_NEW}
         />
+        {/* <Form>
+          <Form.Group> */}
+        <Form.Input
+          placeholder="Search"
+          name="search"
+          value={searchText}
+          icon="search"
+          onChange={handleSearchChange}
+        />
+        {/* </Form.Group>
+        </Form> */}
       </Segment>
       {columns && applicationsRows && (
         <ApplicationsList columns={columns} applications={applicationsRows} />

--- a/src/containers/List/ListWrapper.tsx
+++ b/src/containers/List/ListWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Container, List, Label, Segment, Button, Form } from 'semantic-ui-react'
+import { Container, List, Label, Segment, Button, Form, Search, Grid } from 'semantic-ui-react'
 import { Loading, FilterList } from '../../components'
 import { useRouter } from '../../utils/hooks/useRouter'
 import useListApplications from '../../utils/hooks/useListApplications'
@@ -20,7 +20,7 @@ const ListWrapper: React.FC = () => {
     userState: { templatePermissions },
   } = useUserState()
   const [columns, setColumns] = useState<ColumnDetails[]>([])
-  const [searchText, setSearchText] = useState('')
+  const [searchText, setSearchText] = useState(query?.search)
   const [applicationsRows, setApplicationsRows] = useState<ApplicationList[] | undefined>()
   const { error, loading, applications } = useListApplications(query)
 
@@ -76,22 +76,29 @@ const ListWrapper: React.FC = () => {
             <List.Item key={`ApplicationList-parameter-${value}`} content={key + ' : ' + value} />
           ))}
         </List>
-        <Button
-          as={Link}
-          to={`/application/new?type=${type}`}
-          content={strings.BUTTON_APPLICATION_NEW}
-        />
-        {/* <Form>
-          <Form.Group> */}
-        <Form.Input
-          placeholder="Search"
-          name="search"
-          value={searchText}
-          icon="search"
-          onChange={handleSearchChange}
-        />
-        {/* </Form.Group>
-        </Form> */}
+        <Grid columns={3} style={{ marginTop: '5px' }}>
+          <Grid.Row>
+            <Grid.Column width={3}>
+              <Search
+                // size="large"
+                placeholder="Search Applications"
+                onSearchChange={handleSearchChange}
+                open={false}
+                value={searchText}
+              />
+            </Grid.Column>
+            <Grid.Column textAlign="left" verticalAlign="middle">
+              <Button content={'Clear search'} onClick={() => setSearchText('')} />
+            </Grid.Column>
+            <Grid.Column textAlign="right" verticalAlign="middle" floated="right">
+              <Button
+                as={Link}
+                to={`/application/new?type=${type}`}
+                content={strings.BUTTON_APPLICATION_NEW}
+              />
+            </Grid.Column>
+          </Grid.Row>
+        </Grid>
       </Segment>
       {columns && applicationsRows && (
         <ApplicationsList columns={columns} applications={applicationsRows} />

--- a/src/containers/List/ListWrapper.tsx
+++ b/src/containers/List/ListWrapper.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Container, List, Label, Segment, Button, Form, Search, Grid } from 'semantic-ui-react'
+import { Container, List, Label, Segment, Button, Search, Grid } from 'semantic-ui-react'
 import { Loading, FilterList } from '../../components'
 import { useRouter } from '../../utils/hooks/useRouter'
 import useListApplications from '../../utils/hooks/useListApplications'

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,6 +14,8 @@ export default {
   BUTTON_REVIEW_START: 'Start review',
   BUTTON_SUMMARY: 'Review & Summary',
   BUTTON_SUBMIT: 'Submit',
+  BUTTON_CLEAR_SEARCH: 'Clear Search',
+  PLACEHOLDER_SEARCH: 'Search Applications',
   DATE_APPLICATION_PLACEHOLDER: '31/12/2020',
   ERROR_APPLICATION_CREATE: 'Problem to load application creation page',
   ERROR_APPLICATION_ELEMENTS: 'Elements area cannot be displayed',

--- a/src/utils/hooks/useRouter.tsx
+++ b/src/utils/hooks/useRouter.tsx
@@ -70,9 +70,12 @@ export function useRouter(): RouterResult {
         ...queryFilters,
         ...params,
       },
-      queryString, // query parsing/stringify functions
+
+      // query parsing/stringify functions
+      queryString,
       replaceKebabCaseKeys,
       restoreKebabCaseKeys,
+
       // Include match, location, history objects so we have
       // access to extra React Router functionality if needed.
       params,


### PR DESCRIPTION
Implement #208.

Querying the back-end via search query in URL was already implemented, this just adds a UI search box which updates the URL as you type.

~~Had to expose a little more `useRouter` functionality to the calling component, as we need to handle conversion of the queries back into a kebab-case URL.~~
**UPDATE**: I have simplified this quite a bit in my next PR (Sorting columns #322), so this useRouter messiness will be gone. You may wish to set the base to master on #322 and just review that, since Search and Sort end up sharing quite a bit.