### PR TITLE
#325 Add search capability to Dropdown plugin

### DIFF
--- a/documentation/internal/Element-Type-Specs.md
+++ b/documentation/internal/Element-Type-Specs.md
@@ -137,6 +137,7 @@ _Multi-choice question, with one allowed option, displayed as Drop-down list (Co
 - **description\***: `string` -- as above [Optional]
 - **options\***: `array[string]` -- as above
 - **default**: `string`/`number` -- if not provided, defaults to index 0.
+- **search**: `boolean` (default: `false`) -- if `true`, the list of options can be searched and filtered by user
 - **hasOther**: `boolean` -- if `true`, an additional text-entry field is provided so the user can add their own alternative option _(not yet implemented)_
 
 #### Response type

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -14,7 +14,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   Markdown,
   getDefaultIndex,
 }) => {
-  const { label, description, placeholder, options, default: defaultOption } = parameters
+  const { label, description, placeholder, search, options, default: defaultOption } = parameters
 
   useEffect(() => {
     onUpdate(value)
@@ -47,6 +47,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       <Dropdown
         fluid
         selection
+        search={search}
         placeholder={placeholder}
         options={dropdownOptions}
         onChange={handleChange}


### PR DESCRIPTION
Very small tweak to make this work. Have added documentation for the new parameter `search`.

To see it working, use back-end branch from [PR #217](https://github.com/openmsupply/application-manager-server/pull/217) -- on page 2 of the Feature Showcase application, the "API lookup" element has the searchable parameter enabled.

Thinking that this is probable enough for demonstration purposes. Rather than have a strict "lookup" element, we can just add (for example) ATC codes and their long-form string together in a list of options, and the user can easily search by either ATC code or the full name. (To be clear, I mean each option is a string containing both the ATC code and the full name, i.e. "N02AJ06 | codeine and paracetamol" )