### PR TITLE
#314 Create application wrapper router

### DIFF
--- a/src/containers/Application/ApplicationWrapper.tsx
+++ b/src/containers/Application/ApplicationWrapper.tsx
@@ -7,19 +7,19 @@ import { NoMatch } from '../../components'
 const ApplicationWrapper: React.FC = () => {
   return (
     <Switch>
-      <Route exact path="/application_new/new">
+      <Route exact path="/applicationNEW/new">
         <ApplicationCreateNew />
       </Route>
-      <Route exact path="/application_new/:serialNumber">
+      <Route exact path="/applicationNEW/:serialNumber">
         <ApplicationStartNew />
       </Route>
-      <Route exact path="/application_new/:serialNumber/:sectionCode/Page:page">
+      <Route exact path="/applicationNEW/:serialNumber/:sectionCode/Page:page">
         <ApplicationPageNew />
       </Route>
-      <Route exact path="/application_new/:serialNumber/summary">
+      <Route exact path="/applicationNEW/:serialNumber/summary">
         <ApplicationSummaryNew />
       </Route>
-      <Route exact path="/application_new/:serialNumber/submission">
+      <Route exact path="/applicationNEW/:serialNumber/submission">
         <ApplicationSubmissionNew />
       </Route>
       <Route>

--- a/src/containers/Application/ApplicationWrapper.tsx
+++ b/src/containers/Application/ApplicationWrapper.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { Switch, Route } from 'react-router-dom'
+import { Header } from 'semantic-ui-react'
+
+import { NoMatch } from '../../components'
+
+const ApplicationWrapper: React.FC = () => {
+  return (
+    <Switch>
+      <Route exact path="/application_new/new">
+        <ApplicationCreateNew />
+      </Route>
+      <Route exact path="/application_new/:serialNumber">
+        <ApplicationStartNew />
+      </Route>
+      <Route exact path="/application_new/:serialNumber/:sectionCode/Page:page">
+        <ApplicationPageNew />
+      </Route>
+      <Route exact path="/application_new/:serialNumber/summary">
+        <ApplicationSummaryNew />
+      </Route>
+      <Route exact path="/application_new/:serialNumber/submission">
+        <ApplicationSubmissionNew />
+      </Route>
+      <Route>
+        <NoMatch />
+      </Route>
+    </Switch>
+  )
+}
+
+const ApplicationCreateNew: React.FC = () => {
+  return <Header>CREATE PAGE</Header>
+}
+
+const ApplicationStartNew: React.FC = () => {
+  return <Header>START PAGE</Header>
+}
+
+const ApplicationPageNew: React.FC = () => {
+  return <Header>IN PROGRESS PAGE</Header>
+}
+
+const ApplicationSummaryNew: React.FC = () => {
+  return <Header>SUMMARY PAGE</Header>
+}
+
+const ApplicationSubmissionNew: React.FC = () => {
+  return <Header>SUBMISSION PAGE</Header>
+}
+
+export default ApplicationWrapper

--- a/src/containers/Main/SiteLayout.tsx
+++ b/src/containers/Main/SiteLayout.tsx
@@ -19,7 +19,6 @@ import {
   TemplateList,
   TemplateNew,
   Template,
-  ApplicationStart,
 } from '../../components'
 import { ApplicationCreate, ApplicationPageWrapper } from '../Application'
 import { ReviewOverview, ReviewPageWrapper } from '../Review'
@@ -29,6 +28,7 @@ import ApplicationSubmission from '../Application/ApplicationSubmission'
 import UserArea from '../User/UserArea'
 import ListWrapper from '../List/ListWrapper'
 import ReviewSubmission from '../../components/Review/ReviewSubmission'
+import ApplicationWrapper from '../Application/ApplicationWrapper'
 
 const SiteLayout: React.FC = () => {
   return (
@@ -43,6 +43,9 @@ const SiteLayout: React.FC = () => {
         </Route>
         <Route exact path="/applications">
           <ListWrapper />
+        </Route>
+        <Route path="/application-new">
+          <ApplicationWrapper />
         </Route>
         <Route exact path="/application/new">
           <ApplicationProvider>
@@ -65,6 +68,7 @@ const SiteLayout: React.FC = () => {
         <Route exact path="/application/:serialNumber/summary">
           <ApplicationOverview />
         </Route>
+
         <Route exact path="/application/:serialNumber/review">
           <ReviewOverview />
         </Route>

--- a/src/containers/Main/SiteLayout.tsx
+++ b/src/containers/Main/SiteLayout.tsx
@@ -44,7 +44,7 @@ const SiteLayout: React.FC = () => {
         <Route exact path="/applications">
           <ListWrapper />
         </Route>
-        <Route path="/application-new">
+        <Route path="/applicationNEW">
           <ApplicationWrapper />
         </Route>
         <Route exact path="/application/new">


### PR DESCRIPTION
Fix #341

New route `application-new` to point to `ApplicationWrapper` nested route and link to new pages re-structured in [Epic#21](https://github.com/openmsupply/application-manager-web-app/issues/101). 
Added some local components to each page - to be replaced by proper ones (in new files) on next PRs.