### PR TITLE
#211 expand rows on applications list

### DIFF
--- a/src/components/List/ApplicationsList.tsx
+++ b/src/components/List/ApplicationsList.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Table, Message } from 'semantic-ui-react'
+import React, { useEffect, useState } from 'react'
+import { Table, Message, Segment } from 'semantic-ui-react'
 import { ApplicationList } from '../../utils/generated/graphql'
 import messages from '../../utils/messages'
 import { ColumnDetails, SortQuery } from '../../utils/types'
@@ -20,6 +20,16 @@ const ApplicationsList: React.FC<ApplicationsListProps> = ({
   handleSort,
   loading,
 }) => {
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set())
+  const handleClick = (index: number) => {
+    if (expandedRows.has(index)) expandedRows.delete(index)
+    else expandedRows.add(index)
+    setExpandedRows(expandedRows)
+  }
+
+  useEffect(() => {
+    console.log(expandedRows)
+  }, [expandedRows])
   return (
     <>
       <Table sortable stackable selectable>
@@ -45,13 +55,27 @@ const ApplicationsList: React.FC<ApplicationsListProps> = ({
             </Table.Row>
           ) : (
             applications.map((application, index) => (
-              <Table.Row key={`ApplicationList-application-${application.serial}`}>
-                {columns.map(({ headerName, ColumnComponent }) => (
-                  <Table.Cell key={`ApplicationList-row${index}-${headerName}`}>
-                    <ColumnComponent application={application} />
+              <>
+                <Table.Row
+                  key={`ApplicationList-application-${application.serial}`}
+                  onClick={() => handleClick(index)}
+                >
+                  {columns.map(({ headerName, ColumnComponent }) => (
+                    <Table.Cell key={`ApplicationList-row-${index}-${headerName}`}>
+                      <ColumnComponent application={application} />
+                    </Table.Cell>
+                  ))}
+                  <Table.Cell icon="angle down" />
+                </Table.Row>
+                <Table.Row
+                  key={`ApplicationList-application-${application.serial}-sections`}
+                  colSpan={columns.length}
+                >
+                  <Table.Cell colSpan={columns.length}>
+                    <Segment color="grey" />
                   </Table.Cell>
-                ))}
-              </Table.Row>
+                </Table.Row>
+              </>
             ))
           )}
         </Table.Body>

--- a/src/components/List/ApplicationsList.tsx
+++ b/src/components/List/ApplicationsList.tsx
@@ -1,18 +1,16 @@
 import React, { Fragment } from 'react'
 import { Table, Message, Segment } from 'semantic-ui-react'
-import { ApplicationList } from '../../utils/generated/graphql'
 import messages from '../../utils/messages'
-import { Applications, ColumnDetails, SortQuery } from '../../utils/types'
+import { ApplicationListRow, ColumnDetails, SortQuery } from '../../utils/types'
 import Loading from '../Loading'
 
 interface ApplicationsListProps {
   columns: Array<ColumnDetails>
-  applications: Applications
+  applications: ApplicationListRow[]
   sortQuery: SortQuery
   handleSort: Function
-  handleExpansion: (serialNumber: string) => void
+  handleExpansion: (row: ApplicationListRow) => void
   loading: boolean
-  reload: boolean
 }
 
 const ApplicationsList: React.FC<ApplicationsListProps> = ({
@@ -22,7 +20,6 @@ const ApplicationsList: React.FC<ApplicationsListProps> = ({
   handleSort,
   handleExpansion,
   loading,
-  reload,
 }) => {
   return (
     <>
@@ -48,22 +45,23 @@ const ApplicationsList: React.FC<ApplicationsListProps> = ({
               </Table.Cell>
             </Table.Row>
           ) : (
-            (applications || reload) &&
-            applications.map(({ application, expanded }, index) => {
+            applications.map((application, index) => {
+              const { isExpanded } = application
               const rowProps = {
+                index,
                 columns,
                 application,
-                index,
                 handleExpansion,
               }
               const sectionsProps = {
+                index,
                 application,
                 colSpan: columns.length + 1,
               }
               return (
                 <Fragment key={`ApplicationList-application-${index}`}>
                   <ApplicationRow {...rowProps} />
-                  {expanded && <SectionsExpandedRow {...sectionsProps} />}
+                  {isExpanded && <SectionsExpandedRow {...sectionsProps} />}
                 </Fragment>
               )
             })
@@ -79,43 +77,45 @@ const ApplicationsList: React.FC<ApplicationsListProps> = ({
 }
 
 interface ApplicationRowProps {
-  columns: Array<ColumnDetails>
-  application: ApplicationList
   index: number
-  handleExpansion: (serialNumber: string) => void
+  columns: Array<ColumnDetails>
+  application: ApplicationListRow
+  handleExpansion: (row: ApplicationListRow) => void
 }
 
 const ApplicationRow: React.FC<ApplicationRowProps> = ({
+  index,
   columns,
   application,
-  index,
   handleExpansion,
-}) => {
-  const { serial } = application
-  return (
-    <Table.Row
-      key={`ApplicationList-application-${serial}`}
-      onClick={() => handleExpansion(serial as string)}
-    >
-      {columns.map(({ headerName, ColumnComponent }) => (
-        <Table.Cell key={`ApplicationList-row-${index}-${headerName}`}>
-          <ColumnComponent application={application} />
-        </Table.Cell>
-      ))}
-      <Table.Cell icon="angle down" collapsing />
-    </Table.Row>
-  )
-}
+}) => (
+  <Table.Row
+    key={`ApplicationList-application-${index}`}
+    onClick={() => handleExpansion(application)}
+  >
+    {columns.map(({ headerName, ColumnComponent }) => (
+      <Table.Cell key={`ApplicationList-row-${index}-${headerName}`}>
+        <ColumnComponent application={application} />
+      </Table.Cell>
+    ))}
+    <Table.Cell icon="angle down" collapsing />
+  </Table.Row>
+)
 
 interface SectionsExpandedRowProps {
-  application: ApplicationList
+  application: ApplicationListRow
+  index: number
   colSpan: number
 }
 
-const SectionsExpandedRow: React.FC<SectionsExpandedRowProps> = ({ application, colSpan }) => {
+const SectionsExpandedRow: React.FC<SectionsExpandedRowProps> = ({
+  application,
+  index,
+  colSpan,
+}) => {
   const { serial } = application
   return (
-    <Table.Row key={`ApplicationList-application-${serial}-sections`} colSpan={colSpan}>
+    <Table.Row key={`ApplicationList-application-${index}-sections`} colSpan={colSpan}>
       <Table.Cell colSpan={colSpan}>
         <Segment color="grey">TODO: SECTIONS</Segment>
       </Table.Cell>

--- a/src/components/List/ApplicationsList.tsx
+++ b/src/components/List/ApplicationsList.tsx
@@ -1,10 +1,9 @@
 import React, { Fragment } from 'react'
-import { Table, Message } from 'semantic-ui-react'
+import { Table, Message, Segment } from 'semantic-ui-react'
 import { ApplicationList } from '../../utils/generated/graphql'
 import messages from '../../utils/messages'
 import { Applications, ColumnDetails, SortQuery } from '../../utils/types'
 import Loading from '../Loading'
-import Sections from './Sections'
 
 interface ApplicationsListProps {
   columns: Array<ColumnDetails>
@@ -118,7 +117,7 @@ const SectionsExpandedRow: React.FC<SectionsExpandedRowProps> = ({ application, 
   return (
     <Table.Row key={`ApplicationList-application-${serial}-sections`} colSpan={colSpan}>
       <Table.Cell colSpan={colSpan}>
-        <Sections />
+        <Segment color="grey">TODO: SECTIONS</Segment>
       </Table.Cell>
     </Table.Row>
   )

--- a/src/components/List/ApplicationsList.tsx
+++ b/src/components/List/ApplicationsList.tsx
@@ -26,11 +26,12 @@ const ApplicationsList: React.FC<ApplicationsListProps> = ({
       <Table sortable stackable selectable>
         <Table.Header>
           <Table.Row>
-            {columns.map(({ headerName, sortName }) => (
+            {columns.map(({ headerName, sortName }, index) => (
               <Table.HeaderCell
                 key={`ApplicationList-header-${headerName}`}
                 sorted={sortName && sortColumn === sortName ? sortDirection : undefined}
                 onClick={() => handleSort(sortName)}
+                colSpan={index === columns.length - 1 ? 2 : 1} // Set last column to fill last column (expansion)
               >
                 {headerName}
               </Table.HeaderCell>

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -1618,7 +1618,6 @@ export enum Trigger {
   OnReviewSubmit = 'ON_REVIEW_SUBMIT',
   OnReviewStart = 'ON_REVIEW_START',
   OnReviewAssign = 'ON_REVIEW_ASSIGN',
-  OnReviewSelfAssign = 'ON_REVIEW_SELF_ASSIGN',
   OnApprovalSubmit = 'ON_APPROVAL_SUBMIT',
   OnScheduleTime = 'ON_SCHEDULE_TIME',
   Processing = 'PROCESSING',
@@ -2500,7 +2499,7 @@ export type ReviewAssignmentStatusFilter = {
 
 export enum ReviewAssignmentStatus {
   Available = 'AVAILABLE',
-  SelfAssignedByAnother = 'SELF_ASSIGNED_BY_ANOTHER',
+  NotAvailable = 'NOT_AVAILABLE',
   Assigned = 'ASSIGNED',
   AvailableForSelfAssignment = 'AVAILABLE_FOR_SELF_ASSIGNMENT'
 }
@@ -4523,7 +4522,7 @@ export type ReviewAssignment = Node & {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -13463,7 +13462,7 @@ export type ReviewQuestionAssignmentReviewAssignmentIdFkeyReviewAssignmentCreate
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -13965,7 +13964,7 @@ export type ReviewReviewAssignmentIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14059,7 +14058,7 @@ export type ReviewAssignmentStageIdFkeyReviewAssignmentCreateInput = {
   reviewerId?: Maybe<Scalars['Int']>;
   organisationId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14318,7 +14317,7 @@ export type ReviewAssignmentOrganisationIdFkeyReviewAssignmentCreateInput = {
   reviewerId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14388,7 +14387,7 @@ export type ReviewAssignmentReviewerIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14453,7 +14452,7 @@ export type ReviewAssignmentAssignerIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14519,7 +14518,7 @@ export type ReviewAssignmentApplicationIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
   timeCreated?: Maybe<Scalars['Datetime']>;
@@ -16309,7 +16308,7 @@ export type ReviewAssignmentInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -20,6 +20,7 @@ export {
   ApplicationStageMap,
   ApplicationStages,
   AssignmentDetails,
+  Applications,
   CellProps,
   ColumnDetails,
   ColumnsPerRole,
@@ -111,6 +112,11 @@ interface AssignmentDetails {
   review?: ReviewDetails
   questions: ReviewQuestion[]
 }
+
+type Applications = {
+  application: ApplicationList
+  expanded: boolean
+}[]
 
 interface BasicStringObject {
   [key: string]: string

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -16,11 +16,11 @@ import { APPLICATION_COLUMNS, USER_ROLES } from './data'
 export {
   ApplicationDetails,
   ApplicationElementStates,
+  ApplicationListRow,
   ApplicationStage,
   ApplicationStageMap,
   ApplicationStages,
   AssignmentDetails,
-  Applications,
   CellProps,
   ColumnDetails,
   ColumnsPerRole,
@@ -92,6 +92,10 @@ interface ApplicationElementStates {
   [key: string]: ElementState
 }
 
+interface ApplicationListRow extends ApplicationList {
+  isExpanded: boolean
+}
+
 interface ApplicationStage {
   id: number
   name: string
@@ -112,11 +116,6 @@ interface AssignmentDetails {
   review?: ReviewDetails
   questions: ReviewQuestion[]
 }
-
-type Applications = {
-  application: ApplicationList
-  expanded: boolean
-}[]
 
 interface BasicStringObject {
   [key: string]: string


### PR DESCRIPTION
Fixes #211 

Create expanded row on the list of Applications to be showing sections of application with Progress (To be done in #363).

### Changes
- Each `ApplicationList` that represents one application on the list has also a flag `expanded` to determine if it is expanded on the list
- On the `ApplicationsList` component there is a icon on each application row to allow expansion of display the sections area.
- When expanding/collapsing the sections the table needs to get reloaded - needed to pass a new props to `ApplicationsList` to reload the table, otherwise it was not re-rendering after clicking on the expansion icon.