### PR TITLE
#348 PageElements component

### DIFF
--- a/src/components/Application/PageElements.tsx
+++ b/src/components/Application/PageElements.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { ElementStateNEW, ResponsesByCode } from '../../utils/types'
 import ApplicationViewWrapper from '../../formElementPlugins/ApplicationViewWrapperNEW'
 import SummaryViewWrapper from '../../formElementPlugins/SummaryViewWrapper'
-import { Button, Grid, Header, Message, Segment, Sticky, Form } from 'semantic-ui-react'
+import { Form } from 'semantic-ui-react'
 
 interface PageElementProps {
   elements: ElementStateNEW[]
@@ -56,9 +56,9 @@ const PageElements: React.FC<PageElementProps> = ({
               currentResponse={response}
             />
           )
-        // Summary Page
+        // Summary Page -- TO-DO
         if (!isEditable && !isReview) return <p>Summary View</p>
-        // Review Page
+        // Review Page -- TO-DO
         if (isReview) return <p>Review Elements</p>
       })}
     </Form>

--- a/src/components/Application/PageElements.tsx
+++ b/src/components/Application/PageElements.tsx
@@ -1,14 +1,7 @@
-import React, { useEffect, useState } from 'react'
-import { ElementBaseNEW, ElementStateNEW, FullStructure, ResponsesByCode } from '../../utils/types'
-import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
-import { ApplicationStatus } from '../../utils/generated/graphql'
-import { useApplicationState } from '../../contexts/ApplicationState'
+import React from 'react'
+import { ElementStateNEW, ResponsesByCode } from '../../utils/types'
 import ApplicationViewWrapper from '../../formElementPlugins/ApplicationViewWrapperNEW'
-import { useUserState } from '../../contexts/UserState'
-import { useRouter } from '../../utils/hooks/useRouter'
-import { Loading, NoMatch } from '../../components'
-import strings from '../../utils/constants'
-import messages from '../../utils/messages'
+import SummaryViewWrapper from '../../formElementPlugins/SummaryViewWrapper'
 import { Button, Grid, Header, Message, Segment, Sticky, Form } from 'semantic-ui-react'
 
 interface PageElementProps {
@@ -54,7 +47,7 @@ const PageElements: React.FC<PageElementProps> = ({
               isEditable={isEditable}
               isRequired={isRequired}
               isValid={isValid || true}
-              isStrictPage={true}
+              isStrictPage={isStrictPage}
               validationExpression={validationExpression}
               validationMessage={validationMessage}
               allResponses={responsesByCode}
@@ -64,7 +57,44 @@ const PageElements: React.FC<PageElementProps> = ({
         })}
       </Form>
     )
-  // Summary Page
+  //   if (!isEditable && !isReview)
+  //     // Summary View
+  //     return (
+  //       <Form>
+  //         {elements.map((element) => {
+  //           const {
+  //             code,
+  //             pluginCode,
+  //             parameters,
+  //             isVisible,
+  //             isRequired,
+  //             isEditable,
+  //             validationExpression,
+  //             validationMessage,
+  //           } = element
+  //           const response = responsesByCode?.[code]
+  //           const isValid = response?.isValid
+  //           return (
+  //             <SummaryViewWrapper
+  //               key={`question_${code}`}
+  //               code={code}
+  //               initialValue={response}
+  //               pluginCode={pluginCode}
+  //               parameters={parameters}
+  //               isVisible={isVisible}
+  //               isEditable={isEditable}
+  //               isRequired={isRequired}
+  //               isValid={isValid || true}
+  //               isStrictPage={true}
+  //               validationExpression={validationExpression}
+  //               validationMessage={validationMessage}
+  //               allResponses={responsesByCode}
+  //               currentResponse={response}
+  //             />
+  //           )
+  //         })}
+  //       </Form>
+  //     )
   // Review Page
   else return <p> Nothing to see here</p>
 }

--- a/src/components/Application/PageElements.tsx
+++ b/src/components/Application/PageElements.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react'
+import { ElementBaseNEW, ElementStateNEW, FullStructure, ResponsesByCode } from '../../utils/types'
+import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
+import { ApplicationStatus } from '../../utils/generated/graphql'
+import { useApplicationState } from '../../contexts/ApplicationState'
+import ApplicationViewWrapper from '../../formElementPlugins/ApplicationViewWrapperNEW'
+import { useUserState } from '../../contexts/UserState'
+import { useRouter } from '../../utils/hooks/useRouter'
+import { Loading, NoMatch } from '../../components'
+import strings from '../../utils/constants'
+import messages from '../../utils/messages'
+import { Button, Grid, Header, Message, Segment, Sticky, Form } from 'semantic-ui-react'
+
+interface PageElementProps {
+  elements: ElementStateNEW[]
+  responsesByCode: ResponsesByCode
+  isStrictPage?: boolean
+  isEditable?: boolean
+  isReview?: boolean
+}
+
+const PageElements: React.FC<PageElementProps> = ({
+  elements,
+  responsesByCode,
+  isStrictPage,
+  isEditable,
+  isReview,
+}) => {
+  if (isEditable && !isReview)
+    // Applicant Editable application
+    return (
+      <Form>
+        {elements.map((element) => {
+          const {
+            code,
+            pluginCode,
+            parameters,
+            isVisible,
+            isRequired,
+            isEditable,
+            validationExpression,
+            validationMessage,
+          } = element
+          const response = responsesByCode?.[code]
+          //   const isValid = response.isValid
+          return (
+            <ApplicationViewWrapper
+              key={`question_${code}`}
+              code={code}
+              initialValue={response}
+              pluginCode={pluginCode}
+              parameters={parameters}
+              isVisible={isVisible}
+              isEditable={isEditable}
+              isRequired={isRequired}
+              validationExpression={validationExpression}
+              validationMessage={validationMessage}
+              allResponses={responsesByCode}
+              currentResponse={response}
+              forceValidation={false} // Remove this
+            />
+          )
+        })}
+      </Form>
+    )
+  // Summary Page
+  // Review Page
+  else return <p> Nothing to see here</p>
+}
+
+export default PageElements

--- a/src/components/Application/PageElements.tsx
+++ b/src/components/Application/PageElements.tsx
@@ -42,7 +42,7 @@ const PageElements: React.FC<PageElementProps> = ({
             validationMessage,
           } = element
           const response = responsesByCode?.[code]
-          //   const isValid = response.isValid
+          const isValid = response?.isValid
           return (
             <ApplicationViewWrapper
               key={`question_${code}`}
@@ -53,11 +53,12 @@ const PageElements: React.FC<PageElementProps> = ({
               isVisible={isVisible}
               isEditable={isEditable}
               isRequired={isRequired}
+              isValid={isValid || true}
+              isStrictPage={true}
               validationExpression={validationExpression}
               validationMessage={validationMessage}
               allResponses={responsesByCode}
               currentResponse={response}
-              forceValidation={false} // Remove this
             />
           )
         })}

--- a/src/components/Application/PageElements.tsx
+++ b/src/components/Application/PageElements.tsx
@@ -19,23 +19,25 @@ const PageElements: React.FC<PageElementProps> = ({
   isEditable,
   isReview,
 }) => {
-  if (isEditable && !isReview)
-    // Applicant Editable application
-    return (
-      <Form>
-        {elements.map((element) => {
-          const {
-            code,
-            pluginCode,
-            parameters,
-            isVisible,
-            isRequired,
-            isEditable,
-            validationExpression,
-            validationMessage,
-          } = element
-          const response = responsesByCode?.[code]
-          const isValid = response?.isValid
+  // Applicant Editable application
+  return (
+    <Form>
+      {elements.map((element) => {
+        const {
+          code,
+          pluginCode,
+          parameters,
+          isVisible,
+          isRequired,
+          isEditable,
+          validationExpression,
+          validationMessage,
+        } = element
+        const response = responsesByCode?.[code]
+        const isValid = response?.isValid
+
+        // Regular application view
+        if (isEditable && !isReview)
           return (
             <ApplicationViewWrapper
               key={`question_${code}`}
@@ -54,49 +56,13 @@ const PageElements: React.FC<PageElementProps> = ({
               currentResponse={response}
             />
           )
-        })}
-      </Form>
-    )
-  //   if (!isEditable && !isReview)
-  //     // Summary View
-  //     return (
-  //       <Form>
-  //         {elements.map((element) => {
-  //           const {
-  //             code,
-  //             pluginCode,
-  //             parameters,
-  //             isVisible,
-  //             isRequired,
-  //             isEditable,
-  //             validationExpression,
-  //             validationMessage,
-  //           } = element
-  //           const response = responsesByCode?.[code]
-  //           const isValid = response?.isValid
-  //           return (
-  //             <SummaryViewWrapper
-  //               key={`question_${code}`}
-  //               code={code}
-  //               initialValue={response}
-  //               pluginCode={pluginCode}
-  //               parameters={parameters}
-  //               isVisible={isVisible}
-  //               isEditable={isEditable}
-  //               isRequired={isRequired}
-  //               isValid={isValid || true}
-  //               isStrictPage={true}
-  //               validationExpression={validationExpression}
-  //               validationMessage={validationMessage}
-  //               allResponses={responsesByCode}
-  //               currentResponse={response}
-  //             />
-  //           )
-  //         })}
-  //       </Form>
-  //     )
-  // Review Page
-  else return <p> Nothing to see here</p>
+        // Summary Page
+        if (!isEditable && !isReview) return <p>Summary View</p>
+        // Review Page
+        if (isReview) return <p>Review Elements</p>
+      })}
+    </Form>
+  )
 }
 
 export default PageElements

--- a/src/components/Application/index.ts
+++ b/src/components/Application/index.ts
@@ -4,6 +4,7 @@ import ApplicationSelectType from './ApplicationSelectType'
 import ApplicationStart from './ApplicationStart'
 import SectionSummary from './SectionSummary'
 import ProgressBar from './ProgressBar'
+import PageElements from './PageElements'
 
 export {
   ApplicationEdit,
@@ -11,5 +12,6 @@ export {
   ApplicationSelectType,
   ApplicationStart,
   SectionSummary,
+  PageElements,
   ProgressBar,
 }

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -44,7 +44,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
   }, [structure])
 
   if (error) return <Message error header={strings.ERROR_APPLICATION_PAGE} list={[error]} />
-  if (!fullStructure) return <Loading />
+  if (!fullStructure || !responsesByCode) return <Loading />
 
   return (
     <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { FullStructure, ResponsesByCode } from '../../utils/types'
+import { FullStructure, ResponsesByCode, ElementStateNEW } from '../../utils/types'
 import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
 import { ApplicationStatus } from '../../utils/generated/graphql'
 import { useApplicationState } from '../../contexts/ApplicationState'
@@ -9,6 +9,7 @@ import { Loading, NoMatch } from '../../components'
 import strings from '../../utils/constants'
 import messages from '../../utils/messages'
 import { Button, Grid, Header, Message, Segment, Sticky } from 'semantic-ui-react'
+import { PageElements } from '../../components/Application'
 
 interface ApplicationProps {
   structure: FullStructure
@@ -16,14 +17,17 @@ interface ApplicationProps {
 }
 
 const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
-  const [isStrictPage, setIsStrictPage] = useState(null)
+  const [strictSectionPage, setStrictSectionPage] = useState({ section: null, page: null })
   const { error, isLoading, fullStructure, responsesByCode } = useGetFullApplicationStructure({
     structure,
   })
   const {
     userState: { currentUser },
   } = useUserState()
-  const { push } = useRouter()
+  const { push, query } = useRouter()
+
+  const currentSection = query.sectionCode
+  const currentPage = `Page ${query.page}`
 
   console.log('Structure', fullStructure)
 
@@ -63,7 +67,18 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
         </Grid.Column>
         <Grid.Column width={10} stretched>
           <Segment basic>
-            <PageElements structure={fullStructure as FullStructure} responses={responsesByCode} />
+            <Segment vertical style={{ marginBottom: 20 }}>
+              <Header content={fullStructure.sections[currentSection].details.title} />
+              <PageElements
+                elements={getCurrentPageElements(fullStructure, currentSection, currentPage)}
+                responsesByCode={responsesByCode}
+                isStrictPage={
+                  currentSection === strictSectionPage?.section &&
+                  currentPage === strictSectionPage?.page
+                }
+                isEditable
+              />
+            </Segment>
             <NavigationBox />
           </Segment>
         </Grid.Column>
@@ -89,14 +104,15 @@ const ProgressBar: React.FC<ApplicationProps> = ({ structure }) => {
   return <p>Progress Bar here</p>
 }
 
-const PageElements: React.FC<ApplicationProps> = ({ structure, responses }) => {
-  // Placeholder -- to be replaced with new component
-  return <p>Page Elements go here</p>
-}
-
 const NavigationBox: React.FC = () => {
   // Placeholder -- to be replaced with new component
   return <p>Navigation Buttons</p>
 }
 
 export default ApplicationPage
+
+const getCurrentPageElements = (structure: FullStructure, section: string, page: string) => {
+  return structure.sections[section].pages[page].state.map(
+    (item) => item.element
+  ) as ElementStateNEW[]
+}

--- a/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
@@ -1,0 +1,206 @@
+import React, { useEffect, useState } from 'react'
+import { ErrorBoundary, pluginProvider } from '.'
+import { ApplicationViewWrapperProps, PluginComponents, ValidationState } from './types'
+import { useApplicationState } from '../contexts/ApplicationState'
+import { useUpdateResponseMutation } from '../utils/generated/graphql'
+import {
+  EvaluatorParameters,
+  LooseString,
+  ResponseFull,
+  ElementPluginParameters,
+  ElementPluginParameterValue,
+} from '../utils/types'
+import { useUserState } from '../contexts/UserState'
+import validate from './defaultValidate'
+import evaluateExpression from '@openmsupply/expression-evaluator'
+import { Form } from 'semantic-ui-react'
+import Markdown from '../utils/helpers/semanticReactMarkdown'
+
+const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) => {
+  const {
+    code,
+    pluginCode,
+    parameters,
+    initialValue,
+    isVisible,
+    isEditable,
+    isRequired,
+    validationExpression,
+    validationMessage,
+    currentResponse,
+    allResponses,
+    forceValidation,
+  } = props
+
+  const [responseMutation] = useUpdateResponseMutation()
+  const { setApplicationState } = useApplicationState()
+
+  const {
+    userState: { currentUser },
+  } = useUserState()
+  const [validationState, setValidationState] = useState<ValidationState>({
+    isValid: null,
+  })
+  const [evaluatedParameters, setEvaluatedParameters] = useState({})
+
+  // This value prevents the plugin component from rendering until parameters have been evaluated, otherwise React throws an error when trying to pass an Object in as a prop value
+  const [parametersReady, setParametersReady] = useState(false)
+
+  const { ApplicationView, config }: PluginComponents = pluginProvider.getPluginElement(pluginCode)
+
+  const dynamicParameters = config?.dynamicParameters
+  const dynamicExpressions =
+    dynamicParameters && extractDynamicExpressions(dynamicParameters, parameters)
+  const [value, setValue] = useState<any>(initialValue?.text)
+
+  // Update dynamic parameters when responses change
+  useEffect(() => {
+    evaluateDynamicParameters(dynamicExpressions as ElementPluginParameters, {
+      objects: { responses: allResponses, currentUser },
+      APIfetch: fetch,
+    }).then((result: ElementPluginParameters) => {
+      setEvaluatedParameters(result)
+      setParametersReady(true)
+    })
+  }, [allResponses])
+
+  useEffect(() => {
+    if (forceValidation) onUpdate(currentResponse?.text)
+  }, [currentResponse, forceValidation])
+
+  const onUpdate = async (value: LooseString) => {
+    const responses = { thisResponse: value, ...allResponses }
+
+    if (!validationExpression || value === undefined) {
+      setValidationState({ isValid: true } as ValidationState)
+      return { isValid: true }
+    }
+
+    const validationResult: ValidationState = await validate(
+      validationExpression,
+      validationMessage as string,
+      { objects: { responses, currentUser }, APIfetch: fetch }
+    )
+    setValidationState(validationResult)
+
+    return validationResult
+  }
+
+  const onSave = async (jsonValue: ResponseFull) => {
+    setApplicationState({
+      type: 'setElementTimestamp',
+      timestampType: 'elementLostFocusTimestamp',
+    })
+
+    if (!jsonValue.customValidation) {
+      // Validate and Save response -- generic
+      const validationResult: ValidationState = await onUpdate(jsonValue.text)
+      if (jsonValue.text !== undefined)
+        await responseMutation({
+          variables: {
+            id: currentResponse?.id as number,
+            value: jsonValue,
+            isValid: validationResult.isValid,
+          },
+        })
+      if (jsonValue.text === allResponses[code]?.text) {
+        setApplicationState({
+          type: 'setElementTimestamp',
+          timestampType: 'elementsStateUpdatedTimestamp',
+        })
+      }
+    } else {
+      // Save response for plugins with internal validation
+      const { isValid, validationMessage } = jsonValue.customValidation
+      setValidationState({ isValid, validationMessage })
+      delete jsonValue.customValidation // Don't want to save this field
+      await responseMutation({
+        variables: {
+          id: currentResponse?.id as number,
+          value: jsonValue,
+          isValid,
+        },
+      })
+      setApplicationState({
+        type: 'setElementTimestamp',
+        timestampType: 'elementsStateUpdatedTimestamp',
+      })
+    }
+  }
+
+  const setIsActive = () => {
+    // Tells application state that a plugin field is in focus
+    setApplicationState({
+      type: 'setElementTimestamp',
+      timestampType: 'elementEnteredTimestamp',
+    })
+  }
+
+  if (!pluginCode || !isVisible) return null
+
+  const PluginComponent = (
+    <ApplicationView
+      onUpdate={onUpdate}
+      onSave={onSave}
+      {...props}
+      parameters={{ ...parameters, ...evaluatedParameters }}
+      value={value}
+      setValue={setValue}
+      setIsActive={setIsActive}
+      Markdown={Markdown}
+      validationState={validationState || { isValid: true }}
+      validate={validate}
+      // TO-DO: ensure validationState gets calculated BEFORE rendering this child, so we don't need this fallback.
+      getDefaultIndex={getDefaultIndex}
+    />
+  )
+
+  return (
+    <ErrorBoundary pluginCode={pluginCode}>
+      <React.Suspense fallback="Loading Plugin">
+        {parametersReady && <Form.Field required={isRequired}>{PluginComponent}</Form.Field>}
+      </React.Suspense>
+    </ErrorBoundary>
+  )
+}
+
+export default ApplicationViewWrapper
+
+/* 
+Allows the default value in template to be either an index or string
+value. Number is assumed to be index, else it returns the index of the 
+specified value in the options array. Functions is passed as prop to
+element plug-ins so can be used by any plugin.
+*/
+const getDefaultIndex = (defaultOption: string | number, options: string[]) => {
+  if (typeof defaultOption === 'number') {
+    return defaultOption
+  } else return options.indexOf(defaultOption)
+}
+
+export function extractDynamicExpressions(fields: string[], parameters: ElementPluginParameters) {
+  const expressionObject: ElementPluginParameters = {}
+  fields.forEach((field) => {
+    expressionObject[field] = parameters[field]
+  })
+  return expressionObject
+}
+
+export async function evaluateDynamicParameters(
+  dynamicExpressions: ElementPluginParameters,
+  evaluatorParameters: EvaluatorParameters
+) {
+  if (!dynamicExpressions) return {}
+  const fields = Object.keys(dynamicExpressions)
+  const expressions = Object.values(
+    dynamicExpressions
+  ).map((expression: ElementPluginParameterValue) =>
+    evaluateExpression(expression, evaluatorParameters)
+  )
+  const evaluatedExpressions: any = await Promise.all(expressions)
+  const evaluatedParameters: ElementPluginParameters = {}
+  for (let i = 0; i < fields.length; i++) {
+    evaluatedParameters[fields[i]] = evaluatedExpressions[i]
+  }
+  return evaluatedParameters
+}

--- a/src/formElementPlugins/defaultValidate.tsx
+++ b/src/formElementPlugins/defaultValidate.tsx
@@ -8,7 +8,8 @@ const defaultValidate = async (
   validationMessage: string,
   evaluatorParameters: EvaluatorParameters
 ): Promise<ValidationState> => {
-  if (!validationExpress) return { isValid: true }
+  if (!validationExpress || evaluatorParameters?.objects?.responses.thisResponse === undefined)
+    return { isValid: true }
   const isValid = (await evaluateExpression(validationExpress, evaluatorParameters)) as boolean
   if (isValid) return { isValid }
   return { isValid, validationMessage }

--- a/src/formElementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/shortText/src/ApplicationView.tsx
@@ -45,7 +45,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         disabled={!isEditable}
         type={maskedInput ? 'password' : undefined}
         error={
-          !validationState.isValid && currentResponse?.text !== undefined
+          !validationState.isValid
             ? {
                 content: validationState?.validationMessage,
                 pointing: 'above',

--- a/src/formElementPlugins/types.ts
+++ b/src/formElementPlugins/types.ts
@@ -24,7 +24,25 @@ interface ApplicationViewWrapperProps {
   // applicationState,
   // graphQLclient
   initialValue: any // Could be a primative or an object with any shape
-  forceValidation: boolean // Run validation on formElement on load - usualy would run only onChange events
+  forceValidation?: boolean // Run validation on formElement on load - usualy would run only onChange events
+}
+
+interface ApplicationViewWrapperPropsNEW {
+  code: string
+  pluginCode: string // TODO: Create type OR use existing from graphql
+  isVisible: boolean
+  isEditable: boolean
+  isRequired: boolean
+  isValid: boolean
+  isStrictPage: boolean | undefined
+  parameters: any // TODO: Create type for existing pre-defined types for parameters (TemplateElement)
+  validationExpression: IQueryNode
+  validationMessage: string | null
+  allResponses: ResponsesByCode
+  currentResponse: ResponseFull | null
+  // applicationState,
+  // graphQLclient
+  initialValue: any // Could be a primative or an object with any shape
 }
 
 type ValidationState = {
@@ -105,6 +123,7 @@ export {
   TemplateViewProps,
   OnUpdateTemplateView,
   ApplicationViewWrapperProps,
+  ApplicationViewWrapperPropsNEW,
   ApplicationViewProps,
   ValidationState,
   TemplateViewWrapperProps,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -63,4 +63,5 @@ export default {
   SUBTITLE_REVIEW: 'Please complete the sections that have been assigned to you',
   SUBTITLE_SUBMISSION_STEPS: 'It will be going through the following stages before approval',
   USER_NONREGISTERED: 'nonRegistered',
+  VALIDATION_REQUIRED_ERROR: 'Field is required',
 }

--- a/src/utils/hooks/useGetFullApplicationStructure.tsx
+++ b/src/utils/hooks/useGetFullApplicationStructure.tsx
@@ -174,7 +174,7 @@ const useGetFullApplicationStructure = ({
             currentEvaluationParameters,
             false
           )
-        : new Promise(() => responseObject[element.code]?.isValid)
+        : async () => responseObject[element.code]?.isValid
     const results = await Promise.all([isEditable, isRequired, isVisible, isValid])
 
     const evaluatedElement = {

--- a/src/utils/hooks/useGetFullApplicationStructure.tsx
+++ b/src/utils/hooks/useGetFullApplicationStructure.tsx
@@ -30,7 +30,7 @@ const useGetFullApplicationStructure = ({
     userState: { currentUser },
   } = useUserState()
   const [fullStructure, setFullStructure] = useState<FullStructure>()
-  const [responsesByCode, setResponsesByCode] = useState<ResponsesByCode>({})
+  const [responsesByCode, setResponsesByCode] = useState<ResponsesByCode>()
   const [isLoading, setIsLoading] = useState(true)
   const [isError, setIsError] = useState(false)
   const [firstRunProcessValidation, setFirstRunProcessValidation] = useState(

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -273,7 +273,6 @@ interface ResponsePayload {
   applicationId: number
   templateQuestions: TemplateElement[]
 }
-
 interface ResponsesByCode {
   [key: string]: ResponseFull
 }


### PR DESCRIPTION
Implements #348.

A PageElements component for rendering a passed-in array of elements.

I've only implemented it to work with ApplicationPage for now, as it'll be easier to add the Summary and Review displays once we have their parent pages.

But it's working nicely with Application now, and I've implemented the plug-in Wrapper level validation state checks as per @andreievg 's latest diagram. If you want to see what a page looks like with "Strict" validation, just set `isStrictPage` to `true` temporarily

The ApplicationViewWrapperNEW file is not that different from the original ApplicationViewWrapper -- just updated validation functionality. You can compare the diffs between those two files to see changes if you want.

Note: for Summary and Review, there will need to be another "Sections" component inside their "Page" components to iterate over the Sections, as there needs to be a separate PageElements child per Section.