### PR TITLE
#351 new progress bar component

### DIFF
--- a/src/components/Application/ProgressBarNEW.tsx
+++ b/src/components/Application/ProgressBarNEW.tsx
@@ -50,8 +50,13 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, current }) => {
       ) : (
         <Icon name="circle outline" />
       )
-    if (completed && valid) return <Icon name="check circle" color="green" size="large" />
-    if (completed && !valid) return <Icon name="exclamation circle" color="red" size="large" />
+    return (
+      <Icon
+        name={valid ? 'check circle' : 'exclamation circle'}
+        color={valid ? 'green' : 'red'}
+        size={step ? 'large' : 'small'}
+      />
+    )
   }
 
   const isSectionDisabled = (index: number) => {

--- a/src/components/Application/ProgressBarNEW.tsx
+++ b/src/components/Application/ProgressBarNEW.tsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { Accordion, Container, Grid, Header, Icon, Label, List, Sticky } from 'semantic-ui-react'
+import strings from '../../utils/constants'
+import { FullStructure, PageNEW, Progress } from '../../utils/types'
+
+interface ProgressBarProps {
+  structure: FullStructure
+  current: {
+    sectionCode: string
+    page: number
+  }
+}
+
+const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, current }) => {
+  const {
+    info: { isLinear },
+    sections,
+  } = structure
+
+  const activeIndex =
+    Object.values(sections).findIndex(({ details }) => details.code === current.sectionCode) || 0
+
+  const getPageList = (sectionCode: string, pages: { [pageName: string]: PageNEW }) => {
+    const isActivePage = (sectionCode: string, pageNumber: number) =>
+      current.sectionCode === sectionCode && current.page === pageNumber
+
+    return (
+      <List
+        link
+        style={{ paddingLeft: '50px' }}
+        items={Object.entries(pages).map(([pageName, { number, progress }]) => ({
+          key: `ProgressSection_${sectionCode}_${number}`,
+          active: isActivePage(sectionCode, number),
+          as: 'a',
+          icon: progress ? getIndicator(progress) : null,
+          content: pageName,
+          onClick: () => console.log('Click on Page', number, 'Section', sectionCode),
+        }))}
+      />
+    )
+  }
+
+  const getIndicator = (progress: Progress, step?: number) => {
+    const { completed, valid } = progress
+    if (!completed)
+      return step ? (
+        <Label circular as="a" basic color="blue" key={`progress_${step}`}>
+          {step}
+        </Label>
+      ) : (
+        <Icon name="circle outline" />
+      )
+    if (completed && valid) return <Icon name="check circle" color="green" size="large" />
+    if (completed && !valid) return <Icon name="exclamation circle" color="red" size="large" />
+  }
+
+  const isSectionDisabled = (index: number) => {
+    const currentSection = Object.values(sections).findIndex(
+      ({ details }) => details.code === current.sectionCode
+    )
+    return isLinear && currentSection < index
+  }
+
+  const sectionsList = Object.values(sections).map(({ details, progress, pages }, index) => {
+    const stepNumber = index + 1
+    const { code, title } = details
+    return {
+      key: `progress_${stepNumber}`,
+      title: {
+        children: (
+          <Grid>
+            <Grid.Column width={4} textAlign="right" verticalAlign="middle">
+              {progress && getIndicator(progress, stepNumber)}
+            </Grid.Column>
+            <Grid.Column width={12} textAlign="left" verticalAlign="middle">
+              <Header as="h4" disabled={isSectionDisabled(index)}>
+                {title}
+              </Header>
+            </Grid.Column>
+          </Grid>
+
+          // OR:
+          // <div>
+          //   {progress && getIndicator(progress, stepNumber)}
+          //   <Label basic disabled={isSectionDisabled(index)} content={title} />
+          // </div>
+        ),
+      },
+      onTitleClick: () => console.log('Click on Section', index),
+      content: {
+        content: getPageList(code, pages),
+      },
+    }
+  })
+
+  return (
+    <Sticky as={Container}>
+      <Header as="h5" style={{ paddingLeft: 30 }}>
+        {strings.TITLE_INTRODUCTION}
+      </Header>
+      <Accordion activeIndex={activeIndex} panels={sectionsList} />
+    </Sticky>
+  )
+}
+
+export default ProgressBarNEW

--- a/src/components/Application/ProgressBarNEW.tsx
+++ b/src/components/Application/ProgressBarNEW.tsx
@@ -5,13 +5,14 @@ import { FullStructure, PageNEW, Progress } from '../../utils/types'
 
 interface ProgressBarProps {
   structure: FullStructure
+  changePage: (sectionCode: string, pageNumber: number) => void
   current: {
     sectionCode: string
     page: number
   }
 }
 
-const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, current }) => {
+const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, changePage, current }) => {
   const {
     info: { isLinear },
     sections,
@@ -34,7 +35,7 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, current }) => {
           as: 'a',
           icon: progress ? getIndicator(progress) : null,
           content: pageName,
-          onClick: () => console.log('Click on Page', number, 'Section', sectionCode),
+          onClick: () => changePage(sectionCode, number),
         }))}
       />
     )
@@ -91,7 +92,7 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, current }) => {
           // </div>
         ),
       },
-      onTitleClick: () => console.log('Click on Section', index),
+      onTitleClick: () => changePage(code, 1),
       content: {
         content: getPageList(code, pages),
       },

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -43,6 +43,11 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
     // TO-DO: Redirect based on Progress (wait till Progress calculation is done)
   }, [structure])
 
+  const handleChangeToPage = (sectionCode: string, pageNumber: number) => {
+    if (!structure.info.isLinear)
+      push(`/applicationNEW/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
+  }
+
   if (error) return <Message error header={strings.ERROR_APPLICATION_PAGE} list={[error]} />
   if (!fullStructure) return <Loading />
 
@@ -63,7 +68,11 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
         }}
       >
         <Grid.Column width={4}>
-          <ProgressBarNEW structure={fullStructure} current={{ sectionCode, page: Number(page) }} />
+          <ProgressBarNEW
+            structure={fullStructure}
+            current={{ sectionCode, page: Number(page) }}
+            changePage={handleChangeToPage}
+          />
         </Grid.Column>
         <Grid.Column width={10} stretched>
           <Segment basic>

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -46,6 +46,9 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
   const handleChangeToPage = (sectionCode: string, pageNumber: number) => {
     if (!structure.info.isLinear)
       push(`/applicationNEW/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
+
+    // TODO: Use validationMethod to check if can change to page OR
+    // Would display modal (?) and current page with strict validation
   }
 
   if (error) return <Message error header={strings.ERROR_APPLICATION_PAGE} list={[error]} />

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -40,7 +40,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
   }, [structure])
 
   if (error) return <NoMatch />
-  if (isLoading) return <Loading />
+  if (!fullStructure) return <Loading />
 
   return (
     <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -9,6 +9,7 @@ import { Loading, NoMatch } from '../../components'
 import strings from '../../utils/constants'
 import messages from '../../utils/messages'
 import { Button, Grid, Header, Message, Segment, Sticky } from 'semantic-ui-react'
+import ProgressBarNEW from '../../components/Application/ProgressBarNEW'
 
 interface ApplicationProps {
   structure: FullStructure
@@ -23,7 +24,10 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
   const {
     userState: { currentUser },
   } = useUserState()
-  const { push } = useRouter()
+  const {
+    query: { sectionCode, page },
+    push,
+  } = useRouter()
 
   console.log('Structure', fullStructure)
 
@@ -59,7 +63,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
         }}
       >
         <Grid.Column width={4}>
-          <ProgressBar structure={fullStructure as FullStructure} />
+          <ProgressBarNEW structure={fullStructure} current={{ sectionCode, page: Number(page) }} />
         </Grid.Column>
         <Grid.Column width={10} stretched>
           <Segment basic>
@@ -82,11 +86,6 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
       </Sticky>
     </Segment.Group>
   )
-}
-
-const ProgressBar: React.FC<ApplicationProps> = ({ structure }) => {
-  // Placeholder -- to be replaced with new component
-  return <p>Progress Bar here</p>
 }
 
 const PageElements: React.FC<ApplicationProps> = ({ structure, responses }) => {

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -1618,7 +1618,6 @@ export enum Trigger {
   OnReviewSubmit = 'ON_REVIEW_SUBMIT',
   OnReviewStart = 'ON_REVIEW_START',
   OnReviewAssign = 'ON_REVIEW_ASSIGN',
-  OnReviewSelfAssign = 'ON_REVIEW_SELF_ASSIGN',
   OnApprovalSubmit = 'ON_APPROVAL_SUBMIT',
   OnScheduleTime = 'ON_SCHEDULE_TIME',
   Processing = 'PROCESSING',
@@ -2500,7 +2499,7 @@ export type ReviewAssignmentStatusFilter = {
 
 export enum ReviewAssignmentStatus {
   Available = 'AVAILABLE',
-  SelfAssignedByAnother = 'SELF_ASSIGNED_BY_ANOTHER',
+  NotAvailable = 'NOT_AVAILABLE',
   Assigned = 'ASSIGNED',
   AvailableForSelfAssignment = 'AVAILABLE_FOR_SELF_ASSIGNMENT'
 }
@@ -4523,7 +4522,7 @@ export type ReviewAssignment = Node & {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -13463,7 +13462,7 @@ export type ReviewQuestionAssignmentReviewAssignmentIdFkeyReviewAssignmentCreate
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -13965,7 +13964,7 @@ export type ReviewReviewAssignmentIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14059,7 +14058,7 @@ export type ReviewAssignmentStageIdFkeyReviewAssignmentCreateInput = {
   reviewerId?: Maybe<Scalars['Int']>;
   organisationId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14318,7 +14317,7 @@ export type ReviewAssignmentOrganisationIdFkeyReviewAssignmentCreateInput = {
   reviewerId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14388,7 +14387,7 @@ export type ReviewAssignmentReviewerIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14453,7 +14452,7 @@ export type ReviewAssignmentAssignerIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14519,7 +14518,7 @@ export type ReviewAssignmentApplicationIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
   timeCreated?: Maybe<Scalars['Datetime']>;
@@ -16309,7 +16308,7 @@ export type ReviewAssignmentInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status: ReviewAssignmentStatus;
+  status?: Maybe<ReviewAssignmentStatus>;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;

--- a/src/utils/helpers/structure/checkPageIsAccessible.ts
+++ b/src/utils/helpers/structure/checkPageIsAccessible.ts
@@ -1,0 +1,25 @@
+import { FullStructure } from '../../types'
+
+interface CheckPageIsAccessible {
+  fullStructure: FullStructure
+  firstIncomplete: { sectionCode: string; pageNumber: number }
+  current: { sectionCode: string; pageNumber: number }
+}
+
+const checkPageIsAccessible = ({
+  fullStructure,
+  firstIncomplete,
+  current: { sectionCode, pageNumber },
+}: CheckPageIsAccessible) => {
+  const firstIncompleteSectionIndex =
+    fullStructure.sections[firstIncomplete.sectionCode].details.index
+  const currentSectionIndex = fullStructure.sections[sectionCode].details.index
+
+  return (
+    currentSectionIndex < firstIncompleteSectionIndex ||
+    (currentSectionIndex === firstIncompleteSectionIndex &&
+      pageNumber <= firstIncomplete.pageNumber)
+  )
+}
+
+export default checkPageIsAccessible

--- a/src/utils/helpers/structure/generateProgress.ts
+++ b/src/utils/helpers/structure/generateProgress.ts
@@ -1,23 +1,62 @@
-import { ElementStateNEW, FullStructure, Progress } from '../../types'
+import { TemplateElementCategory } from '../../generated/graphql'
+import { ElementStateNEW, FullStructure, PageNEW, Progress } from '../../types'
+
+const initialProgress = {
+  doneNonRequired: 0,
+  doneRequired: 0,
+  completed: false,
+  totalNonRequired: 0,
+  totalRequired: 0,
+  totalSum: 0,
+  valid: true,
+}
+
+const calculateCompleted = (totalSum: number, doneRequired: number, doneNonRequired: number) => {
+  const totalDone = doneRequired + doneNonRequired
+  return totalSum === totalDone
+}
+
+const getSectionProgress = (pages: PageNEW[]): Progress => {
+  return pages.reduce((sectionProgress: Progress, { progress }) => {
+    if (!progress) return sectionProgress
+    let {
+      doneNonRequired,
+      doneRequired,
+      completed,
+      totalNonRequired,
+      totalRequired,
+      totalSum,
+      valid,
+    } = sectionProgress
+    doneNonRequired += progress.doneNonRequired || 0
+    totalNonRequired += progress.totalNonRequired || 0
+    doneRequired += progress.doneRequired || 0
+    totalRequired += progress.totalRequired || 0
+    totalSum = totalRequired + doneNonRequired
+    completed = calculateCompleted(totalSum, doneRequired, doneNonRequired)
+    if (!progress.valid) valid = false
+    return {
+      doneNonRequired,
+      doneRequired,
+      completed,
+      totalNonRequired,
+      totalRequired,
+      totalSum,
+      valid,
+    }
+  }, initialProgress)
+}
 
 export const generateResponsesProgress = (structure: FullStructure) => {
-  Object.entries(structure.sections).forEach(([code, section]) => {
-    Object.entries(section.pages).forEach(([pageName, page]) => {
-      const progress: Progress = {
-        doneNonRequired: 0,
-        doneRequired: 0,
-        completed: false,
-        totalNonRequired: 0,
-        totalRequired: 0,
-        totalSum: 0,
-        valid: true,
-      }
+  Object.values(structure.sections).forEach((section) => {
+    Object.values(section.pages).forEach((page) => {
+      const progress: Progress = initialProgress
       page.state
         .filter(({ element }) => {
-          const { isVisible, isEditable } = element as ElementStateNEW
-          return isVisible && isEditable
+          const { category, isVisible, isEditable } = element as ElementStateNEW
+          return isVisible && isEditable && category === TemplateElementCategory.Question
         })
-        .forEach(({ element, response, review }) => {
+        .forEach(({ element, response }) => {
           const { isRequired } = element as ElementStateNEW
           if (isRequired) progress.totalRequired++
           else progress.totalNonRequired++
@@ -25,8 +64,19 @@ export const generateResponsesProgress = (structure: FullStructure) => {
             if (isRequired) progress.doneRequired++
             else progress.doneNonRequired++
           }
-          if (response !== null && !response.isValid) progress.valid = false
+          if (response !== null && !response?.isValid) progress.valid = false
+          progress.totalSum = progress.totalRequired + progress.doneNonRequired
+          progress.completed = calculateCompleted(
+            progress.totalSum,
+            progress.doneRequired,
+            progress.doneNonRequired
+          )
         })
+      page.progress = progress
     })
+    section.progress = getSectionProgress(Object.values(section.pages))
+    section.invalidPage =
+      Object.values(section.pages).find(({ progress }) => progress && !progress.valid)?.number ||
+      undefined
   })
 }

--- a/src/utils/helpers/structure/generateProgress.ts
+++ b/src/utils/helpers/structure/generateProgress.ts
@@ -1,6 +1,6 @@
 import { ElementStateNEW, FullStructure, Progress } from '../../types'
 
-const generateProgressInStructure = (structure: FullStructure) => {
+export const generateResponsesProgress = (structure: FullStructure) => {
   Object.entries(structure.sections).forEach(([code, section]) => {
     Object.entries(section.pages).forEach(([pageName, page]) => {
       const progress: Progress = {
@@ -30,5 +30,3 @@ const generateProgressInStructure = (structure: FullStructure) => {
     })
   })
 }
-
-export default generateProgressInStructure

--- a/src/utils/helpers/structure/generateProgressInStructure.ts
+++ b/src/utils/helpers/structure/generateProgressInStructure.ts
@@ -1,0 +1,34 @@
+import { ElementStateNEW, FullStructure, Progress } from '../../types'
+
+const generateProgressInStructure = (structure: FullStructure) => {
+  Object.entries(structure.sections).forEach(([code, section]) => {
+    Object.entries(section.pages).forEach(([pageName, page]) => {
+      const progress: Progress = {
+        doneNonRequired: 0,
+        doneRequired: 0,
+        completed: false,
+        totalNonRequired: 0,
+        totalRequired: 0,
+        totalSum: 0,
+        valid: true,
+      }
+      page.state
+        .filter(({ element }) => {
+          const { isVisible, isEditable } = element as ElementStateNEW
+          return isVisible && isEditable
+        })
+        .forEach(({ element, response, review }) => {
+          const { isRequired } = element as ElementStateNEW
+          if (isRequired) progress.totalRequired++
+          else progress.totalNonRequired++
+          if (response?.text) {
+            if (isRequired) progress.doneRequired++
+            else progress.doneNonRequired++
+          }
+          if (response !== null && !response.isValid) progress.valid = false
+        })
+    })
+  })
+}
+
+export default generateProgressInStructure

--- a/src/utils/hooks/useGetFullApplicationStructure.tsx
+++ b/src/utils/hooks/useGetFullApplicationStructure.tsx
@@ -11,7 +11,7 @@ import { ApplicationResponse, useGetAllResponsesQuery } from '../generated/graph
 import { useUserState } from '../../contexts/UserState'
 import evaluateExpression from '@openmsupply/expression-evaluator'
 import { IQueryNode } from '@openmsupply/expression-evaluator/lib/types'
-import generateProgressInStructure from '../helpers/structure/generateProgressInStructure'
+import { generateResponsesProgress } from '../helpers/structure/generateProgress'
 
 interface useGetFullApplicationStructureProps {
   structure: FullStructure
@@ -101,7 +101,7 @@ const useGetFullApplicationStructure = ({
       })
       if (shouldProcessValidation || firstRunProcessValidation)
         setLastValidationTimestamp(Date.now())
-      generateProgressInStructure(newStructure) // To-Do
+      generateResponsesProgress(newStructure) // Progress for Applicant
       setFirstRunProcessValidation(false)
       setFullStructure(newStructure)
       setResponsesByCode(responseObject)

--- a/src/utils/hooks/useGetFullApplicationStructure.tsx
+++ b/src/utils/hooks/useGetFullApplicationStructure.tsx
@@ -100,6 +100,7 @@ const useGetFullApplicationStructure = ({
       })
       if (shouldProcessValidation || firstRunProcessValidation)
         setLastValidationTimestamp(Date.now())
+      generateProgressStructure(newStructure) // To-Do
       setFirstRunProcessValidation(false)
       setFullStructure(newStructure)
       setResponsesByCode(responseObject)
@@ -189,4 +190,10 @@ const flattenStructureElements = (structure: FullStructure) => {
     })
   })
   return flattened
+}
+
+const generateProgressStructure = (structure: FullStructure) => {
+  // TO-DO:
+  // Calculate all Progress objects and update structure in-place
+  // Shouldn't return anything
 }

--- a/src/utils/hooks/useGetFullApplicationStructure.tsx
+++ b/src/utils/hooks/useGetFullApplicationStructure.tsx
@@ -172,9 +172,10 @@ const useGetFullApplicationStructure = ({
 
   return {
     fullStructure,
+    responsesByCode,
     error: isError ? error : false,
     isLoading: loading || isLoading,
-    responsesByCode,
+    lastValidationTimestamp,
   }
 }
 

--- a/src/utils/hooks/useGetFullApplicationStructure.tsx
+++ b/src/utils/hooks/useGetFullApplicationStructure.tsx
@@ -11,6 +11,7 @@ import { ApplicationResponse, useGetAllResponsesQuery } from '../generated/graph
 import { useUserState } from '../../contexts/UserState'
 import evaluateExpression from '@openmsupply/expression-evaluator'
 import { IQueryNode } from '@openmsupply/expression-evaluator/lib/types'
+import generateProgressInStructure from '../helpers/structure/generateProgressInStructure'
 
 interface useGetFullApplicationStructureProps {
   structure: FullStructure
@@ -100,7 +101,7 @@ const useGetFullApplicationStructure = ({
       })
       if (shouldProcessValidation || firstRunProcessValidation)
         setLastValidationTimestamp(Date.now())
-      generateProgressStructure(newStructure) // To-Do
+      generateProgressInStructure(newStructure) // To-Do
       setFirstRunProcessValidation(false)
       setFullStructure(newStructure)
       setResponsesByCode(responseObject)
@@ -190,10 +191,4 @@ const flattenStructureElements = (structure: FullStructure) => {
     })
   })
   return flattened
-}
-
-const generateProgressStructure = (structure: FullStructure) => {
-  // TO-DO:
-  // Calculate all Progress objects and update structure in-place
-  // Shouldn't return anything
 }

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -70,6 +70,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
         serial: application.serial as string,
         name: application.name as string,
         outcome: application.outcome as string,
+        firstIncompletePage: null, // Added for new FullStructure
       }
 
       setApplication(applicationDetails)

--- a/src/utils/hooks/useLoadApplicationNEW.ts
+++ b/src/utils/hooks/useLoadApplicationNEW.ts
@@ -126,6 +126,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
         else
           baseElements.push({
             // ...element,
+            category: element.category,
             code: element.code,
             pluginCode: element.elementTypePluginCode,
             sectionIndex: sectionNode?.templateSection?.index,

--- a/src/utils/hooks/useLoadApplicationNEW.ts
+++ b/src/utils/hooks/useLoadApplicationNEW.ts
@@ -114,6 +114,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
         status: status as ApplicationStatus,
         date: DateTime.fromISO(statusHistoryTimeCreated),
       },
+      firstIncompletePage: null,
     }
 
     const baseElements: ElementBaseNEW[] = []

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -44,8 +44,8 @@ export {
   PageElements,
   PageNEW,
   PageElement,
-  PageElementsNEW,
   PageElementsStatuses,
+  Progress,
   ProgressStatus,
   ResponseFull,
   ResponsePayload,
@@ -59,6 +59,7 @@ export {
   SectionState,
   SectionDetails,
   SectionProgress,
+  SectionProgressNEW,
   SectionsStructure,
   SectionStateNEW,
   SectionsStructureNEW,
@@ -243,7 +244,8 @@ type PageElements = {
 
 interface PageNEW {
   number: number
-  state: PageElementsNEW
+  progress: Progress
+  state: PageElement[]
 }
 
 type PageElement = {
@@ -252,12 +254,22 @@ type PageElement = {
   review?: ReviewQuestionDecision
 }
 
-type PageElementsNEW = PageElement[]
 interface PageElementsStatuses {
   [code: string]: ProgressStatus
 }
 
+interface Progress {
+  doneRequired: number
+  doneNonRequired: number
+  completed: boolean
+  totalRequired: number
+  totalNonRequired: number
+  totalSum: number
+  valid: boolean
+}
+
 type ProgressStatus = 'VALID' | 'NOT_VALID' | 'INCOMPLETE'
+
 interface ResponseFull {
   id: number
   text: string | null | undefined
@@ -325,6 +337,12 @@ interface SectionProgress {
   valid: boolean
   linkedPage: number
 }
+
+interface SectionProgressNEW {
+  state: Progress
+  linkedPage: number
+}
+
 interface SectionState {
   details: SectionDetails
   progress?: SectionProgress
@@ -338,7 +356,7 @@ interface SectionsStructure {
 }
 interface SectionStateNEW {
   details: SectionDetails
-  progress?: SectionProgress
+  progress?: SectionProgressNEW
   assigned?: ReviewerDetails
   pages: {
     [pageName: string]: PageNEW

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -59,7 +59,6 @@ export {
   SectionState,
   SectionDetails,
   SectionProgress,
-  SectionProgressNEW,
   SectionsStructure,
   SectionStateNEW,
   SectionsStructureNEW,
@@ -244,7 +243,7 @@ type PageElements = {
 
 interface PageNEW {
   number: number
-  progress: Progress
+  progress?: Progress
   state: PageElement[]
 }
 
@@ -338,11 +337,6 @@ interface SectionProgress {
   linkedPage: number
 }
 
-interface SectionProgressNEW {
-  state: Progress
-  linkedPage: number
-}
-
 interface SectionState {
   details: SectionDetails
   progress?: SectionProgress
@@ -356,7 +350,8 @@ interface SectionsStructure {
 }
 interface SectionStateNEW {
   details: SectionDetails
-  progress?: SectionProgressNEW
+  invalidPage?: number
+  progress?: Progress
   assigned?: ReviewerDetails
   pages: {
     [pageName: string]: PageNEW

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -42,7 +42,8 @@ export {
   FullStructure,
   IGraphQLConnection,
   LooseString,
-  MethodToCallOnRevalidation,
+  MethodRevalidate,
+  MethodToCallProps,
   Page,
   PageElements,
   PageNEW,
@@ -96,7 +97,7 @@ interface ApplicationDetails {
   outcome: string
   isLinear: boolean
   current?: StageAndStatus // TODO: Change to compulsory after re-strcture is finished
-  firstIncompletePage?: SectionAndPage | null
+  firstIncompletePage: SectionAndPage | null
 }
 
 interface ApplicationElementStates {
@@ -248,8 +249,13 @@ interface IGraphQLConnection {
 
 type LooseString = string | null | undefined
 
-interface MethodToCallOnRevalidation {
-  (firstInvalidPage: SectionAndPage | null, setStrictSectionPage: SetStrictSectionPage): void
+interface MethodRevalidate {
+  (methodToCall: (props: MethodToCallProps) => void): void
+}
+
+interface MethodToCallProps {
+  firstIncompletePage: SectionAndPage | null
+  setStrictSectionPage: SetStrictSectionPage
 }
 
 interface Page {


### PR DESCRIPTION
Fixes #351 

~~Branched of #366 please merge it first before this one!~~ DONE

### Changes
- Use new `FullStructure` to display on the `ProgressBar` new component, now each Page has a progress and no longer needs to deduce the page progress on the go.
- Simplified the component (compared to old `ProgressBar`) to be easier to read, there is an alternative to using `Grid` commented, but that needs a bit tweaking to get rid of the background on `Label`...
- Change pages on **non linear** applications, ~~still has a TODO to deal with **linear** which is pending on checking with @andreievg what was the approach decided (it has been removed from Application Flow chart).~~
- [In progress] Adding validation to change to another page on **linear** applications  