### PR TITLE
#345 Application home page

### DIFF
--- a/src/components/Application/ApplicationHeader.tsx
+++ b/src/components/Application/ApplicationHeader.tsx
@@ -1,31 +1,44 @@
 import React from 'react'
-import { Container, Grid, Header, Segment } from 'semantic-ui-react'
+import { Link } from 'react-router-dom'
+import { Button, Header, Segment } from 'semantic-ui-react'
+import strings from '../../utils/constants'
+import { TemplateDetails, User } from '../../utils/types'
 
 export interface AppHeaderProps {
-  serialNumber: string
-  name: string
-  mode?: string
+  template: TemplateDetails
+  currentUser: User | null
+  ChildComponent: React.FC
 }
 
-const ApplicationHeader: React.FC<AppHeaderProps> = (props) => {
-  const { mode, serialNumber, name } = props
-
+const ApplicationHeader: React.FC<AppHeaderProps> = ({ template, currentUser, ChildComponent }) => {
+  const { code, name } = template
   return (
-    <Container>
-      <Grid columns={2} stackable textAlign='right'>
-        <Grid.Row>
-          <Grid.Column>
-            <Header as='h2' content={`${name}`}>
-            </Header>
-          </Grid.Column>
-          <Grid.Column>
-            <Header as='h3' content={`Number ${serialNumber}`}>
-            </Header>
-          </Grid.Column>
-      </Grid.Row>
-      </Grid>
-      {mode && <Header as="h3" content={mode} />}
-    </Container>
+    <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>
+      <Button
+        as={Link}
+        to={`/applications?type=${code}`}
+        icon="angle left"
+        label={{ content: `${name} ${strings.LABEL_APPLICATIONS}`, color: 'grey' }}
+      />
+      <Header textAlign="center">
+        {currentUser?.organisation?.orgName || strings.TITLE_NO_ORGANISATION}
+      </Header>
+      <Segment
+        style={{
+          backgroundColor: 'white',
+          padding: 10,
+          margin: '0px 50px',
+          minHeight: 500,
+          flex: 1,
+        }}
+      >
+        <Header as="h2" textAlign="center">
+          {`${name} ${strings.TITLE_APPLICATION_FORM}`}
+          <Header.Subheader>{strings.TITLE_INTRODUCTION}</Header.Subheader>
+        </Header>
+        <ChildComponent />
+      </Segment>
+    </Segment.Group>
   )
 }
 

--- a/src/components/Sections/SectionsProgress.tsx
+++ b/src/components/Sections/SectionsProgress.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { Button, Grid, Icon, List, Progress } from 'semantic-ui-react'
+import { Progress as ProgressType, SectionsStructureNEW } from '../../utils/types'
+
+interface SectionsProgressProps {
+  sections: SectionsStructureNEW
+}
+
+const SectionsProgress: React.FC<SectionsProgressProps> = ({ sections }) => {
+  const getIndicator = ({ completed, valid }: ProgressType) => {
+    return completed ? (
+      <Icon name={valid ? 'check circle' : 'exclamation circle'} color={valid ? 'green' : 'red'} />
+    ) : (
+      <Icon name="circle outline" />
+    )
+  }
+
+  const getProgress = ({ doneRequired, doneNonRequired, totalSum, valid }: ProgressType) => {
+    const totalDone = doneRequired + doneNonRequired
+    return (
+      <Progress
+        style={{ width: 200 }}
+        percent={(100 * totalDone) / totalSum}
+        size="tiny"
+        success={valid}
+        error={!valid}
+      />
+    )
+  }
+
+  return (
+    <List
+      divided
+      relaxed="very"
+      items={Object.entries(sections).map(([sectionCode, { details, progress }]) => ({
+        key: `list-item-${sectionCode}`,
+        icon: progress ? getIndicator(progress) : null,
+        header: (
+          <Grid stackable>
+            <Grid.Column style={{ minWidth: 100 }} floated="left" width={4}>
+              <p>{details.title}</p>
+            </Grid.Column>
+            <Grid.Column style={{ minWidth: 200 }} floated="right" width={4}>
+              {progress && progress.totalSum > 0 && getProgress(progress)}
+            </Grid.Column>
+            <Grid.Column style={{ minWidth: 100 }} width={2}>
+              TODO: RESUME BUTTON
+            </Grid.Column>
+          </Grid>
+        ),
+      }))}
+    />
+  )
+}
+
+export default SectionsProgress
+
+// Object.entries(sections).map(([sectionCode, { details, progress }]) => (
+{
+  /* <Grid.Column width={2}>
+        TODO: RESUME BUTTON
+        { {resumeApplication && progress && sectionCode === firstIncomplete && (
+            <Button
+            color="blue"
+            onClick={() =>
+                resumeApplication({ sectionCode, page: progress.linkedPage })
+            }
+            >
+            {strings.BUTTON_APPLICATION_RESUME}
+            </Button>
+        )} }
+        </Grid.Column>
+)*/
+}

--- a/src/components/Sections/SectionsProgress.tsx
+++ b/src/components/Sections/SectionsProgress.tsx
@@ -4,11 +4,16 @@ import { Progress as ProgressType, SectionAndPage, SectionsStructureNEW } from '
 import strings from '../../utils/constants'
 
 interface SectionsProgressProps {
+  firstStrictInvalidPage: SectionAndPage | null
   sections: SectionsStructureNEW
   resumeApplication: (location: SectionAndPage) => void
 }
 
-const SectionsProgress: React.FC<SectionsProgressProps> = ({ sections, resumeApplication }) => {
+const SectionsProgress: React.FC<SectionsProgressProps> = ({
+  firstStrictInvalidPage,
+  sections,
+  resumeApplication,
+}) => {
   const getIndicator = ({ completed, valid }: ProgressType) => {
     return completed ? (
       <Icon name={valid ? 'check circle' : 'exclamation circle'} color={valid ? 'green' : 'red'} />
@@ -30,9 +35,6 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({ sections, resumeApp
     ) : null
   }
 
-  // TODO: Use correct firstIncomplete sections
-  const firstIncomplete: SectionAndPage = { sectionCode: 'S1', pageNumber: 1 }
-
   return (
     <List
       divided
@@ -49,11 +51,12 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({ sections, resumeApp
               {progress && getProgress(progress)}
             </Grid.Column>
             <Grid.Column style={{ minWidth: 100, padding: 0 }} width={2}>
-              {firstIncomplete && sectionCode === firstIncomplete.sectionCode && (
-                <Button color="blue" onClick={() => resumeApplication(firstIncomplete)}>
-                  {strings.BUTTON_APPLICATION_RESUME}
-                </Button>
-              )}
+              {firstStrictInvalidPage !== null &&
+                sectionCode === firstStrictInvalidPage.sectionCode && (
+                  <Button color="blue" onClick={() => resumeApplication(firstStrictInvalidPage)}>
+                    {strings.BUTTON_APPLICATION_RESUME}
+                  </Button>
+                )}
             </Grid.Column>
           </Grid>
         ),

--- a/src/components/Sections/SectionsProgress.tsx
+++ b/src/components/Sections/SectionsProgress.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import { Button, Grid, Icon, List, Progress } from 'semantic-ui-react'
-import { Progress as ProgressType, SectionsStructureNEW } from '../../utils/types'
+import { Progress as ProgressType, SectionAndPage, SectionsStructureNEW } from '../../utils/types'
+import strings from '../../utils/constants'
 
 interface SectionsProgressProps {
   sections: SectionsStructureNEW
+  resumeApplication: (location: SectionAndPage) => void
 }
 
-const SectionsProgress: React.FC<SectionsProgressProps> = ({ sections }) => {
+const SectionsProgress: React.FC<SectionsProgressProps> = ({ sections, resumeApplication }) => {
   const getIndicator = ({ completed, valid }: ProgressType) => {
     return completed ? (
       <Icon name={valid ? 'check circle' : 'exclamation circle'} color={valid ? 'green' : 'red'} />
@@ -17,7 +19,7 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({ sections }) => {
 
   const getProgress = ({ doneRequired, doneNonRequired, totalSum, valid }: ProgressType) => {
     const totalDone = doneRequired + doneNonRequired
-    return (
+    return totalDone > 0 && totalSum > 0 ? (
       <Progress
         style={{ width: 200 }}
         percent={(100 * totalDone) / totalSum}
@@ -25,8 +27,11 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({ sections }) => {
         success={valid}
         error={!valid}
       />
-    )
+    ) : null
   }
+
+  // TODO: Use correct firstIncomplete sections
+  const firstIncomplete: SectionAndPage = { sectionCode: 'S1', pageName: 'Page1' }
 
   return (
     <List
@@ -36,15 +41,19 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({ sections }) => {
         key: `list-item-${sectionCode}`,
         icon: progress ? getIndicator(progress) : null,
         header: (
-          <Grid stackable>
+          <Grid stackable style={{ minHeight: 50 }}>
             <Grid.Column style={{ minWidth: 100 }} floated="left" width={4}>
               <p>{details.title}</p>
             </Grid.Column>
-            <Grid.Column style={{ minWidth: 200 }} floated="right" width={4}>
-              {progress && progress.totalSum > 0 && getProgress(progress)}
+            <Grid.Column style={{ width: 200, paddingRight: '5%' }} floated="right" width={4}>
+              {progress && getProgress(progress)}
             </Grid.Column>
-            <Grid.Column style={{ minWidth: 100 }} width={2}>
-              TODO: RESUME BUTTON
+            <Grid.Column style={{ minWidth: 100, padding: 0 }} width={2}>
+              {firstIncomplete && sectionCode === firstIncomplete.sectionCode && (
+                <Button color="blue" onClick={() => resumeApplication(firstIncomplete)}>
+                  {strings.BUTTON_APPLICATION_RESUME}
+                </Button>
+              )}
             </Grid.Column>
           </Grid>
         ),
@@ -54,21 +63,3 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({ sections }) => {
 }
 
 export default SectionsProgress
-
-// Object.entries(sections).map(([sectionCode, { details, progress }]) => (
-{
-  /* <Grid.Column width={2}>
-        TODO: RESUME BUTTON
-        { {resumeApplication && progress && sectionCode === firstIncomplete && (
-            <Button
-            color="blue"
-            onClick={() =>
-                resumeApplication({ sectionCode, page: progress.linkedPage })
-            }
-            >
-            {strings.BUTTON_APPLICATION_RESUME}
-            </Button>
-        )} }
-        </Grid.Column>
-)*/
-}

--- a/src/components/Sections/index.ts
+++ b/src/components/Sections/index.ts
@@ -1,0 +1,3 @@
+import { SectionsProgress } from './SectionsProgress'
+
+export { SectionsProgress }

--- a/src/components/Sections/index.ts
+++ b/src/components/Sections/index.ts
@@ -1,3 +1,3 @@
-import { SectionsProgress } from './SectionsProgress'
+import SectionsProgress from './SectionsProgress'
 
 export { SectionsProgress }

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
+import { Button, Divider, Header, Message, Segment, Sticky } from 'semantic-ui-react'
 import { FullStructure, SectionAndPage, TemplateDetails } from '../../utils/types'
 import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
 import { ApplicationHeader, Loading } from '../../components'
-import { Button, Divider, Header, Message, Segment } from 'semantic-ui-react'
 import strings from '../../utils/constants'
 import { useUserState } from '../../contexts/UserState'
 import SectionsProgress from '../../components/Sections/SectionsProgress'
@@ -21,24 +21,50 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
   const {
     userState: { currentUser },
   } = useUserState()
+
   const { error, fullStructure } = useGetFullApplicationStructure({
     structure,
   })
-
-  if (!fullStructure || !fullStructure.responsesByCode) return <Loading />
 
   const handleResumeClick = ({ sectionCode, pageName }: SectionAndPage) => {
     push(`/applicationNEW/${serialNumber}/${sectionCode}/${pageName}`)
   }
 
+  const handleSummaryClicked = () => {
+    push(`/applicationNEW/${serialNumber}/summary`)
+  }
+
+  if (!fullStructure || !fullStructure.responsesByCode) return <Loading />
+
+  const isCompleted = Object.values(fullStructure.sections).every(
+    ({ progress }) => progress?.completed && progress.valid
+  )
+
   const HomeMain: React.FC = () => {
     return (
-      <Segment>
-        <Header as="h5">{strings.SUBTITLE_APPLICATION_STEPS}</Header>
-        <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
-        <SectionsProgress sections={fullStructure.sections} resumeApplication={handleResumeClick} />
-        <Divider />
-      </Segment>
+      <>
+        <Segment>
+          <Header as="h5">{strings.SUBTITLE_APPLICATION_STEPS}</Header>
+          <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
+          <SectionsProgress
+            sections={fullStructure.sections}
+            resumeApplication={handleResumeClick}
+          />
+          <Divider />
+        </Segment>
+        {isCompleted && (
+          <Sticky
+            pushing
+            style={{ backgroundColor: 'white', boxShadow: ' 0px -5px 8px 0px rgba(0,0,0,0.1)' }}
+          >
+            <Segment basic textAlign="right">
+              <Button color="blue" onClick={handleSummaryClicked}>
+                {strings.BUTTON_SUMMARY}
+              </Button>
+            </Segment>
+          </Sticky>
+        )}
+      </>
     )
   }
 
@@ -50,18 +76,3 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
 }
 
 export default ApplicationHome
-
-{
-  /* {isApplicationCompleted && (
-        <Sticky
-          pushing
-          style={{ backgroundColor: 'white', boxShadow: ' 0px -5px 8px 0px rgba(0,0,0,0.1)' }}
-        >
-          <Segment basic textAlign="right">
-            <Button color="blue" onClick={setSummaryButtonClicked}>
-              {strings.BUTTON_SUMMARY}
-            </Button>
-          </Segment>
-        </Sticky>
-      )} */
-}

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -1,21 +1,86 @@
 import React from 'react'
-import { FullStructure } from '../../utils/types'
+import { FullStructure, TemplateDetails } from '../../utils/types'
 import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
+import { ApplicationSelectType, Loading } from '../../components'
+import { Button, Divider, Header, Message, Segment } from 'semantic-ui-react'
+import strings from '../../utils/constants'
+import { Link } from 'react-router-dom'
+import { useUserState } from '../../contexts/UserState'
+import SectionsProgress from '../../components/Sections/SectionsProgress'
 
 interface ApplicationProps {
   structure: FullStructure
+  template: TemplateDetails
 }
 
-const ApplicationHome: React.FC<ApplicationProps> = ({ structure }) => {
+const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) => {
+  const {
+    userState: { currentUser },
+  } = useUserState()
   const { error, fullStructure } = useGetFullApplicationStructure({
     structure,
   })
 
-  console.log('FULL STRUCTURE', fullStructure)
-  console.log('responsesByCode', fullStructure?.responsesByCode)
-  console.log('isLoading', !fullStructure)
+  if (!fullStructure || !fullStructure.responsesByCode) return <Loading />
 
-  return <p>START PAGE</p>
+  // const { info: { code, name } } = fullStructure as FullStructure
+  const { code, name } = template
+
+  return error ? (
+    <Message error title={strings.ERROR_APPLICATION_OVERVIEW} list={[error]} />
+  ) : (
+    <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>
+      <Button
+        as={Link}
+        to={`/applications?type=${code}`}
+        icon="angle left"
+        label={{ content: `${name} ${strings.LABEL_APPLICATIONS}`, color: 'grey' }}
+      />
+      <Header textAlign="center">
+        {currentUser?.organisation?.orgName || strings.TITLE_NO_ORGANISATION}
+      </Header>
+      <Segment
+        style={{
+          backgroundColor: 'white',
+          padding: 10,
+          margin: '0px 50px',
+          minHeight: 500,
+          flex: 1,
+        }}
+      >
+        <Header as="h2" textAlign="center">
+          {`${name} ${strings.TITLE_APPLICATION_FORM}`}
+          <Header.Subheader>{strings.TITLE_INTRODUCTION}</Header.Subheader>
+        </Header>
+        {template && (
+          <Segment basic>
+            <Header as="h5">{strings.SUBTITLE_APPLICATION_STEPS}</Header>
+            <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
+            <SectionsProgress sections={fullStructure.sections} />
+            <Divider />
+            {/* <Markdown text={startMessageEvaluated} semanticComponent="Message" info />
+            {startApplication && (
+              <Button color="blue" onClick={startApplication}>
+                {strings.BUTTON_APPLICATION_START}
+              </Button>
+            )} */}
+          </Segment>
+        )}
+      </Segment>
+      {/* {isApplicationCompleted && (
+        <Sticky
+          pushing
+          style={{ backgroundColor: 'white', boxShadow: ' 0px -5px 8px 0px rgba(0,0,0,0.1)' }}
+        >
+          <Segment basic textAlign="right">
+            <Button color="blue" onClick={setSummaryButtonClicked}>
+              {strings.BUTTON_SUMMARY}
+            </Button>
+          </Segment>
+        </Sticky>
+      )} */}
+    </Segment.Group>
+  )
 }
 
 export default ApplicationHome

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -44,10 +44,6 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
 
   if (!fullStructure || !fullStructure.responsesByCode) return <Loading />
 
-  const isCompleted = Object.values(fullStructure.sections).every(
-    ({ progress }) => progress?.completed && progress.valid
-  )
-
   const { firstStrictInvalidPage } = fullStructure.info
 
   const HomeMain: React.FC = () => {
@@ -63,7 +59,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
           />
           <Divider />
         </Segment>
-        {isCompleted && (
+        {firstStrictInvalidPage === null && (
           <Sticky
             pushing
             style={{ backgroundColor: 'white', boxShadow: ' 0px -5px 8px 0px rgba(0,0,0,0.1)' }}

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
-import { FullStructure, TemplateDetails } from '../../utils/types'
+import { FullStructure, SectionAndPage, TemplateDetails } from '../../utils/types'
 import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
 import { ApplicationHeader, Loading } from '../../components'
 import { Button, Divider, Header, Message, Segment } from 'semantic-ui-react'
 import strings from '../../utils/constants'
 import { useUserState } from '../../contexts/UserState'
 import SectionsProgress from '../../components/Sections/SectionsProgress'
+import { useRouter } from '../../utils/hooks/useRouter'
 
 interface ApplicationProps {
   structure: FullStructure
@@ -13,6 +14,10 @@ interface ApplicationProps {
 }
 
 const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) => {
+  const {
+    query: { serialNumber },
+    push,
+  } = useRouter()
   const {
     userState: { currentUser },
   } = useUserState()
@@ -22,12 +27,16 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
 
   if (!fullStructure || !fullStructure.responsesByCode) return <Loading />
 
+  const handleResumeClick = ({ sectionCode, pageName }: SectionAndPage) => {
+    push(`/applicationNEW/${serialNumber}/${sectionCode}/${pageName}`)
+  }
+
   const HomeMain: React.FC = () => {
     return (
       <Segment>
         <Header as="h5">{strings.SUBTITLE_APPLICATION_STEPS}</Header>
         <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
-        <SectionsProgress sections={fullStructure.sections} />
+        <SectionsProgress sections={fullStructure.sections} resumeApplication={handleResumeClick} />
         <Divider />
       </Segment>
     )

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -31,7 +31,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
     if (!fullStructure) return
     const { status } = fullStructure.info.current as StageAndStatus
     if (status !== ApplicationStatus.Draft && status !== ApplicationStatus.ChangesRequired)
-      push(`/application/${serialNumber}/summary`)
+      push(`/applicationNEW/${serialNumber}/summary`)
   }, [fullStructure])
 
   const handleResumeClick = ({ sectionCode, pageNumber }: SectionAndPage) => {

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -48,6 +48,8 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
     ({ progress }) => progress?.completed && progress.valid
   )
 
+  const { firstStrictInvalidPage } = fullStructure.info
+
   const HomeMain: React.FC = () => {
     return (
       <>
@@ -56,6 +58,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
           <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
           <SectionsProgress
             sections={fullStructure.sections}
+            firstStrictInvalidPage={firstStrictInvalidPage}
             resumeApplication={handleResumeClick}
           />
           <Divider />

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -8,6 +8,7 @@ import { useUserState } from '../../contexts/UserState'
 import SectionsProgress from '../../components/Sections/SectionsProgress'
 import { useRouter } from '../../utils/hooks/useRouter'
 import { ApplicationStatus } from '../../utils/generated/graphql'
+import { Link } from 'react-router-dom'
 
 interface ApplicationProps {
   structure: FullStructure
@@ -59,13 +60,13 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
           />
           <Divider />
         </Segment>
-        {firstStrictInvalidPage === null && (
+        {!firstStrictInvalidPage && (
           <Sticky
             pushing
             style={{ backgroundColor: 'white', boxShadow: ' 0px -5px 8px 0px rgba(0,0,0,0.1)' }}
           >
             <Segment basic textAlign="right">
-              <Button color="blue" onClick={handleSummaryClicked}>
+              <Button as={Link} color="blue" onClick={handleSummaryClicked}>
                 {strings.BUTTON_SUMMARY}
               </Button>
             </Segment>

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import { FullStructure, TemplateDetails } from '../../utils/types'
 import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
-import { ApplicationSelectType, Loading } from '../../components'
+import { ApplicationHeader, Loading } from '../../components'
 import { Button, Divider, Header, Message, Segment } from 'semantic-ui-react'
 import strings from '../../utils/constants'
-import { Link } from 'react-router-dom'
 import { useUserState } from '../../contexts/UserState'
 import SectionsProgress from '../../components/Sections/SectionsProgress'
 
@@ -23,51 +22,28 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
 
   if (!fullStructure || !fullStructure.responsesByCode) return <Loading />
 
-  // const { info: { code, name } } = fullStructure as FullStructure
-  const { code, name } = template
+  const HomeMain: React.FC = () => {
+    return (
+      <Segment>
+        <Header as="h5">{strings.SUBTITLE_APPLICATION_STEPS}</Header>
+        <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
+        <SectionsProgress sections={fullStructure.sections} />
+        <Divider />
+      </Segment>
+    )
+  }
 
   return error ? (
     <Message error title={strings.ERROR_APPLICATION_OVERVIEW} list={[error]} />
   ) : (
-    <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>
-      <Button
-        as={Link}
-        to={`/applications?type=${code}`}
-        icon="angle left"
-        label={{ content: `${name} ${strings.LABEL_APPLICATIONS}`, color: 'grey' }}
-      />
-      <Header textAlign="center">
-        {currentUser?.organisation?.orgName || strings.TITLE_NO_ORGANISATION}
-      </Header>
-      <Segment
-        style={{
-          backgroundColor: 'white',
-          padding: 10,
-          margin: '0px 50px',
-          minHeight: 500,
-          flex: 1,
-        }}
-      >
-        <Header as="h2" textAlign="center">
-          {`${name} ${strings.TITLE_APPLICATION_FORM}`}
-          <Header.Subheader>{strings.TITLE_INTRODUCTION}</Header.Subheader>
-        </Header>
-        {template && (
-          <Segment basic>
-            <Header as="h5">{strings.SUBTITLE_APPLICATION_STEPS}</Header>
-            <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
-            <SectionsProgress sections={fullStructure.sections} />
-            <Divider />
-            {/* <Markdown text={startMessageEvaluated} semanticComponent="Message" info />
-            {startApplication && (
-              <Button color="blue" onClick={startApplication}>
-                {strings.BUTTON_APPLICATION_START}
-              </Button>
-            )} */}
-          </Segment>
-        )}
-      </Segment>
-      {/* {isApplicationCompleted && (
+    <ApplicationHeader template={template} currentUser={currentUser} ChildComponent={HomeMain} />
+  )
+}
+
+export default ApplicationHome
+
+{
+  /* {isApplicationCompleted && (
         <Sticky
           pushing
           style={{ backgroundColor: 'white', boxShadow: ' 0px -5px 8px 0px rgba(0,0,0,0.1)' }}
@@ -78,9 +54,5 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
             </Button>
           </Segment>
         </Sticky>
-      )} */}
-    </Segment.Group>
-  )
+      )} */
 }
-
-export default ApplicationHome

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -1,12 +1,13 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Button, Divider, Header, Message, Segment, Sticky } from 'semantic-ui-react'
-import { FullStructure, SectionAndPage, TemplateDetails } from '../../utils/types'
+import { FullStructure, SectionAndPage, StageAndStatus, TemplateDetails } from '../../utils/types'
 import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
 import { ApplicationHeader, Loading } from '../../components'
 import strings from '../../utils/constants'
 import { useUserState } from '../../contexts/UserState'
 import SectionsProgress from '../../components/Sections/SectionsProgress'
 import { useRouter } from '../../utils/hooks/useRouter'
+import { ApplicationStatus } from '../../utils/generated/graphql'
 
 interface ApplicationProps {
   structure: FullStructure
@@ -17,6 +18,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
   const {
     query: { serialNumber },
     push,
+    replace,
   } = useRouter()
   const {
     userState: { currentUser },
@@ -25,6 +27,13 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
   const { error, fullStructure } = useGetFullApplicationStructure({
     structure,
   })
+
+  useEffect(() => {
+    if (!fullStructure) return
+    const { status } = fullStructure.info.current as StageAndStatus
+    if (status !== ApplicationStatus.Draft && status !== ApplicationStatus.ChangesRequired)
+      replace(`/application/${serialNumber}/summary`)
+  }, [fullStructure])
 
   const handleResumeClick = ({ sectionCode, pageName }: SectionAndPage) => {
     push(`/applicationNEW/${serialNumber}/${sectionCode}/${pageName}`)

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -18,7 +18,6 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
   const {
     query: { serialNumber },
     push,
-    replace,
   } = useRouter()
   const {
     userState: { currentUser },
@@ -32,7 +31,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
     if (!fullStructure) return
     const { status } = fullStructure.info.current as StageAndStatus
     if (status !== ApplicationStatus.Draft && status !== ApplicationStatus.ChangesRequired)
-      replace(`/application/${serialNumber}/summary`)
+      push(`/application/${serialNumber}/summary`)
   }, [fullStructure])
 
   const handleResumeClick = ({ sectionCode, pageName }: SectionAndPage) => {

--- a/src/containers/Application/ApplicationWrapper.tsx
+++ b/src/containers/Application/ApplicationWrapper.tsx
@@ -28,10 +28,10 @@ const ApplicationWrapper: React.FC = () => {
     <Message error header={strings.ERROR_APPLICATION_PAGE} list={[error]} />
   ) : isLoading ? (
     <Loading />
-  ) : structure ? (
+  ) : structure && template ? (
     <Switch>
       <Route exact path={path}>
-        <ApplicationHome structure={structure} />
+        <ApplicationHome structure={structure} template={template} />
       </Route>
       <Route exact path={`${path}/:sectionCode/Page:page`}>
         <ApplicationPage structure={structure} />

--- a/src/containers/Main/AuthenticatedWrapper.tsx
+++ b/src/containers/Main/AuthenticatedWrapper.tsx
@@ -7,7 +7,7 @@ import { Redirect } from 'react-router'
 
 const AuthenticatedContent: React.FC = () => {
   return isLoggedIn() ? (
-    <Container fluid>
+    <Container>
       <SiteLayout />
       <Footer />
     </Container>

--- a/src/containers/Main/AuthenticatedWrapper.tsx
+++ b/src/containers/Main/AuthenticatedWrapper.tsx
@@ -7,7 +7,7 @@ import { Redirect } from 'react-router'
 
 const AuthenticatedContent: React.FC = () => {
   return isLoggedIn() ? (
-    <Container>
+    <Container fluid>
       <SiteLayout />
       <Footer />
     </Container>

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -53,14 +53,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         onChange={handleChange}
         value={value}
         disabled={!isEditable}
-        error={
-          !validationState.isValid
-            ? {
-                content: validationState?.validationMessage,
-                pointing: 'above',
-              }
-            : null
-        }
+        error={!validationState.isValid ? true : undefined}
       />
       {validationState.isValid ? null : (
         <Label basic color="red" pointing>


### PR DESCRIPTION
Fixes #345 

### Branched from Issue's PR:
~~#371~~ MERGED 

### Changes
- New component `ApplicationHeader` to render the top part of the  container on Home page and **back to list** button. It also receives the content to be displayed inside its container
- New component `SectionsProgress`  to display  all sections in the application (using **fullStructure.sections** with each progress on sections and a **Resume** button on the first section with invalid/incomplete page
- Find the correct first section with invalid page to be done in issue #374 
- When all sections are complete show the **Review & Summary** button on the Home page
- When the application is not in `Draft` or `Changes Requested` status redirect to the Summary page (Issue #367 in progress)

### Unrelated changes
- Add `fluid` to main container to display the application a little better on mobile
- Still can't find a simple way to display the progress nicely on mobile. Probably something to do as part of [Epic#10 - App menu & layout](https://github.com/openmsupply/application-manager-web-app/issues/78)
<img width="367" alt="Screen Shot 2021-02-25 at 10 39 56 PM" src="https://user-images.githubusercontent.com/16461988/109134264-ba690800-77ba-11eb-9208-0e16f9ad2b0e.png">
