### PR TITLE
#374 firstInvalidPage handling

### DIFF
--- a/src/components/Application/ProgressBarNEW.tsx
+++ b/src/components/Application/ProgressBarNEW.tsx
@@ -29,13 +29,13 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, changePage, cur
       <List
         link
         style={{ paddingLeft: '50px' }}
-        items={Object.entries(pages).map(([pageName, { number, progress }]) => ({
+        items={Object.entries(pages).map(([number, { name: pageName, progress }]) => ({
           key: `ProgressSection_${sectionCode}_${number}`,
-          active: isActivePage(sectionCode, number),
+          active: isActivePage(sectionCode, Number(number)),
           as: 'a',
           icon: progress ? getIndicator(progress) : null,
           content: pageName,
-          onClick: () => changePage(sectionCode, number),
+          onClick: () => changePage(sectionCode, Number(number)),
         }))}
       />
     )

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -30,10 +30,9 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
     push,
   } = useRouter()
 
-  const currentSection = sectionCode
+  const pageNum = Number(page)
   const currentPage = `Page ${page}`
-  const currentSectionIndex = structure.sections[currentSection].details.index
-  const currentPageNumber = structure.sections[currentSection].pages[currentPage].number
+  const currentSectionIndex = structure.sections[sectionCode].details.index
 
   console.log('Structure', fullStructure)
 
@@ -47,20 +46,20 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
       push(`/applicationNEW/${structure.info.serial}/summary`)
 
     // Re-direct if trying to access page higher than allowed
-    if (!fullStructure.info.isLinear) return
-    const firstInvalidSectionIndex = fullStructure.info?.firstInvalidPageStrict?.sectionIndex
-    const firstInvalidPageNum = fullStructure.info?.firstInvalidPageStrict?.pageNumber
-    if (
-      firstInvalidSectionIndex != null &&
-      firstInvalidPageNum != null &&
-      (currentSectionIndex > firstInvalidSectionIndex ||
-        (currentSectionIndex >= firstInvalidSectionIndex &&
-          currentPageNumber > firstInvalidPageNum))
-    ) {
-      push(
-        `/applicationNEW/${structure.info.serial}/${structure.info.firstInvalidPageStrict?.sectionCode}/Page${structure.info.firstInvalidPageStrict?.pageNumber}`
-      )
-    }
+    // if (!fullStructure.info.isLinear) return
+    // const firstInvalidSectionIndex = fullStructure.info?.firstInvalidPageStrict?.sectionIndex
+    // const firstInvalidPageNum = fullStructure.info?.firstInvalidPageStrict?.pageNumber
+    // if (
+    //   firstInvalidSectionIndex != null &&
+    //   firstInvalidPageNum != null &&
+    //   (currentSectionIndex > firstInvalidSectionIndex ||
+    //     (currentSectionIndex >= firstInvalidSectionIndex &&
+    //       currentPageNumber > firstInvalidPageNum))
+    // ) {
+    //   push(
+    //     `/applicationNEW/${structure.info.serial}/${structure.info.firstInvalidPageStrict?.sectionCode}/Page${structure.info.firstInvalidPageStrict?.pageNumber}`
+    //   )
+    // }
   }, [structure, fullStructure, sectionCode, page])
 
   const handleChangeToPage = (sectionCode: string, pageNumber: number) => {
@@ -100,12 +99,12 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
         <Grid.Column width={10} stretched>
           <Segment basic>
             <Segment vertical style={{ marginBottom: 20 }}>
-              <Header content={fullStructure.sections[currentSection].details.title} />
+              <Header content={fullStructure.sections[sectionCode].details.title} />
               <PageElements
-                elements={getCurrentPageElements(fullStructure, currentSection, currentPage)}
+                elements={getCurrentPageElements(fullStructure, sectionCode, pageNum)}
                 responsesByCode={responsesByCode}
                 isStrictPage={
-                  currentSection === strictSectionPage?.section &&
+                  sectionCode === strictSectionPage?.section &&
                   currentPage === strictSectionPage?.page
                 }
                 isEditable
@@ -138,7 +137,7 @@ const NavigationBox: React.FC = () => {
 
 export default ApplicationPage
 
-const getCurrentPageElements = (structure: FullStructure, section: string, page: string) => {
+const getCurrentPageElements = (structure: FullStructure, section: string, page: number) => {
   return structure.sections[section].pages[page].state.map(
     (item) => item.element
   ) as ElementStateNEW[]

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -32,20 +32,36 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
 
   const currentSection = sectionCode
   const currentPage = `Page ${page}`
+  const currentSectionIndex = structure.sections[currentSection].details.index
+  const currentPageNumber = structure.sections[currentSection].pages[currentPage].number
 
   console.log('Structure', fullStructure)
 
   useEffect(() => {
-    if (!structure) return
+    if (!structure && !fullStructure) return
 
-    // Re-direct based on application status and progress
+    // Re-direct based on application status
     if (structure.info.current?.status === ApplicationStatus.ChangesRequired)
       push(`/applicationNEW/${structure.info.serial}`)
     if (structure.info.current?.status !== ApplicationStatus.Draft)
       push(`/applicationNEW/${structure.info.serial}/summary`)
 
-    // TO-DO: Redirect based on Progress (wait till Progress calculation is done)
-  }, [structure])
+    // Re-direct if trying to access page higher than allowed
+    if (!structure.info.isLinear) return
+    const firstInvalidSectionIndex = structure.info?.firstInvalidPageStrict?.sectionIndex
+    const firstInvalidPageNum = structure.info?.firstInvalidPageStrict?.pageNumber
+    if (
+      firstInvalidSectionIndex != null &&
+      firstInvalidPageNum != null &&
+      (currentSectionIndex > firstInvalidSectionIndex ||
+        (currentSectionIndex >= firstInvalidSectionIndex &&
+          currentPageNumber > firstInvalidPageNum))
+    ) {
+      push(
+        `/applicationNEW/${structure.info.serial}/${structure.info.firstInvalidPageStrict?.sectionCode}/Page${structure.info.firstInvalidPageStrict?.pageNumber}`
+      )
+    }
+  }, [structure, fullStructure])
 
   const handleChangeToPage = (sectionCode: string, pageNumber: number) => {
     if (!structure.info.isLinear)

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -61,7 +61,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
         `/applicationNEW/${structure.info.serial}/${structure.info.firstInvalidPageStrict?.sectionCode}/Page${structure.info.firstInvalidPageStrict?.pageNumber}`
       )
     }
-  }, [structure, fullStructure])
+  }, [structure, fullStructure, sectionCode, page])
 
   const handleChangeToPage = (sectionCode: string, pageNumber: number) => {
     if (!structure.info.isLinear)

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -31,8 +31,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
   } = useRouter()
 
   const pageNum = Number(page)
-  const currentPage = `Page ${page}`
-  const currentSectionIndex = structure.sections[sectionCode].details.index
+  const sectionIndex = structure.sections[sectionCode].details.index
 
   console.log('Structure', fullStructure)
 
@@ -46,20 +45,21 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
       push(`/applicationNEW/${structure.info.serial}/summary`)
 
     // Re-direct if trying to access page higher than allowed
-    // if (!fullStructure.info.isLinear) return
-    // const firstInvalidSectionIndex = fullStructure.info?.firstInvalidPageStrict?.sectionIndex
-    // const firstInvalidPageNum = fullStructure.info?.firstInvalidPageStrict?.pageNumber
-    // if (
-    //   firstInvalidSectionIndex != null &&
-    //   firstInvalidPageNum != null &&
-    //   (currentSectionIndex > firstInvalidSectionIndex ||
-    //     (currentSectionIndex >= firstInvalidSectionIndex &&
-    //       currentPageNumber > firstInvalidPageNum))
-    // ) {
-    //   push(
-    //     `/applicationNEW/${structure.info.serial}/${structure.info.firstInvalidPageStrict?.sectionCode}/Page${structure.info.firstInvalidPageStrict?.pageNumber}`
-    //   )
-    // }
+    if (!fullStructure.info.isLinear || !fullStructure.info?.firstIncompletePage) return
+    const {
+      sectionCode: firstIncompleteSectionCode,
+      pageNumber: firstIncompletePageNum,
+    } = fullStructure.info?.firstIncompletePage
+    const firstIncompleteSectionIndex =
+      fullStructure.sections[firstIncompleteSectionCode].details.index
+    if (
+      sectionIndex > firstIncompleteSectionIndex ||
+      (sectionIndex >= firstIncompleteSectionIndex && pageNum > firstIncompletePageNum)
+    ) {
+      push(
+        `/applicationNEW/${structure.info.serial}/${firstIncompleteSectionCode}/Page${firstIncompletePageNum}`
+      )
+    }
   }, [structure, fullStructure, sectionCode, page])
 
   const handleChangeToPage = (sectionCode: string, pageNumber: number) => {
@@ -104,8 +104,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
                 elements={getCurrentPageElements(fullStructure, sectionCode, pageNum)}
                 responsesByCode={responsesByCode}
                 isStrictPage={
-                  sectionCode === strictSectionPage?.section &&
-                  currentPage === strictSectionPage?.page
+                  sectionCode === strictSectionPage?.section && pageNum === strictSectionPage?.page
                 }
                 isEditable
               />

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -38,18 +38,18 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
   console.log('Structure', fullStructure)
 
   useEffect(() => {
-    if (!structure && !fullStructure) return
+    if (!fullStructure) return
 
     // Re-direct based on application status
-    if (structure.info.current?.status === ApplicationStatus.ChangesRequired)
-      push(`/applicationNEW/${structure.info.serial}`)
+    if (fullStructure.info.current?.status === ApplicationStatus.ChangesRequired)
+      push(`/applicationNEW/${fullStructure.info.serial}`)
     if (structure.info.current?.status !== ApplicationStatus.Draft)
       push(`/applicationNEW/${structure.info.serial}/summary`)
 
     // Re-direct if trying to access page higher than allowed
-    if (!structure.info.isLinear) return
-    const firstInvalidSectionIndex = structure.info?.firstInvalidPageStrict?.sectionIndex
-    const firstInvalidPageNum = structure.info?.firstInvalidPageStrict?.pageNumber
+    if (!fullStructure.info.isLinear) return
+    const firstInvalidSectionIndex = fullStructure.info?.firstInvalidPageStrict?.sectionIndex
+    const firstInvalidPageNum = fullStructure.info?.firstInvalidPageStrict?.pageNumber
     if (
       firstInvalidSectionIndex != null &&
       firstInvalidPageNum != null &&

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -42,7 +42,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
     if (fullStructure.info.current?.status === ApplicationStatus.ChangesRequired)
       push(`/applicationNEW/${fullStructure.info.serial}`)
     if (structure.info.current?.status !== ApplicationStatus.Draft)
-      push(`/applicationNEW/${structure.info.serial}/summary`)
+      push(`/applicationNEW/${fullStructure.info.serial}/summary`)
 
     // Re-direct if trying to access page higher than allowed
     if (!fullStructure.info.isLinear || !fullStructure.info?.firstIncompletePage) return

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -1618,6 +1618,7 @@ export enum Trigger {
   OnReviewSubmit = 'ON_REVIEW_SUBMIT',
   OnReviewStart = 'ON_REVIEW_START',
   OnReviewAssign = 'ON_REVIEW_ASSIGN',
+  OnReviewSelfAssign = 'ON_REVIEW_SELF_ASSIGN',
   OnApprovalSubmit = 'ON_APPROVAL_SUBMIT',
   OnScheduleTime = 'ON_SCHEDULE_TIME',
   Processing = 'PROCESSING',
@@ -2499,7 +2500,7 @@ export type ReviewAssignmentStatusFilter = {
 
 export enum ReviewAssignmentStatus {
   Available = 'AVAILABLE',
-  NotAvailable = 'NOT_AVAILABLE',
+  SelfAssignedByAnother = 'SELF_ASSIGNED_BY_ANOTHER',
   Assigned = 'ASSIGNED',
   AvailableForSelfAssignment = 'AVAILABLE_FOR_SELF_ASSIGNMENT'
 }
@@ -4522,7 +4523,7 @@ export type ReviewAssignment = Node & {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status?: Maybe<ReviewAssignmentStatus>;
+  status: ReviewAssignmentStatus;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -13462,7 +13463,7 @@ export type ReviewQuestionAssignmentReviewAssignmentIdFkeyReviewAssignmentCreate
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status?: Maybe<ReviewAssignmentStatus>;
+  status: ReviewAssignmentStatus;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -13964,7 +13965,7 @@ export type ReviewReviewAssignmentIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status?: Maybe<ReviewAssignmentStatus>;
+  status: ReviewAssignmentStatus;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14058,7 +14059,7 @@ export type ReviewAssignmentStageIdFkeyReviewAssignmentCreateInput = {
   reviewerId?: Maybe<Scalars['Int']>;
   organisationId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status?: Maybe<ReviewAssignmentStatus>;
+  status: ReviewAssignmentStatus;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14317,7 +14318,7 @@ export type ReviewAssignmentOrganisationIdFkeyReviewAssignmentCreateInput = {
   reviewerId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status?: Maybe<ReviewAssignmentStatus>;
+  status: ReviewAssignmentStatus;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14387,7 +14388,7 @@ export type ReviewAssignmentReviewerIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status?: Maybe<ReviewAssignmentStatus>;
+  status: ReviewAssignmentStatus;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14452,7 +14453,7 @@ export type ReviewAssignmentAssignerIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status?: Maybe<ReviewAssignmentStatus>;
+  status: ReviewAssignmentStatus;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
@@ -14518,7 +14519,7 @@ export type ReviewAssignmentApplicationIdFkeyReviewAssignmentCreateInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status?: Maybe<ReviewAssignmentStatus>;
+  status: ReviewAssignmentStatus;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;
   timeCreated?: Maybe<Scalars['Datetime']>;
@@ -16308,7 +16309,7 @@ export type ReviewAssignmentInput = {
   organisationId?: Maybe<Scalars['Int']>;
   stageId?: Maybe<Scalars['Int']>;
   stageNumber?: Maybe<Scalars['Int']>;
-  status?: Maybe<ReviewAssignmentStatus>;
+  status: ReviewAssignmentStatus;
   applicationId?: Maybe<Scalars['Int']>;
   templateSectionRestrictions?: Maybe<Array<Maybe<Scalars['String']>>>;
   trigger?: Maybe<Trigger>;

--- a/src/utils/helpers/structure/buildSectionsStructureNEW.ts
+++ b/src/utils/helpers/structure/buildSectionsStructureNEW.ts
@@ -34,7 +34,7 @@ export const buildSectionsStructure = ({
       const state = elements.map((element) => ({ element }))
 
       const pageName = `Page ${pageNumber}`
-      return { ...pages, [pageName]: { number: pageNumber, state } }
+      return { ...pages, [pageNumber]: { name: pageName, number: pageNumber, state } }
     }, {})
 
     return {

--- a/src/utils/helpers/structure/generateProgress.ts
+++ b/src/utils/helpers/structure/generateProgress.ts
@@ -37,9 +37,6 @@ const getSectionProgress = (pages: PageNEW[]): Progress =>
   )
 
 export const generateResponsesProgress = (structure: FullStructure) => {
-  let firstInvalidSectionCode = ''
-  let firstInvalidSectionIndex = Infinity
-  let firstInvalidPageInSection = Infinity
   let firstInvalidSectionCodeStrict = ''
   let firstInvalidSectionIndexStrict = Infinity
   let firstInvalidPageInSectionStrict = Infinity
@@ -69,20 +66,9 @@ export const generateResponsesProgress = (structure: FullStructure) => {
           )
         })
       if (
-        !page.progress.valid &&
-        section.details.index <= firstInvalidSectionIndex &&
-        page.number < firstInvalidPageInSection
-      ) {
-        firstInvalidPageInSection = page.number
-        firstInvalidSectionIndex = section.details.index
-        firstInvalidSectionCode = section.details.code
-        firstInvalidPageInSectionStrict = page.number
-        firstInvalidSectionIndexStrict = section.details.index
-        firstInvalidSectionCodeStrict = section.details.code
-      } else if (
-        page.progress.doneRequired < page.progress.totalRequired &&
         section.details.index <= firstInvalidSectionIndexStrict &&
-        page.number < firstInvalidPageInSectionStrict
+        page.number < firstInvalidPageInSectionStrict &&
+        (!page.progress.valid || page.progress.doneRequired < page.progress.totalRequired)
       ) {
         firstInvalidPageInSectionStrict = page.number
         firstInvalidSectionIndexStrict = section.details.index
@@ -91,14 +77,6 @@ export const generateResponsesProgress = (structure: FullStructure) => {
     })
     section.progress = getSectionProgress(Object.values(section.pages))
   })
-  structure.info.firstInvalidPage = firstInvalidSectionCode
-    ? {
-        sectionCode: firstInvalidSectionCode,
-        pageName: `Page ${firstInvalidPageInSection}`,
-        sectionIndex: firstInvalidSectionIndex,
-        pageNumber: firstInvalidPageInSection,
-      }
-    : null
   structure.info.firstInvalidPageStrict = firstInvalidSectionCodeStrict
     ? {
         sectionCode: firstInvalidSectionCodeStrict,

--- a/src/utils/helpers/structure/generateProgress.ts
+++ b/src/utils/helpers/structure/generateProgress.ts
@@ -1,12 +1,5 @@
 import { TemplateElementCategory } from '../../generated/graphql'
-import {
-  ElementStateNEW,
-  FullStructure,
-  PageNEW,
-  Progress,
-  SectionAndPage,
-  SectionStateNEW,
-} from '../../types'
+import { ElementStateNEW, FullStructure, PageNEW, Progress } from '../../types'
 
 const initialProgress = {
   doneNonRequired: 0,
@@ -99,12 +92,19 @@ export const generateResponsesProgress = (structure: FullStructure) => {
     section.progress = getSectionProgress(Object.values(section.pages))
   })
   structure.info.firstInvalidPage = firstInvalidSectionCode
-    ? { sectionCode: firstInvalidSectionCode, pageName: `Page ${firstInvalidPageInSection}` }
+    ? {
+        sectionCode: firstInvalidSectionCode,
+        pageName: `Page ${firstInvalidPageInSection}`,
+        sectionIndex: firstInvalidSectionIndex,
+        pageNumber: firstInvalidPageInSection,
+      }
     : null
   structure.info.firstInvalidPageStrict = firstInvalidSectionCodeStrict
     ? {
         sectionCode: firstInvalidSectionCodeStrict,
         pageName: `Page ${firstInvalidPageInSectionStrict}`,
+        sectionIndex: firstInvalidSectionIndexStrict,
+        pageNumber: firstInvalidPageInSectionStrict,
       }
     : null
 }

--- a/src/utils/helpers/structure/generateProgress.ts
+++ b/src/utils/helpers/structure/generateProgress.ts
@@ -9,6 +9,7 @@ const initialProgress = {
   totalRequired: 0,
   totalSum: 0,
   valid: true,
+  firstIncompletePage: Infinity,
 }
 
 const calculateCompleted = (totalSum: number, doneRequired: number, doneNonRequired: number) => {
@@ -16,9 +17,9 @@ const calculateCompleted = (totalSum: number, doneRequired: number, doneNonRequi
   return totalSum === totalDone
 }
 
-const getSectionProgress = (pages: PageNEW[]): Progress =>
-  pages.reduce(
-    (sectionProgress: Progress, { progress }) => {
+const getSectionProgress = (pages: PageNEW[]): Progress => {
+  const sectionProgress = pages.reduce(
+    (sectionProgress: Progress, { number, progress }) => {
       if (!progress) return sectionProgress
       sectionProgress.doneNonRequired += progress.doneNonRequired || 0
       sectionProgress.totalNonRequired += progress.totalNonRequired || 0
@@ -31,27 +32,38 @@ const getSectionProgress = (pages: PageNEW[]): Progress =>
         sectionProgress.doneNonRequired
       )
       if (!progress.valid) sectionProgress.valid = false
+      if (
+        sectionProgress.firstIncompletePage &&
+        number < sectionProgress.firstIncompletePage &&
+        (!progress.valid || progress.doneRequired < progress.totalRequired)
+      )
+        sectionProgress.firstIncompletePage = number
       return sectionProgress
     },
     { ...initialProgress }
   )
+  if (sectionProgress.firstIncompletePage === Infinity) sectionProgress.firstIncompletePage = null
+  return sectionProgress
+}
 
 export const generateResponsesProgress = (structure: FullStructure) => {
-  let firstInvalidSectionCodeStrict = ''
-  let firstInvalidSectionIndexStrict = Infinity
-  let firstInvalidPageInSectionStrict = Infinity
+  let firstIncompleteSectionCode = ''
+  let firstIncompleteSectionIndex = Infinity
+  let firstIncompletePageInSection = Infinity
+  let firstIncompletePageThisSection = Infinity
   const updateFirstInvalid = (section: SectionStateNEW, page: PageNEW) => {
     if (
-      section.details.index <= firstInvalidSectionIndexStrict &&
-      page.number < firstInvalidPageInSectionStrict &&
+      section.details.index <= firstIncompleteSectionIndex &&
+      page.number < firstIncompletePageInSection &&
       (!page.progress.valid || page.progress.doneRequired < page.progress.totalRequired)
     ) {
-      firstInvalidPageInSectionStrict = page.number
-      firstInvalidSectionIndexStrict = section.details.index
-      firstInvalidSectionCodeStrict = section.details.code
+      firstIncompletePageInSection = page.number
+      firstIncompleteSectionIndex = section.details.index
+      firstIncompleteSectionCode = section.details.code
     }
   }
   Object.values(structure.sections).forEach((section) => {
+    firstIncompletePageThisSection = Infinity
     Object.values(section.pages).forEach((page) => {
       page.progress = { ...initialProgress }
       page.state
@@ -80,12 +92,12 @@ export const generateResponsesProgress = (structure: FullStructure) => {
     })
     section.progress = getSectionProgress(Object.values(section.pages))
   })
-  structure.info.firstInvalidPageStrict = firstInvalidSectionCodeStrict
+  structure.info.firstIncompletePage = firstIncompleteSectionCode
     ? {
-        sectionCode: firstInvalidSectionCodeStrict,
-        pageName: `Page ${firstInvalidPageInSectionStrict}`,
-        sectionIndex: firstInvalidSectionIndexStrict,
-        pageNumber: firstInvalidPageInSectionStrict,
+        sectionCode: firstIncompleteSectionCode,
+        pageName: `Page ${firstIncompletePageInSection}`,
+        sectionIndex: firstIncompleteSectionIndex,
+        pageNumber: firstIncompletePageInSection,
       }
     : null
 }

--- a/src/utils/helpers/structure/generateProgress.ts
+++ b/src/utils/helpers/structure/generateProgress.ts
@@ -50,7 +50,6 @@ export const generateResponsesProgress = (structure: FullStructure) => {
   let firstIncompleteSectionCode = ''
   let firstIncompleteSectionIndex = Infinity
   let firstIncompletePageInSection = Infinity
-  let firstIncompletePageThisSection = Infinity
   const updateFirstInvalid = (section: SectionStateNEW, page: PageNEW) => {
     if (
       section.details.index <= firstIncompleteSectionIndex &&
@@ -63,7 +62,6 @@ export const generateResponsesProgress = (structure: FullStructure) => {
     }
   }
   Object.values(structure.sections).forEach((section) => {
-    firstIncompletePageThisSection = Infinity
     Object.values(section.pages).forEach((page) => {
       page.progress = { ...initialProgress }
       page.state
@@ -95,8 +93,6 @@ export const generateResponsesProgress = (structure: FullStructure) => {
   structure.info.firstIncompletePage = firstIncompleteSectionCode
     ? {
         sectionCode: firstIncompleteSectionCode,
-        pageName: `Page ${firstIncompletePageInSection}`,
-        sectionIndex: firstIncompleteSectionIndex,
         pageNumber: firstIncompletePageInSection,
       }
     : null

--- a/src/utils/hooks/useGetFullApplicationStructure.tsx
+++ b/src/utils/hooks/useGetFullApplicationStructure.tsx
@@ -204,7 +204,7 @@ const flattenStructureElements = (structure: FullStructure) => {
   const flattened: any = []
   Object.keys(structure.sections).forEach((section) => {
     Object.keys(structure.sections[section].pages).forEach((page) => {
-      flattened.push(...structure.sections[section].pages[page].state)
+      flattened.push(...structure.sections[section].pages[Number(page)].state)
     })
   })
   return flattened

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -93,7 +93,7 @@ interface ApplicationDetails {
   outcome: string
   isLinear: boolean
   current?: StageAndStatus // TODO: Change to compulsory after re-strcture is finished
-  firstInvalidPageStrict?: SectionAndPage | null
+  firstIncompletePage?: SectionAndPage | null
 }
 
 interface ApplicationElementStates {
@@ -250,6 +250,7 @@ type PageElements = {
 
 interface PageNEW {
   number: number
+  name: string
   progress: Progress
   state: PageElement[]
 }
@@ -272,6 +273,7 @@ interface Progress {
   totalNonRequired: number
   totalSum: number
   valid: boolean
+  firstIncompletePage: number | null
 }
 
 type ProgressStatus = 'VALID' | 'NOT_VALID' | 'INCOMPLETE'
@@ -359,7 +361,7 @@ interface SectionStateNEW {
   progress?: Progress
   assigned?: ReviewerDetails
   pages: {
-    [pageName: string]: PageNEW
+    [pageNum: number]: PageNEW
   }
 }
 interface SectionsStructureNEW {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -93,7 +93,6 @@ interface ApplicationDetails {
   outcome: string
   isLinear: boolean
   current?: StageAndStatus // TODO: Change to compulsory after re-strcture is finished
-  firstInvalidPage?: SectionAndPage | null
   firstInvalidPageStrict?: SectionAndPage | null
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -485,4 +485,9 @@ interface SortQuery {
   sortDirection?: 'ascending' | 'descending'
 }
 
-type SectionAndPage = { sectionCode: string; pageName: string } | null
+type SectionAndPage = {
+  sectionCode: string
+  pageName: string
+  sectionIndex?: number
+  pageNumber?: number
+} | null

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -82,6 +82,7 @@ export {
   LoginPayload,
   BasicStringObject,
   SortQuery,
+  SectionAndPage,
 }
 
 interface ApplicationDetails {
@@ -92,6 +93,8 @@ interface ApplicationDetails {
   outcome: string
   isLinear: boolean
   current?: StageAndStatus // TODO: Change to compulsory after re-strcture is finished
+  firstInvalidPage?: SectionAndPage | null
+  firstInvalidPageStrict?: SectionAndPage | null
 }
 
 interface ApplicationElementStates {
@@ -354,7 +357,6 @@ interface SectionsStructure {
 }
 interface SectionStateNEW {
   details: SectionDetails
-  invalidPage?: number
   progress?: Progress
   assigned?: ReviewerDetails
   pages: {
@@ -482,3 +484,5 @@ interface SortQuery {
   sortColumn?: string
   sortDirection?: 'ascending' | 'descending'
 }
+
+type SectionAndPage = { sectionCode: string; pageName: string } | null

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -488,7 +488,5 @@ interface SortQuery {
 
 type SectionAndPage = {
   sectionCode: string
-  pageName: string
-  sectionIndex?: number
-  pageNumber?: number
+  pageNumber: number
 } | null


### PR DESCRIPTION
Implement #374 with re-direction on ApplicationPage.

Couple of comments:

- am calculating `firstInvalidPage` and `firstInvalidPageStrict`, but I think we really only want the "strict" value -- any re-directs are going to be based on strict, right? Let me know if you think we can remove the non-strict one
- Calulated these values during the iteration over the pages rather than a new function
- Removed the `invalidPage` field from .progress -- after discussion with Nicole, we don't really need to know the first invalid page for each section.
- Added a check on ApplicationPage -- will re-direct you if you attempt to load a page beyond your current valid one (in linear mode).
- It will work to have all buttons link to whatever page,then have this function re-direct, but it's a bit ugly. So the buttons will still need to have their own logic before pushing to the new URL