### PR TITLE
polish of validation and progress bar logic

### DIFF
--- a/src/components/Application/ProgressBarNEW.tsx
+++ b/src/components/Application/ProgressBarNEW.tsx
@@ -46,6 +46,7 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({
     // display current page with strict validation
     requestRevalidation(({ firstStrictInvalidPage, setStrictSectionPage }: MethodToCallProps) => {
       if (!firstStrictInvalidPage) {
+        setStrictSectionPage(null)
         push(`/applicationNEW/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
         return
       }
@@ -55,9 +56,10 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({
           firstIncomplete: firstStrictInvalidPage,
           current: { sectionCode, pageNumber },
         })
-      )
+      ) {
+        setStrictSectionPage(null)
         push(`/applicationNEW/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
-      else {
+      } else {
         setStrictSectionPage(firstStrictInvalidPage)
         push(
           `/applicationNEW/${structure.info.serial}/${firstStrictInvalidPage.sectionCode}/Page${firstStrictInvalidPage.pageNumber}`

--- a/src/components/Application/ProgressBarNEW.tsx
+++ b/src/components/Application/ProgressBarNEW.tsx
@@ -71,13 +71,13 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({
   const getPageList = (
     sectionCode: string,
     pages: { [pageNumber: string]: PageNEW },
-    isIsStrictSection: boolean
+    isStrictSection: boolean
   ) => {
     const isActivePage = (sectionCode: string, pageNumber: number) =>
       currentSectionCode === sectionCode && Number(page) === pageNumber
 
     const checkPageIsStrict = (pageNumber: string) =>
-      isIsStrictSection && strictSectionPage?.pageNumber === Number(pageNumber)
+      isStrictSection && strictSectionPage?.pageNumber === Number(pageNumber)
 
     return (
       <List
@@ -117,7 +117,7 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({
   }
 
   const sectionsList = Object.values(sections).map(({ details, progress, pages }, index) => {
-    const isIsStrictSection = !!strictSectionPage && strictSectionPage.sectionCode === details.code
+    const isStrictSection = !!strictSectionPage && strictSectionPage.sectionCode === details.code
 
     const stepNumber = index + 1
     const { code, title } = details
@@ -127,7 +127,7 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({
         children: (
           <Grid>
             <Grid.Column width={4} textAlign="right" verticalAlign="middle">
-              {progress && getIndicator(progress, isIsStrictSection, stepNumber)}
+              {progress && getIndicator(progress, isStrictSection, stepNumber)}
             </Grid.Column>
             <Grid.Column width={12} textAlign="left" verticalAlign="middle">
               <Header as="h4">{title}</Header>
@@ -143,7 +143,7 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({
       },
       onTitleClick: () => handleChangeToPage(code, 1),
       content: {
-        content: getPageList(code, pages, isIsStrictSection),
+        content: getPageList(code, pages, isStrictSection),
       },
     }
   })

--- a/src/components/Application/ProgressBarNEW.tsx
+++ b/src/components/Application/ProgressBarNEW.tsx
@@ -9,14 +9,20 @@ import {
   MethodToCallProps,
   PageNEW,
   Progress,
+  SectionAndPage,
 } from '../../utils/types'
 
 interface ProgressBarProps {
   structure: FullStructure
   requestRevalidation: MethodRevalidate
+  strictSectionPage: SectionAndPage | null
 }
 
-const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, requestRevalidation }) => {
+const ProgressBarNEW: React.FC<ProgressBarProps> = ({
+  structure,
+  requestRevalidation,
+  strictSectionPage,
+}) => {
   const {
     info: { isLinear },
     sections,
@@ -31,28 +37,45 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, requestRevalida
     Object.values(sections).findIndex(({ details }) => details.code === currentSectionCode) || 0
 
   const handleChangeToPage = (sectionCode: string, pageNumber: number) => {
-    if (!structure.info.isLinear)
+    if (!isLinear) {
       push(`/applicationNEW/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
+      return
+    }
 
     // Use validationMethod to check if can change to page (on linear application) OR
     // display current page with strict validation
-    requestRevalidation(({ firstIncompletePage, setStrictSectionPage }: MethodToCallProps) => {
+    requestRevalidation(({ firstStrictInvalidPage, setStrictSectionPage }: MethodToCallProps) => {
+      if (!firstStrictInvalidPage) {
+        push(`/applicationNEW/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
+        return
+      }
       if (
-        firstIncompletePage &&
         checkPageIsAccessible({
           fullStructure: structure,
-          firstIncomplete: firstIncompletePage,
+          firstIncomplete: firstStrictInvalidPage,
           current: { sectionCode, pageNumber },
         })
-      ) {
+      )
         push(`/applicationNEW/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
-      } else setStrictSectionPage(firstIncompletePage)
+      else {
+        setStrictSectionPage(firstStrictInvalidPage)
+        push(
+          `/applicationNEW/${structure.info.serial}/${firstStrictInvalidPage.sectionCode}/Page${firstStrictInvalidPage.pageNumber}`
+        )
+      }
     })
   }
 
-  const getPageList = (sectionCode: string, pages: { [pageNumber: string]: PageNEW }) => {
+  const getPageList = (
+    sectionCode: string,
+    pages: { [pageNumber: string]: PageNEW },
+    isIsStrictSection: boolean
+  ) => {
     const isActivePage = (sectionCode: string, pageNumber: number) =>
       currentSectionCode === sectionCode && Number(page) === pageNumber
+
+    const checkPageIsStrict = (pageNumber: string) =>
+      isIsStrictSection && strictSectionPage?.pageNumber === Number(pageNumber)
 
     return (
       <List
@@ -62,7 +85,7 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, requestRevalida
           key: `ProgressSection_${sectionCode}_${number}`,
           active: isActivePage(sectionCode, Number(number)),
           as: 'a',
-          icon: progress ? getIndicator(progress) : null,
+          icon: progress ? getIndicator(progress, checkPageIsStrict(number)) : null,
           content: pageName,
           onClick: () => handleChangeToPage(sectionCode, Number(number)),
         }))}
@@ -70,9 +93,11 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, requestRevalida
     )
   }
 
-  const getIndicator = (progress: Progress, step?: number) => {
+  const getIndicator = (progress: Progress, isStrict: boolean, step?: number) => {
     const { completed, valid } = progress
-    if (!completed)
+    const isStrictlylInvalid = !valid || (isStrict && !completed)
+
+    if (!completed && !isStrict)
       return step ? (
         <Label circular as="a" basic color="blue" key={`progress_${step}`}>
           {step}
@@ -82,14 +107,16 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, requestRevalida
       )
     return (
       <Icon
-        name={valid ? 'check circle' : 'exclamation circle'}
-        color={valid ? 'green' : 'red'}
+        name={isStrictlylInvalid ? 'exclamation circle' : 'check circle'}
+        color={isStrictlylInvalid ? 'red' : 'green'}
         size={step ? 'large' : 'small'}
       />
     )
   }
 
   const sectionsList = Object.values(sections).map(({ details, progress, pages }, index) => {
+    const isIsStrictSection = !!strictSectionPage && strictSectionPage.sectionCode === details.code
+
     const stepNumber = index + 1
     const { code, title } = details
     return {
@@ -98,7 +125,7 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, requestRevalida
         children: (
           <Grid>
             <Grid.Column width={4} textAlign="right" verticalAlign="middle">
-              {progress && getIndicator(progress, stepNumber)}
+              {progress && getIndicator(progress, isIsStrictSection, stepNumber)}
             </Grid.Column>
             <Grid.Column width={12} textAlign="left" verticalAlign="middle">
               <Header as="h4">{title}</Header>
@@ -114,7 +141,7 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({ structure, requestRevalida
       },
       onTitleClick: () => handleChangeToPage(code, 1),
       content: {
-        content: getPageList(code, pages),
+        content: getPageList(code, pages, isIsStrictSection),
       },
     }
   })

--- a/src/contexts/FormElementUpdateTrackerState.tsx
+++ b/src/contexts/FormElementUpdateTrackerState.tsx
@@ -1,12 +1,15 @@
 import React, { createContext, useContext, useReducer } from 'react'
 import { ContextFormElementUpdateTrackerState } from '../utils/types'
 
-type TimestampType = 'elementEnteredTimestamp' | 'elementUpdatedTimestamp'
-
-export type UpdateAction = {
-  type: 'setElementTimestamp'
-  timestampType: TimestampType
-}
+export type UpdateAction =
+  | {
+      type: 'setElementEntered'
+      textValue: string
+    }
+  | {
+      type: 'setElementUpdated'
+      textValue: string
+    }
 
 type FormElementUpdateTrackerProps = { children: React.ReactNode }
 
@@ -15,14 +18,31 @@ type FormElementUpdateTrackerProps = { children: React.ReactNode }
 // straight away
 const reducer = (state: ContextFormElementUpdateTrackerState, action: UpdateAction) => {
   switch (action.type) {
-    case 'setElementTimestamp':
-      const newState = { ...state, [action.timestampType]: Date.now() }
-
+    case 'setElementUpdated': {
+      const newState = {
+        ...state,
+        elementUpdatedTimestamp: Date.now(),
+        elementUpdatedTextValue: action.textValue,
+      }
       return {
         ...newState,
         isLastElementUpdateProcessed:
-          newState.elementEnteredTimestamp <= newState.elementUpdatedTimestamp,
+          newState.elementUpdatedTimestamp >= newState.elementEnteredTimestamp,
+        wasValueChange: newState.elementUpdatedTextValue !== newState.elementEnteredTextValue,
       }
+    }
+    case 'setElementEntered': {
+      const newState = {
+        ...state,
+        elementEnteredTimestamp: Date.now(),
+        elementEnteredTextValue: action.textValue,
+      }
+
+      return {
+        ...newState,
+        isLastElementUpdateProcessed: false,
+      }
+    }
     default:
       return state
   }
@@ -32,6 +52,9 @@ const initialState: ContextFormElementUpdateTrackerState = {
   isLastElementUpdateProcessed: true,
   elementEnteredTimestamp: Date.now(),
   elementUpdatedTimestamp: Date.now(),
+  elementEnteredTextValue: '',
+  elementUpdatedTextValue: '',
+  wasElementChange: false,
 }
 
 // By setting the typings here, we ensure we get intellisense in VS Code

--- a/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
@@ -216,9 +216,7 @@ const calculateValidationState = async ({
   const validationResult = validationExpression
     ? await validate(validationExpression, validationMessage as string, evaluationParameters)
     : { isValid: true }
-  console.log(responses, isRequired && isStrictPage && !responses?.thisResponse, {
-    validationMessage: validationMessage || strings.VALIDATION_REQUIRED_ERROR,
-  })
+
   if (!validationResult.isValid) return validationResult
   // !responses.thisResponse, check for null, undefined, empty string
   if (isRequired && isStrictPage && !responses?.thisResponse)

--- a/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
@@ -70,7 +70,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperPropsNEW> = (props)
 
   useEffect(() => {
     onUpdate(currentResponse?.text)
-  }, [currentResponse])
+  }, [currentResponse, isStrictPage])
 
   const onUpdate = async (value: LooseString) => {
     const responses = { thisResponse: value, ...allResponses }
@@ -99,8 +99,8 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperPropsNEW> = (props)
           },
         })
       setUpdateTrackerState({
-        type: 'setElementTimestamp',
-        timestampType: 'elementUpdatedTimestamp',
+        type: 'setElementUpdated',
+        textValue: jsonValue?.text || '',
       })
     } else {
       // Save response for plugins with internal validation
@@ -115,8 +115,8 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperPropsNEW> = (props)
         },
       })
       setUpdateTrackerState({
-        type: 'setElementTimestamp',
-        timestampType: 'elementUpdatedTimestamp',
+        type: 'setElementUpdated',
+        textValue: jsonValue?.text || '',
       })
     }
   }
@@ -124,8 +124,8 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperPropsNEW> = (props)
   const setIsActive = () => {
     // Tells application state that a plugin field is in focus
     setUpdateTrackerState({
-      type: 'setElementTimestamp',
-      timestampType: 'elementEnteredTimestamp',
+      type: 'setElementUpdated',
+      textValue: value || '',
     })
   }
 
@@ -217,11 +217,8 @@ const calculateValidationState = async ({
     ? await validate(validationExpression, validationMessage as string, evaluationParameters)
     : { isValid: true }
   if (!validationResult.isValid) return validationResult
-  if (
-    isRequired &&
-    isStrictPage &&
-    (responses.thisResponse === undefined || responses.thisResponse === null)
-  )
+  // !responses.thisResponse, check for null, undefined, empty string
+  if (isRequired && isStrictPage && !responses.thisResponse)
     return {
       isValid: false,
       validationMessage: validationMessage || strings.VALIDATION_REQUIRED_ERROR,

--- a/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
@@ -216,9 +216,12 @@ const calculateValidationState = async ({
   const validationResult = validationExpression
     ? await validate(validationExpression, validationMessage as string, evaluationParameters)
     : { isValid: true }
+  console.log(responses, isRequired && isStrictPage && !responses?.thisResponse, {
+    validationMessage: validationMessage || strings.VALIDATION_REQUIRED_ERROR,
+  })
   if (!validationResult.isValid) return validationResult
   // !responses.thisResponse, check for null, undefined, empty string
-  if (isRequired && isStrictPage && !responses.thisResponse)
+  if (isRequired && isStrictPage && !responses?.thisResponse)
     return {
       isValid: false,
       validationMessage: validationMessage || strings.VALIDATION_REQUIRED_ERROR,

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react'
-import { Dropdown, Header } from 'semantic-ui-react'
+import { Dropdown, Header, Label } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
@@ -53,7 +53,20 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         onChange={handleChange}
         value={value}
         disabled={!isEditable}
+        error={
+          !validationState.isValid
+            ? {
+                content: validationState?.validationMessage,
+                pointing: 'above',
+              }
+            : null
+        }
       />
+      {validationState.isValid ? null : (
+        <Label basic color="red" pointing>
+          {validationState?.validationMessage}
+        </Label>
+      )}
     </>
   )
 }

--- a/src/utils/helpers/structure/generateProgress.ts
+++ b/src/utils/helpers/structure/generateProgress.ts
@@ -9,7 +9,7 @@ const initialProgress = {
   totalRequired: 0,
   totalSum: 0,
   valid: true,
-  firstIncompletePage: Infinity,
+  firstStrictInvalidPage: Infinity,
 }
 
 const calculateCompleted = (totalSum: number, doneRequired: number, doneNonRequired: number) => {
@@ -33,30 +33,31 @@ const getSectionProgress = (pages: PageNEW[]): Progress => {
       )
       if (!progress.valid) sectionProgress.valid = false
       if (
-        sectionProgress.firstIncompletePage &&
-        number < sectionProgress.firstIncompletePage &&
+        sectionProgress.firstStrictInvalidPage &&
+        number < sectionProgress.firstStrictInvalidPage &&
         (!progress.valid || progress.doneRequired < progress.totalRequired)
       )
-        sectionProgress.firstIncompletePage = number
+        sectionProgress.firstStrictInvalidPage = number
       return sectionProgress
     },
     { ...initialProgress }
   )
-  if (sectionProgress.firstIncompletePage === Infinity) sectionProgress.firstIncompletePage = null
+  if (sectionProgress.firstStrictInvalidPage === Infinity)
+    sectionProgress.firstStrictInvalidPage = null
   return sectionProgress
 }
 
 export const generateResponsesProgress = (structure: FullStructure) => {
   let firstIncompleteSectionCode = ''
   let firstIncompleteSectionIndex = Infinity
-  let firstIncompletePageInSection = Infinity
+  let firstStrictInvalidPageInSection = Infinity
   const updateFirstInvalid = (section: SectionStateNEW, page: PageNEW) => {
     if (
       section.details.index <= firstIncompleteSectionIndex &&
-      page.number < firstIncompletePageInSection &&
+      page.number < firstStrictInvalidPageInSection &&
       (!page.progress.valid || page.progress.doneRequired < page.progress.totalRequired)
     ) {
-      firstIncompletePageInSection = page.number
+      firstStrictInvalidPageInSection = page.number
       firstIncompleteSectionIndex = section.details.index
       firstIncompleteSectionCode = section.details.code
     }
@@ -90,10 +91,10 @@ export const generateResponsesProgress = (structure: FullStructure) => {
     })
     section.progress = getSectionProgress(Object.values(section.pages))
   })
-  structure.info.firstIncompletePage = firstIncompleteSectionCode
+  structure.info.firstStrictInvalidPage = firstIncompleteSectionCode
     ? {
         sectionCode: firstIncompleteSectionCode,
-        pageNumber: firstIncompletePageInSection,
+        pageNumber: firstStrictInvalidPageInSection,
       }
     : null
 }

--- a/src/utils/hooks/useGetFullApplicationStructure.tsx
+++ b/src/utils/hooks/useGetFullApplicationStructure.tsx
@@ -194,7 +194,7 @@ const useGetFullApplicationStructure = ({
           currentEvaluationParameters,
           false
         )
-      : async () => responseObject[element.code]?.isValid
+      : (async () => responseObject[element.code]?.isValid)()
     const results = await Promise.all([isEditable, isRequired, isVisible, isValid])
 
     const evaluatedElement = {

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -70,7 +70,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
         serial: application.serial as string,
         name: application.name as string,
         outcome: application.outcome as string,
-        firstIncompletePage: null, // Added for new FullStructure
+        firstStrictInvalidPage: null, // Added for new FullStructure
       }
 
       setApplication(applicationDetails)

--- a/src/utils/hooks/useLoadApplicationNEW.ts
+++ b/src/utils/hooks/useLoadApplicationNEW.ts
@@ -114,7 +114,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
         status: status as ApplicationStatus,
         date: DateTime.fromISO(statusHistoryTimeCreated),
       },
-      firstIncompletePage: null,
+      firstStrictInvalidPage: null,
     }
 
     const baseElements: ElementBaseNEW[] = []

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -97,7 +97,7 @@ interface ApplicationDetails {
   outcome: string
   isLinear: boolean
   current?: StageAndStatus // TODO: Change to compulsory after re-strcture is finished
-  firstIncompletePage: SectionAndPage | null
+  firstStrictInvalidPage: SectionAndPage | null
 }
 
 interface ApplicationElementStates {
@@ -148,8 +148,11 @@ type ColumnsPerRole = {
 
 interface ContextFormElementUpdateTrackerState {
   elementEnteredTimestamp: number
+  elementEnteredTextValue: string
   elementUpdatedTimestamp: number
+  elementUpdatedTextValue: string
   isLastElementUpdateProcessed: boolean
+  wasElementChange: boolean
 }
 
 interface ContextApplicationState {
@@ -254,7 +257,7 @@ interface MethodRevalidate {
 }
 
 interface MethodToCallProps {
-  firstIncompletePage: SectionAndPage | null
+  firstStrictInvalidPage: SectionAndPage | null
   setStrictSectionPage: SetStrictSectionPage
 }
 
@@ -294,7 +297,7 @@ interface Progress {
   totalNonRequired: number
   totalSum: number
   valid: boolean
-  firstIncompletePage: number | null
+  firstStrictInvalidPage: number | null
 }
 
 type ProgressStatus = 'VALID' | 'NOT_VALID' | 'INCOMPLETE'


### PR DESCRIPTION
Branched from #351 

### Reason for PR

While reviewing #351, I've noticed a few issues:

* Is strict wasn't being applied to progress bar (i.e. when there is a strict validation fail progress bar should indicate which page and section)
* Empty field wasn't being shown as invalid in application view wrapper when it has an empty string
* When value was not change but field focused/unfocused, request validation was failing (it was hanging)
* When future page is failing strict validation but navigating to even further page from lower page, no navigation happens (i.e. I am on page 1, page 2 is invalid, i am trying to navigate to page 3)
* 

### Changes

* Renamed (globally) `firstIncompletePageInSection` to `firstStrictInvalidPageInSection` <- because it could be completed but not valid
* Changes FormElementUpdateTrackerState to keep track of previous and current text value, and used it in ApplicationViewWrapper and ApplicationPage (validation will re-run, not waiting for fetch if value wasn't changed)
* Passing strictSectionPage to progress bar now and if doing strict indication of page and section of not validity
* In progress bar when navigating to future page but a page in between current page and future page is not valid, navigate to it
* ApplicationViewWrapper watching isStrinctPage change to do revalidation (probably would do this differently ? Not sure if we want to revalidate at when isStrinctPage is set (just use existing value), but it's ok for now

### Further changes

* Added validation error to drop down
* Reset strict page when navigating away from error page to non error page (noticing section was being stuck on strict if page one was strict, but fixed, and navigated to page 2

@CarlosNZ I am a little bit confused, it looks like we are only passing text value to the ApplicationView for plugin, is that right ? Does this restrict us from dealing with more complex data types ?