### PR TITLE
#318 Edit button on application home

### DIFF
--- a/src/components/Sections/SectionsProgress.tsx
+++ b/src/components/Sections/SectionsProgress.tsx
@@ -13,7 +13,6 @@ interface SectionsProgressProps {
 
 interface SectionActionProps {
   sectionCode: string
-  firstStrictInvalidPage: SectionAndPage | null
   progress?: ProgressType
 }
 
@@ -24,7 +23,7 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
   sections,
   resumeApplication,
 }) => {
-  let isBeforeStrict = false
+  let isBeforeStrict = true
 
   const getIndicator = ({ completed, valid }: ProgressType) => {
     return completed ? (
@@ -54,52 +53,51 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
     ) : null
   }
 
-  const SectionAction: React.FC<SectionActionProps> = ({
-    sectionCode,
-    firstStrictInvalidPage,
-    progress,
-  }) => {
+  const SectionAction: React.FC<SectionActionProps> = ({ sectionCode, progress }) => {
     const isStrictSection = sectionCode === firstStrictInvalidPage?.sectionCode
     isBeforeStrict = isBeforeStrict ? firstStrictInvalidPage === null || !isStrictSection : false
 
-    return (
-      <Grid.Column style={{ minWidth: 100, padding: 0 }} verticalAlign="middle" width={2}>
-        {canEdit ? (
-          isStrictSection ? (
-            <Button
-              color="blue"
-              onClick={() =>
-                resumeApplication({
-                  sectionCode,
-                  pageNumber: firstStrictInvalidPage?.pageNumber || 1,
-                })
-              }
-            >
-              {strings.BUTTON_APPLICATION_RESUME}
-            </Button>
-          ) : progress?.completed && isBeforeStrict ? (
-            <Icon
-              name="pencil square"
-              color="blue"
-              style={{ minWidth: 100 }}
-              onClick={() => resumeApplication({ sectionCode, pageNumber: 1 })}
-            />
-          ) : null
-        ) : changes.state && isStrictSection ? (
-          <Button
-            color="blue"
-            onClick={() =>
-              resumeApplication({
-                sectionCode,
-                pageNumber: firstStrictInvalidPage?.pageNumber || 1,
-              })
-            }
-          >
-            {changes.label}
-          </Button>
-        ) : null}
-      </Grid.Column>
-    )
+    if (!canEdit) return null
+
+    if (isStrictSection)
+      return (
+        <Button
+          color="blue"
+          content={strings.BUTTON_APPLICATION_RESUME}
+          onClick={() =>
+            resumeApplication({
+              sectionCode,
+              pageNumber: firstStrictInvalidPage?.pageNumber || 1,
+            })
+          }
+        />
+      )
+
+    if (progress?.completed && isBeforeStrict)
+      return (
+        <Icon
+          name="pencil square"
+          color="blue"
+          style={{ minWidth: 100 }}
+          onClick={() => resumeApplication({ sectionCode, pageNumber: 1 })}
+        />
+      )
+
+    if (changes.state)
+      return (
+        <Button
+          color="blue"
+          content={changes.label}
+          onClick={() =>
+            resumeApplication({
+              sectionCode,
+              pageNumber: firstStrictInvalidPage?.pageNumber || 1,
+            })
+          }
+        />
+      )
+
+    return null
   }
 
   return (
@@ -115,7 +113,9 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
               <p>{details.title}</p>
             </Grid.Column>
             {canEdit && progress && <SectionProgress {...progress} />}
-            {<SectionAction {...{ sectionCode, firstStrictInvalidPage, progress }} />}
+            <Grid.Column style={{ minWidth: 100, padding: 0 }} verticalAlign="middle" width={2}>
+              <SectionAction {...{ sectionCode, progress }} />
+            </Grid.Column>
           </Grid>
         ),
       }))}

--- a/src/components/Sections/SectionsProgress.tsx
+++ b/src/components/Sections/SectionsProgress.tsx
@@ -24,6 +24,8 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
   sections,
   resumeApplication,
 }) => {
+  let isAfterStrict = false
+
   const getIndicator = ({ completed, valid }: ProgressType) => {
     return completed ? (
       <Icon name={valid ? 'check circle' : 'exclamation circle'} color={valid ? 'green' : 'red'} />
@@ -32,6 +34,13 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
     )
   }
 
+  const getIsStrictSection = (sectionCode: string) =>
+    sectionCode === firstStrictInvalidPage?.sectionCode
+
+  const setIsAfterStrict = (sectionCode: string) => {
+    if (!isAfterStrict)
+      isAfterStrict = firstStrictInvalidPage === null ? true : getIsStrictSection(sectionCode)
+  }
   const SectionProgress: React.FC<ProgressType> = ({
     doneRequired,
     doneNonRequired,
@@ -57,31 +66,38 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
     firstStrictInvalidPage,
     progress,
   }) => {
+    setIsAfterStrict(sectionCode)
     return (
       <Grid.Column style={{ minWidth: 100, padding: 0 }} width={2}>
         {canEdit ? (
-          firstStrictInvalidPage && sectionCode === firstStrictInvalidPage.sectionCode ? (
+          getIsStrictSection(sectionCode) ? (
             <Button
               color="blue"
               onClick={() =>
                 resumeApplication({
                   sectionCode,
-                  pageNumber: firstStrictInvalidPage.pageNumber || 1,
+                  pageNumber: firstStrictInvalidPage?.pageNumber || 1,
                 })
               }
             >
               {strings.BUTTON_APPLICATION_RESUME}
             </Button>
-          ) : progress?.completed ? (
-            <Icon name="pencil square" color="blue" style={{ minWidth: 100 }} />
+          ) : progress?.completed && isAfterStrict ? (
+            <Icon
+              name="pencil square"
+              color="blue"
+              style={{ minWidth: 100 }}
+              onClick={() => resumeApplication({ sectionCode, pageNumber: 1 })}
+            />
           ) : null
-        ) : changes.state &&
-          firstStrictInvalidPage &&
-          firstStrictInvalidPage.sectionCode === sectionCode ? (
+        ) : changes.state && getIsStrictSection(sectionCode) ? (
           <Button
             color="blue"
             onClick={() =>
-              resumeApplication({ sectionCode, pageNumber: firstStrictInvalidPage.pageNumber })
+              resumeApplication({
+                sectionCode,
+                pageNumber: firstStrictInvalidPage?.pageNumber || 1,
+              })
             }
           >
             {changes.label}

--- a/src/components/Sections/SectionsProgress.tsx
+++ b/src/components/Sections/SectionsProgress.tsx
@@ -39,7 +39,7 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
 
   const setIsAfterStrict = (sectionCode: string) => {
     if (!isAfterStrict)
-      isAfterStrict = firstStrictInvalidPage === null ? true : getIsStrictSection(sectionCode)
+      isAfterStrict = firstStrictInvalidPage === null || getIsStrictSection(sectionCode)
   }
   const SectionProgress: React.FC<ProgressType> = ({
     doneRequired,

--- a/src/components/Sections/SectionsProgress.tsx
+++ b/src/components/Sections/SectionsProgress.tsx
@@ -68,7 +68,7 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
   }) => {
     setIsAfterStrict(sectionCode)
     return (
-      <Grid.Column style={{ minWidth: 100, padding: 0 }} width={2}>
+      <Grid.Column style={{ minWidth: 100, padding: 0 }} verticalAlign="middle" width={2}>
         {canEdit ? (
           getIsStrictSection(sectionCode) ? (
             <Button

--- a/src/components/Sections/SectionsProgress.tsx
+++ b/src/components/Sections/SectionsProgress.tsx
@@ -24,7 +24,7 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
   sections,
   resumeApplication,
 }) => {
-  let isAfterStrict = false
+  let isBeforeStrict = false
 
   const getIndicator = ({ completed, valid }: ProgressType) => {
     return completed ? (
@@ -34,13 +34,6 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
     )
   }
 
-  const getIsStrictSection = (sectionCode: string) =>
-    sectionCode === firstStrictInvalidPage?.sectionCode
-
-  const setIsAfterStrict = (sectionCode: string) => {
-    if (!isAfterStrict)
-      isAfterStrict = firstStrictInvalidPage === null || getIsStrictSection(sectionCode)
-  }
   const SectionProgress: React.FC<ProgressType> = ({
     doneRequired,
     doneNonRequired,
@@ -66,11 +59,13 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
     firstStrictInvalidPage,
     progress,
   }) => {
-    setIsAfterStrict(sectionCode)
+    const isStrictSection = sectionCode === firstStrictInvalidPage?.sectionCode
+    isBeforeStrict = isBeforeStrict ? firstStrictInvalidPage === null || !isStrictSection : false
+
     return (
       <Grid.Column style={{ minWidth: 100, padding: 0 }} verticalAlign="middle" width={2}>
         {canEdit ? (
-          getIsStrictSection(sectionCode) ? (
+          isStrictSection ? (
             <Button
               color="blue"
               onClick={() =>
@@ -82,7 +77,7 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
             >
               {strings.BUTTON_APPLICATION_RESUME}
             </Button>
-          ) : progress?.completed && isAfterStrict ? (
+          ) : progress?.completed && isBeforeStrict ? (
             <Icon
               name="pencil square"
               color="blue"
@@ -90,7 +85,7 @@ const SectionsProgress: React.FC<SectionsProgressProps> = ({
               onClick={() => resumeApplication({ sectionCode, pageNumber: 1 })}
             />
           ) : null
-        ) : changes.state && getIsStrictSection(sectionCode) ? (
+        ) : changes.state && isStrictSection ? (
           <Button
             color="blue"
             onClick={() =>

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -48,6 +48,11 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
     ({ progress }) => progress?.completed && progress.valid
   )
 
+  const canUserEdit = () => {
+    const { status } = fullStructure.info.current as StageAndStatus
+    return status === ApplicationStatus.Draft ? true : false
+  }
+
   const HomeMain: React.FC = () => {
     return (
       <>
@@ -55,6 +60,8 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
           <Header as="h5">{strings.SUBTITLE_APPLICATION_STEPS}</Header>
           <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
           <SectionsProgress
+            canEdit={canUserEdit()}
+            changes={{ state: true, label: 'Update' }}
             sections={fullStructure.sections}
             resumeApplication={handleResumeClick}
           />

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -62,6 +62,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
           <SectionsProgress
             canEdit={canUserEdit()}
             changes={{ state: true, label: 'Update' }}
+            firstStrictInvalidPage={fullStructure.info.firstStrictInvalidPage}
             sections={fullStructure.sections}
             resumeApplication={handleResumeClick}
           />

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -45,10 +45,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
 
   if (!fullStructure || !fullStructure.responsesByCode) return <Loading />
 
-  const canUserEdit = () => {
-    const { status } = fullStructure.info.current as StageAndStatus
-    return status === ApplicationStatus.Draft ? true : false
-  }
+  const canUserEdit = fullStructure.info?.current?.status === ApplicationStatus.Draft
 
   const { firstStrictInvalidPage } = fullStructure.info
 
@@ -59,7 +56,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
           <Header as="h5">{strings.SUBTITLE_APPLICATION_STEPS}</Header>
           <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
           <SectionsProgress
-            canEdit={canUserEdit()}
+            canEdit={canUserEdit}
             sections={fullStructure.sections}
             firstStrictInvalidPage={firstStrictInvalidPage}
             resumeApplication={handleResumeClick}

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -45,7 +45,6 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
 
   if (!fullStructure || !fullStructure.responsesByCode) return <Loading />
 
-
   const canUserEdit = () => {
     const { status } = fullStructure.info.current as StageAndStatus
     return status === ApplicationStatus.Draft ? true : false
@@ -61,7 +60,6 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
           <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
           <SectionsProgress
             canEdit={canUserEdit()}
-            changes={{ state: true, label: 'Update' }}
             sections={fullStructure.sections}
             firstStrictInvalidPage={firstStrictInvalidPage}
             resumeApplication={handleResumeClick}

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -53,14 +53,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         onChange={handleChange}
         value={value}
         disabled={!isEditable}
-        error={
-          !validationState.isValid
-            ? {
-                content: validationState?.validationMessage,
-                pointing: 'above',
-              }
-            : null
-        }
+        error={!validationState.isValid} // From PR #384 - wasn't compiling
       />
       {validationState.isValid ? null : (
         <Label basic color="red" pointing>


### PR DESCRIPTION
Fixes #318 

### Branched from
- ~~PR #384~~ MERGED
- ~~#375~~ MERGED 

### Changes
- Add edit button on `ApplicationHome` to display on application that editable, completed and before a strict section.
- Uses the `firstStrictSectionPage` to be displayed as the section with `Resume` button when user navigates to the home page.
- `SectionsProgress` component to be used by Review and Application to display the progress on each section - and options. The **badly** named received prop `changes` to be used by Review/Edit application and allow many different labels to the button that display on the same line as a section that needs attention. Thought about instead of doing passing a constructed a UI structure to this component that only renders cells... But just did this way now so we can discuss more the idea. 