### PR TITLE
#383 extract evaluation of response from usetGetFullApplicationStructure

### DIFF
--- a/src/utils/helpers/structure/addEvaluatedResponsesToStructure.ts
+++ b/src/utils/helpers/structure/addEvaluatedResponsesToStructure.ts
@@ -1,0 +1,161 @@
+import evaluateExpression from '@openmsupply/expression-evaluator'
+import { IQueryNode } from '@openmsupply/expression-evaluator/lib/types'
+import { ApplicationResponse } from '../../generated/graphql'
+import {
+  ElementStateNEW,
+  EvaluatorParameters,
+  FullStructure,
+  PageElement,
+  ResponsesByCode,
+  TemplateElementStateNEW,
+  User,
+} from '../../types'
+
+type EvaluationOptions = {
+  isRequired: boolean
+  isVisible: boolean
+  isEditable: boolean
+  isValid: boolean
+}
+
+const evaluationMapping = {
+  isEditable: 'isEditableExpression',
+  isRequired: 'isRequiredExpression',
+  isVisible: 'isVisibleExpression',
+  isValid: 'validationExpression',
+}
+
+const addEvaluatedResponsesToStructure = async ({
+  structure,
+  applicationResponses,
+  currentUser,
+  evaluationOptions,
+}: {
+  structure: FullStructure
+  applicationResponses: ApplicationResponse[]
+  currentUser: User | null
+  evaluationOptions: EvaluationOptions
+}) => {
+  const newStructure = { ...structure } // This MIGHT need to be deep-copied
+
+  // Build responses by code (and only keep latest)
+  const responseObject: any = {}
+
+  applicationResponses?.forEach((response) => {
+    const { id, isValid, value, templateElement, timeCreated } = response
+    const code = templateElement?.code as string
+    if (!(code in responseObject) || timeCreated > responseObject[code].timeCreated)
+      responseObject[code] = {
+        id,
+        isValid,
+        timeCreated,
+        ...value,
+      }
+  })
+
+  const flattenedElements = flattenStructureElements(newStructure)
+
+  // Note: Flattened elements are evaluated IN-PLACE, so structure can be
+  // updated with evaluated elements and responses without re-building
+  // structure
+  const results = await evaluateAndValidateElements(
+    flattenedElements.map((elem: PageElement) => elem.element),
+    responseObject,
+    currentUser,
+    evaluationOptions
+  )
+  results.forEach((evaluatedElement, index) => {
+    flattenedElements[index].element = evaluatedElement
+    flattenedElements[index].response = responseObject[evaluatedElement.code]
+  })
+  newStructure.responsesByCode = responseObject
+  return newStructure
+}
+
+async function evaluateAndValidateElements(
+  elements: TemplateElementStateNEW[],
+  responseObject: ResponsesByCode,
+  currentUser: User | null,
+  evaluationOptions: EvaluationOptions
+) {
+  const elementPromiseArray: Promise<ElementStateNEW>[] = []
+  elements.forEach((element) => {
+    elementPromiseArray.push(
+      evaluateSingleElement(element, responseObject, currentUser, evaluationOptions)
+    )
+  })
+  return await Promise.all(elementPromiseArray)
+}
+
+const evaluateExpressionWithFallBack = (
+  expression: IQueryNode,
+  evaluationParameters: EvaluatorParameters,
+  fallBackValue: any
+) =>
+  new Promise(async (resolve) => {
+    try {
+      resolve(await evaluateExpression(expression, evaluationParameters))
+    } catch (e) {
+      console.log(e)
+      resolve(fallBackValue)
+    }
+  })
+
+async function evaluateSingleElement(
+  element: TemplateElementStateNEW,
+  responseObject: ResponsesByCode,
+  currentUser: User | null,
+  evaluationOptions: EvaluationOptions
+): Promise<ElementStateNEW> {
+  const evaluationParameters = {
+    objects: {
+      responses: { ...responseObject, thisResponse: responseObject?.[element.code]?.text },
+      currentUser,
+    },
+    APIfetch: fetch,
+    // TO-DO: Also send org objects etc.
+    // graphQLConnection: TO-DO
+  }
+
+  const evaluationKeys = Object.keys(evaluationMapping).filter(
+    (evaluationKey) => evaluationOptions[evaluationKey as keyof EvaluationOptions]
+  )
+
+  const evaluations = evaluationKeys.map((evaluationKey) => {
+    const elementKey = evaluationMapping[evaluationKey as keyof EvaluationOptions]
+    const evaluationExpression = element[elementKey as keyof TemplateElementStateNEW]
+
+    return evaluateExpressionWithFallBack(evaluationExpression, evaluationParameters, true)
+  })
+
+  const results = (await Promise.all(evaluations)) as any
+  const evaluatedElement: { [key: string]: any } = {}
+
+  evaluationKeys.forEach((evaluationKey, index) => {
+    if (evaluationKey !== 'isValid') {
+      evaluatedElement[evaluationKey] = results[index]
+      return
+    }
+    // TODO maybe it's better to not mutate responseObject but add element.isValid
+    if (responseObject[element.code]) responseObject[element.code].isValid = results[index]
+  })
+
+  const elementBase = {
+    isEditable: true,
+    isVisible: true,
+    isRequired: true,
+  }
+  return { ...element, ...elementBase, ...evaluatedElement }
+}
+
+const flattenStructureElements = (structure: FullStructure) => {
+  const flattened: any = []
+  Object.keys(structure.sections).forEach((section) => {
+    Object.keys(structure.sections[section].pages).forEach((page) => {
+      flattened.push(...structure.sections[section].pages[Number(page)].state)
+    })
+  })
+  return flattened
+}
+
+export default addEvaluatedResponsesToStructure

--- a/src/utils/hooks/useGetFullApplicationStructure.tsx
+++ b/src/utils/hooks/useGetFullApplicationStructure.tsx
@@ -1,17 +1,9 @@
 import { useState, useEffect } from 'react'
-import {
-  ElementStateNEW,
-  EvaluatorParameters,
-  FullStructure,
-  PageElement,
-  ResponsesByCode,
-  TemplateElementStateNEW,
-} from '../types'
+import { FullStructure } from '../types'
 import { ApplicationResponse, useGetAllResponsesQuery } from '../generated/graphql'
 import { useUserState } from '../../contexts/UserState'
-import evaluateExpression from '@openmsupply/expression-evaluator'
-import { IQueryNode } from '@openmsupply/expression-evaluator/lib/types'
 import { generateResponsesProgress } from '../helpers/structure/generateProgress'
+import addEvaluatedResponsesToStructure from '../helpers/structure/addEvaluatedResponsesToStructure'
 
 interface useGetFullApplicationStructureProps {
   structure: FullStructure
@@ -39,11 +31,9 @@ const useGetFullApplicationStructure = ({
   const [lastRefetchedTimestamp, setLastRefetchedTimestamp] = useState<number>(0)
   const [lastProcessedTimestamp, setLastProcessedTimestamp] = useState<number>(0)
 
-  const newStructure = { ...structure } // This MIGHT need to be deep-copied
-
   const networkFetch = true // To-DO: make this conditional
 
-  const { data, error, loading } = useGetAllResponsesQuery({
+  const { data, error } = useGetAllResponsesQuery({
     variables: {
       serial,
     },
@@ -73,140 +63,32 @@ const useGetFullApplicationStructure = ({
 
     if (isDataUpToDate && !shouldRevalidateThisRun) return
 
-    // Build responses by code (and only keep latest)
-    const responseObject: any = {}
-    const responseArray = data?.applicationBySerial?.applicationResponses
-      ?.nodes as ApplicationResponse[]
-    responseArray?.forEach((response) => {
-      const { id, isValid, value, templateElement, timeCreated } = response
-      const code = templateElement?.code as string
-      if (!(code in responseObject) || timeCreated > responseObject[code].timeCreated)
-        responseObject[code] = {
-          id,
-          isValid,
-          timeCreated,
-          ...value,
-        }
-    })
+    const shouldDoValidation = shouldRevalidateThisRun || firstRunProcessValidation
 
-    const flattenedElements = flattenStructureElements(newStructure)
-
-    const evaluationParameters = {
-      objects: { responses: responseObject, currentUser },
-      APIfetch: fetch,
-      // TO-DO: Also send org objects etc.
-      // graphQLConnection: TO-DO
-    }
-
-    // Note: Flattened elements are evaluated IN-PLACE, so structure can be
-    // updated with evaluated elements and responses without re-building
-    // structure
-    evaluateAndValidateElements(
-      flattenedElements.map((elem: PageElement) => elem.element),
-      responseObject,
-      evaluationParameters,
-      shouldRevalidateThisRun || firstRunProcessValidation
-    ).then((result) => {
-      result.forEach((evaluatedElement, index) => {
-        flattenedElements[index].element = evaluatedElement
-        flattenedElements[index].response = responseObject[evaluatedElement.code]
-      })
-
-      if (shouldRevalidateThisRun || firstRunProcessValidation) {
+    addEvaluatedResponsesToStructure({
+      structure,
+      applicationResponses: data?.applicationBySerial?.applicationResponses
+        ?.nodes as ApplicationResponse[],
+      currentUser,
+      evaluationOptions: {
+        isEditable: true,
+        isVisible: true,
+        isRequired: true,
+        isValid: shouldDoValidation,
+      },
+    }).then((newStructure: FullStructure) => {
+      if (shouldDoValidation) {
         newStructure.lastValidationTimestamp = Date.now()
       }
-
-      newStructure.responsesByCode = responseObject
 
       generateResponsesProgress(newStructure)
 
       setLastProcessedTimestamp(Date.now())
       setFirstRunProcessValidation(false)
       setFullStructure(newStructure)
+      console.log({ newStructure })
     })
   }, [lastRefetchedTimestamp, shouldRevalidate, minRefetchTimestampForRevalidation, error])
-
-  async function evaluateAndValidateElements(
-    elements: TemplateElementStateNEW[],
-    responseObject: ResponsesByCode,
-    evaluationParameters: EvaluatorParameters,
-    shouldValidate: boolean
-  ) {
-    const elementPromiseArray: Promise<ElementStateNEW>[] = []
-    elements.forEach((element) => {
-      elementPromiseArray.push(
-        evaluateSingleElement(element, responseObject, evaluationParameters, shouldValidate)
-      )
-    })
-    return await Promise.all(elementPromiseArray)
-  }
-
-  const evaluateExpressionWithFallBack = (
-    expression: IQueryNode,
-    evaluationParameters: EvaluatorParameters,
-    fallBackValue: any
-  ) =>
-    new Promise(async (resolve) => {
-      try {
-        resolve(await evaluateExpression(expression, evaluationParameters))
-      } catch (e) {
-        console.log(e)
-        resolve(fallBackValue)
-      }
-    })
-
-  async function evaluateSingleElement(
-    element: TemplateElementStateNEW,
-    responseObject: ResponsesByCode,
-    evaluationParameters: EvaluatorParameters,
-    shouldValidate: boolean
-  ): Promise<ElementStateNEW> {
-    const responses = { ...evaluationParameters.objects?.responses }
-    const currentEvaluationParameters = {
-      ...evaluationParameters,
-      objects: {
-        ...evaluationParameters.objects,
-        responses: {
-          ...evaluationParameters.objects?.responses,
-          thisResponse: responses?.[element.code]?.text,
-        },
-      },
-    }
-
-    const isEditable = evaluateExpressionWithFallBack(
-      element.isEditableExpression,
-      currentEvaluationParameters,
-      true
-    )
-    const isRequired = evaluateExpressionWithFallBack(
-      element.isRequiredExpression,
-      currentEvaluationParameters,
-      false
-    )
-    const isVisible = evaluateExpressionWithFallBack(
-      element.isVisibleExpression,
-      currentEvaluationParameters,
-      true
-    )
-    const isValid = shouldValidate
-      ? evaluateExpressionWithFallBack(
-          element.validationExpression,
-          currentEvaluationParameters,
-          false
-        )
-      : async () => responseObject[element.code]?.isValid
-    const results = await Promise.all([isEditable, isRequired, isVisible, isValid])
-
-    const evaluatedElement = {
-      ...element,
-      isEditable: results[0] as boolean,
-      isRequired: results[1] as boolean,
-      isVisible: results[2] as boolean,
-    }
-    // Update isValid field in Response, in-place
-    if (responseObject[element.code]) responseObject[element.code].isValid = results[3] as boolean
-    return evaluatedElement
-  }
 
   return {
     fullStructure,
@@ -215,13 +97,3 @@ const useGetFullApplicationStructure = ({
 }
 
 export default useGetFullApplicationStructure
-
-const flattenStructureElements = (structure: FullStructure) => {
-  const flattened: any = []
-  Object.keys(structure.sections).forEach((section) => {
-    Object.keys(structure.sections[section].pages).forEach((page) => {
-      flattened.push(...structure.sections[section].pages[Number(page)].state)
-    })
-  })
-  return flattened
-}

--- a/src/utils/hooks/useGetFullApplicationStructure.tsx
+++ b/src/utils/hooks/useGetFullApplicationStructure.tsx
@@ -86,7 +86,6 @@ const useGetFullApplicationStructure = ({
       setLastProcessedTimestamp(Date.now())
       setFirstRunProcessValidation(false)
       setFullStructure(newStructure)
-      console.log({ newStructure })
     })
   }, [lastRefetchedTimestamp, shouldRevalidate, minRefetchTimestampForRevalidation, error])
 


### PR DESCRIPTION
After a deeper look, it seems the functionality that needs to be shared is adding responses to structure (and evaluating them)

### Changes

* Extracted logic from useGetFullApplicationStructure to addEvaluatedResponsesToStructure
* Added conditional parameter to specify what needs to be evaluated (isVisiblity, isRequired, isEditable, isValid)

Most of the evaluator logic is the same as it was, apart from `evaluateSingleElement`.

Also had to fight type script a few times (when accessing properties of an object that are not indexable by string)