### PR TITLE
#350 ApplicationPage with previous and next buttons

### DIFF
--- a/src/components/Application/ApplicationEdit.tsx
+++ b/src/components/Application/ApplicationEdit.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useMutation } from '@apollo/client'
 import updateApplication from '../../utils/graphql/mutations/updateApplication.mutation'
 
+// TODO: Remove this
 interface updateApplicationProps {
   id: number
   name: string

--- a/src/components/Application/ApplicationStart.tsx
+++ b/src/components/Application/ApplicationStart.tsx
@@ -13,6 +13,8 @@ import Markdown from '../../utils/helpers/semanticReactMarkdown'
 import evaluate from '@openmsupply/expression-evaluator'
 import { useUserState } from '../../contexts/UserState'
 import { checkSectionsProgress } from '../../utils/helpers/structure/checkSectionsProgress'
+
+// TODO: Remove this
 export interface ApplicationStartProps extends RouteComponentProps {
   template: TemplateDetails
   sections: SectionsStructure

--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -27,31 +27,30 @@ const Navigation: React.FC<NavigationProps> = ({
 
   const currentSectionDetails = sections[current.sectionCode].details
 
-  const hasNextSection = Object.values(sections).find(
-    ({ details: { index } }) => index > currentSectionDetails.index
-  )
-  const hasPreviousSection = Object.values(sections).find(
-    ({ details: { index } }) => index < currentSectionDetails.index
-  )
+  const nextSection = (): SectionDetails | null => {
+    const nextSections = Object.values(sections)
+      .filter(({ details: { index } }) => index > currentSectionDetails.index)
+      .sort(({ details: { index: aIndex } }, { details: { index: bIndex } }) => aIndex - bIndex)
+    return nextSections.length > 0 ? nextSections[0].details : null
+  }
 
-  const isFirstPage = current.pageNumber - 1 === 0 && !hasPreviousSection
-  const isLastPage = current.pageNumber + 1 > currentSectionDetails.totalPages && !hasNextSection
+  const previousSection = (): SectionDetails | null => {
+    const previousSections = Object.values(sections)
+      .filter(({ details: { index } }) => index < currentSectionDetails.index)
+      .sort(({ details: { index: aIndex } }, { details: { index: bIndex } }) => bIndex - aIndex)
+    return previousSections.length > 0 ? previousSections[0].details : null
+  }
+
+  const isFirstPage = current.pageNumber - 1 === 0 && previousSection() == null
+  const isLastPage =
+    current.pageNumber + 1 > currentSectionDetails.totalPages && nextSection() == null
 
   const getPreviousSectionPage = (): SectionAndPage => {
     const { sectionCode, pageNumber } = current
     if (pageNumber > 1) return { sectionCode, pageNumber: pageNumber - 1 }
-    else {
-      const previousSectionDetails = Object.values(sections).reduce(
-        (previousSection: SectionDetails, { details: { code, index } }) => {
-          if (index < previousSection.index) return sections[code].details
-          return previousSection
-        },
-        currentSectionDetails
-      )
-      return {
-        sectionCode: previousSectionDetails.code,
-        pageNumber: previousSectionDetails.totalPages,
-      }
+    return {
+      sectionCode: (previousSection() as SectionDetails).code,
+      pageNumber: (previousSection() as SectionDetails).totalPages,
     }
   }
 
@@ -59,18 +58,9 @@ const Navigation: React.FC<NavigationProps> = ({
     const { sectionCode, pageNumber } = current
     if (pageNumber < currentSectionDetails.totalPages)
       return { sectionCode, pageNumber: pageNumber + 1 }
-    else {
-      const nextSectionDetails = Object.values(sections).reduce(
-        (nextSection: SectionDetails, { details: { code, index } }) => {
-          if (index > nextSection.index) return sections[code].details
-          return nextSection
-        },
-        currentSectionDetails
-      )
-      return {
-        sectionCode: nextSectionDetails.code,
-        pageNumber: 1,
-      }
+    return {
+      sectionCode: (nextSection() as SectionDetails).code,
+      pageNumber: 1,
     }
   }
 

--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Label, Segment } from 'semantic-ui-react'
+import { Button, Container, Label, Segment, Sticky } from 'semantic-ui-react'
 import { SectionAndPage, SectionDetails, SectionsStructureNEW } from '../../utils/types'
 import strings from '../../utils/constants'
 import { useRouter } from '../../utils/hooks/useRouter'
@@ -14,7 +14,6 @@ const Navigation: React.FC<NavigationProps> = ({ current, sections, serialNumber
   const { push } = useRouter()
 
   const currentSectionDetails = sections[current.sectionCode].details
-  console.log('currentSection', currentSectionDetails)
 
   const hasNextSection = Object.values(sections).find(
     ({ details: { index } }) => index > currentSectionDetails.index
@@ -79,22 +78,40 @@ const Navigation: React.FC<NavigationProps> = ({ current, sections, serialNumber
   }
 
   return (
-    <Segment.Group horizontal>
-      <Segment basic floated="left">
-        {!isFirstPage && (
-          <Label basic as="a" onClick={previousButtonHandler}>
-            {strings.BUTTON_PREVIOUS}
-          </Label>
-        )}
-      </Segment>
-      <Segment basic floated="right">
-        {!isLastPage && (
-          <Label basic as="a" onClick={nextPageButtonHandler}>
-            {strings.BUTTON_NEXT}
-          </Label>
-        )}
-      </Segment>
-    </Segment.Group>
+    <Sticky
+      pushing
+      style={{ backgroundColor: 'white', boxShadow: ' 0px -5px 8px 0px rgba(0,0,0,0.1)' }}
+    >
+      <Segment.Group horizontal>
+        <Segment style={{ minWidth: '50%' }}>
+          {!isFirstPage && (
+            <Button
+              basic
+              floated="left"
+              onClick={previousButtonHandler}
+              content={strings.BUTTON_PREVIOUS}
+            />
+          )}
+          {!isLastPage && (
+            <Button
+              basic
+              floated="right"
+              onClick={nextPageButtonHandler}
+              content={strings.BUTTON_NEXT}
+            />
+          )}
+        </Segment>
+        <Segment basic textAlign="center" clearing>
+          <Button
+            color="blue"
+            onClick={() => {
+              /* TO-DO */
+            }}
+            content={strings.BUTTON_SUMMARY}
+          />
+        </Segment>
+      </Segment.Group>
+    </Sticky>
   )
 }
 

--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -1,6 +1,12 @@
 import React from 'react'
-import { Button, Container, Label, Segment, Sticky } from 'semantic-ui-react'
-import { SectionAndPage, SectionDetails, SectionsStructureNEW } from '../../utils/types'
+import { Button, Segment, Sticky } from 'semantic-ui-react'
+import {
+  MethodRevalidate,
+  MethodToCallProps,
+  SectionAndPage,
+  SectionDetails,
+  SectionsStructureNEW,
+} from '../../utils/types'
 import strings from '../../utils/constants'
 import { useRouter } from '../../utils/hooks/useRouter'
 
@@ -8,9 +14,15 @@ interface NavigationProps {
   current: SectionAndPage
   sections: SectionsStructureNEW
   serialNumber: string
+  requestRevalidation: MethodRevalidate
 }
 
-const Navigation: React.FC<NavigationProps> = ({ current, sections, serialNumber }) => {
+const Navigation: React.FC<NavigationProps> = ({
+  current,
+  sections,
+  serialNumber,
+  requestRevalidation,
+}) => {
   const { push } = useRouter()
 
   const currentSectionDetails = sections[current.sectionCode].details
@@ -74,7 +86,20 @@ const Navigation: React.FC<NavigationProps> = ({ current, sections, serialNumber
 
   const nextPageButtonHandler = (_: any) => {
     const nextSectionPage = getNextSectionPage()
-    sendToPage(nextSectionPage)
+    // Use validationMethod to check if can change to page (on linear application) OR
+    // display current page with strict validation
+    requestRevalidation(({ firstStrictInvalidPage, setStrictSectionPage }: MethodToCallProps) => {
+      if (
+        firstStrictInvalidPage !== null &&
+        current.sectionCode === firstStrictInvalidPage.sectionCode &&
+        current.pageNumber === firstStrictInvalidPage.pageNumber
+      ) {
+        setStrictSectionPage(firstStrictInvalidPage)
+      } else {
+        setStrictSectionPage(null)
+        sendToPage(nextSectionPage)
+      }
+    })
   }
 
   return (

--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { Container, Label, Segment } from 'semantic-ui-react'
+import { SectionAndPage, SectionDetails, SectionsStructureNEW } from '../../utils/types'
+import strings from '../../utils/constants'
+import { useRouter } from '../../utils/hooks/useRouter'
+
+interface NavigationProps {
+  current: SectionAndPage
+  sections: SectionsStructureNEW
+  serialNumber: string
+}
+
+const Navigation: React.FC<NavigationProps> = ({ current, sections, serialNumber }) => {
+  const { push } = useRouter()
+
+  const currentSectionDetails = sections[current.sectionCode].details
+  console.log('currentSection', currentSectionDetails)
+
+  const hasNextSection = Object.values(sections).find(
+    ({ details: { index } }) => index > currentSectionDetails.index
+  )
+  const hasPreviousSection = Object.values(sections).find(
+    ({ details: { index } }) => index < currentSectionDetails.index
+  )
+
+  const isFirstPage = current.pageNumber - 1 === 0 && !hasPreviousSection
+  const isLastPage = current.pageNumber + 1 > currentSectionDetails.totalPages && !hasNextSection
+
+  const getPreviousSectionPage = (): SectionAndPage => {
+    const { sectionCode, pageNumber } = current
+    if (pageNumber >= 1) return { sectionCode, pageNumber: pageNumber - 1 }
+    else {
+      const previousSectionDetails = Object.values(sections).reduce(
+        (previousSection: SectionDetails, { details: { code, index } }) => {
+          if (index < previousSection.index) return sections[code].details
+          return previousSection
+        },
+        currentSectionDetails
+      )
+      return {
+        sectionCode: previousSectionDetails.code,
+        pageNumber: previousSectionDetails.totalPages,
+      }
+    }
+  }
+
+  const getNextSectionPage = (): SectionAndPage => {
+    const { sectionCode, pageNumber } = current
+    if (pageNumber < currentSectionDetails.totalPages)
+      return { sectionCode, pageNumber: pageNumber + 1 }
+    else {
+      const nextSectionDetails = Object.values(sections).reduce(
+        (nextSection: SectionDetails, { details: { code, index } }) => {
+          if (index > nextSection.index) return sections[code].details
+          return nextSection
+        },
+        currentSectionDetails
+      )
+      return {
+        sectionCode: nextSectionDetails.code,
+        pageNumber: 1,
+      }
+    }
+  }
+
+  const sendToPage = (sectionPage: SectionAndPage) => {
+    const { sectionCode, pageNumber } = sectionPage
+    push(`/application/${serialNumber}/${sectionCode}/Page${pageNumber}`)
+  }
+
+  const previousButtonHandler = (_: any) => {
+    const previousSectionPage = getPreviousSectionPage()
+    sendToPage(previousSectionPage)
+  }
+
+  const nextPageButtonHandler = (_: any) => {
+    const nextSectionPage = getNextSectionPage()
+    sendToPage(nextSectionPage)
+  }
+
+  return (
+    <Container>
+      <Segment.Group>
+        <Segment basic floated="left">
+          {!isFirstPage && (
+            <Label basic as="a" onClick={previousButtonHandler}>
+              {strings.BUTTON_PREVIOUS}
+            </Label>
+          )}
+        </Segment>
+        <Segment basic floated="right">
+          {!isLastPage && (
+            <Label basic as="a" onClick={nextPageButtonHandler}>
+              {strings.BUTTON_NEXT}
+            </Label>
+          )}
+        </Segment>
+      </Segment.Group>
+      {/* TODO: Add "Summary & Review" button and Stick component */}
+    </Container>
+  )
+}
+
+export default Navigation

--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -12,6 +12,7 @@ import { useRouter } from '../../utils/hooks/useRouter'
 
 interface NavigationProps {
   current: SectionAndPage
+  isLinear: boolean
   sections: SectionsStructureNEW
   serialNumber: string
   requestRevalidation: MethodRevalidate
@@ -19,6 +20,7 @@ interface NavigationProps {
 
 const Navigation: React.FC<NavigationProps> = ({
   current,
+  isLinear,
   sections,
   serialNumber,
   requestRevalidation,
@@ -72,6 +74,11 @@ const Navigation: React.FC<NavigationProps> = ({
 
   const nextPageButtonHandler = (_: any) => {
     const nextSectionPage = getNextSectionPage()
+    if (!isLinear) {
+      sendToPage(nextSectionPage)
+      return
+    }
+
     // Use validationMethod to check if can change to page (on linear application) OR
     // display current page with strict validation
     requestRevalidation(({ firstStrictInvalidPage, setStrictSectionPage }: MethodToCallProps) => {

--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Segment, Sticky } from 'semantic-ui-react'
+import { Button, Grid, Sticky } from 'semantic-ui-react'
 import {
   MethodRevalidate,
   MethodToCallProps,
@@ -100,35 +100,35 @@ const Navigation: React.FC<NavigationProps> = ({
       pushing
       style={{ backgroundColor: 'white', boxShadow: ' 0px -5px 8px 0px rgba(0,0,0,0.1)' }}
     >
-      <Segment.Group horizontal>
-        <Segment style={{ minWidth: '50%' }}>
-          {!isFirstPage && (
+      <Grid container>
+        <Grid.Row verticalAlign="middle">
+          <Grid.Column width={5}>
             <Button
               basic
-              floated="left"
               onClick={previousButtonHandler}
               content={strings.BUTTON_PREVIOUS}
+              style={{ display: isFirstPage ? 'none' : 'inline-block' }}
             />
-          )}
-          {!isLastPage && (
+          </Grid.Column>
+          <Grid.Column width={5}>
             <Button
               basic
-              floated="right"
               onClick={nextPageButtonHandler}
               content={strings.BUTTON_NEXT}
+              style={{ display: isLastPage ? 'none' : 'inline-block' }}
             />
-          )}
-        </Segment>
-        <Segment basic textAlign="center" clearing>
-          <Button
-            color="blue"
-            onClick={() => {
-              /* TO-DO */
-            }}
-            content={strings.BUTTON_SUMMARY}
-          />
-        </Segment>
-      </Segment.Group>
+          </Grid.Column>
+          <Grid.Column width={5}>
+            <Button
+              color="blue"
+              onClick={() => {
+                /* TO-DO */
+              }}
+              content={strings.BUTTON_SUMMARY}
+            />
+          </Grid.Column>
+        </Grid.Row>
+      </Grid>
     </Sticky>
   )
 }

--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -27,30 +27,26 @@ const Navigation: React.FC<NavigationProps> = ({
 
   const currentSectionDetails = sections[current.sectionCode].details
 
-  const nextSection = (): SectionDetails | null => {
-    const nextSections = Object.values(sections)
-      .filter(({ details: { index } }) => index > currentSectionDetails.index)
-      .sort(({ details: { index: aIndex } }, { details: { index: bIndex } }) => aIndex - bIndex)
-    return nextSections.length > 0 ? nextSections[0].details : null
-  }
+  const nextSections = Object.values(sections)
+    .filter(({ details: { index } }) => index > currentSectionDetails.index)
+    .sort(({ details: { index: aIndex } }, { details: { index: bIndex } }) => aIndex - bIndex)
+  const nextSection = nextSections.length > 0 ? nextSections[0].details : null
 
-  const previousSection = (): SectionDetails | null => {
-    const previousSections = Object.values(sections)
-      .filter(({ details: { index } }) => index < currentSectionDetails.index)
-      .sort(({ details: { index: aIndex } }, { details: { index: bIndex } }) => bIndex - aIndex)
-    return previousSections.length > 0 ? previousSections[0].details : null
-  }
+  const previousSections = Object.values(sections)
+    .filter(({ details: { index } }) => index < currentSectionDetails.index)
+    .sort(({ details: { index: aIndex } }, { details: { index: bIndex } }) => bIndex - aIndex)
+  const previousSection = previousSections.length > 0 ? previousSections[0].details : null
 
-  const isFirstPage = current.pageNumber - 1 === 0 && previousSection() == null
+  const isFirstPage = current.pageNumber - 1 === 0 && previousSection == null
   const isLastPage =
-    current.pageNumber + 1 > currentSectionDetails.totalPages && nextSection() == null
+    current.pageNumber + 1 > currentSectionDetails.totalPages && nextSection == null
 
   const getPreviousSectionPage = (): SectionAndPage => {
     const { sectionCode, pageNumber } = current
     if (pageNumber > 1) return { sectionCode, pageNumber: pageNumber - 1 }
     return {
-      sectionCode: (previousSection() as SectionDetails).code,
-      pageNumber: (previousSection() as SectionDetails).totalPages,
+      sectionCode: (previousSection as SectionDetails).code,
+      pageNumber: (previousSection as SectionDetails).totalPages,
     }
   }
 
@@ -59,7 +55,7 @@ const Navigation: React.FC<NavigationProps> = ({
     if (pageNumber < currentSectionDetails.totalPages)
       return { sectionCode, pageNumber: pageNumber + 1 }
     return {
-      sectionCode: (nextSection() as SectionDetails).code,
+      sectionCode: (nextSection as SectionDetails).code,
       pageNumber: 1,
     }
   }

--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Container, Label, Segment } from 'semantic-ui-react'
+import { Label, Segment } from 'semantic-ui-react'
 import { SectionAndPage, SectionDetails, SectionsStructureNEW } from '../../utils/types'
 import strings from '../../utils/constants'
 import { useRouter } from '../../utils/hooks/useRouter'
@@ -28,7 +28,7 @@ const Navigation: React.FC<NavigationProps> = ({ current, sections, serialNumber
 
   const getPreviousSectionPage = (): SectionAndPage => {
     const { sectionCode, pageNumber } = current
-    if (pageNumber >= 1) return { sectionCode, pageNumber: pageNumber - 1 }
+    if (pageNumber > 1) return { sectionCode, pageNumber: pageNumber - 1 }
     else {
       const previousSectionDetails = Object.values(sections).reduce(
         (previousSection: SectionDetails, { details: { code, index } }) => {
@@ -65,7 +65,7 @@ const Navigation: React.FC<NavigationProps> = ({ current, sections, serialNumber
 
   const sendToPage = (sectionPage: SectionAndPage) => {
     const { sectionCode, pageNumber } = sectionPage
-    push(`/application/${serialNumber}/${sectionCode}/Page${pageNumber}`)
+    push(`/applicationNEW/${serialNumber}/${sectionCode}/Page${pageNumber}`)
   }
 
   const previousButtonHandler = (_: any) => {
@@ -79,25 +79,22 @@ const Navigation: React.FC<NavigationProps> = ({ current, sections, serialNumber
   }
 
   return (
-    <Container>
-      <Segment.Group>
-        <Segment basic floated="left">
-          {!isFirstPage && (
-            <Label basic as="a" onClick={previousButtonHandler}>
-              {strings.BUTTON_PREVIOUS}
-            </Label>
-          )}
-        </Segment>
-        <Segment basic floated="right">
-          {!isLastPage && (
-            <Label basic as="a" onClick={nextPageButtonHandler}>
-              {strings.BUTTON_NEXT}
-            </Label>
-          )}
-        </Segment>
-      </Segment.Group>
-      {/* TODO: Add "Summary & Review" button and Stick component */}
-    </Container>
+    <Segment.Group horizontal>
+      <Segment basic floated="left">
+        {!isFirstPage && (
+          <Label basic as="a" onClick={previousButtonHandler}>
+            {strings.BUTTON_PREVIOUS}
+          </Label>
+        )}
+      </Segment>
+      <Segment basic floated="right">
+        {!isLastPage && (
+          <Label basic as="a" onClick={nextPageButtonHandler}>
+            {strings.BUTTON_NEXT}
+          </Label>
+        )}
+      </Segment>
+    </Segment.Group>
   )
 }
 

--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -67,12 +67,12 @@ const Navigation: React.FC<NavigationProps> = ({
     push(`/applicationNEW/${serialNumber}/${sectionCode}/Page${pageNumber}`)
   }
 
-  const previousButtonHandler = (_: any) => {
+  const previousButtonHandler = () => {
     const previousSectionPage = getPreviousSectionPage()
     sendToPage(previousSectionPage)
   }
 
-  const nextPageButtonHandler = (_: any) => {
+  const nextPageButtonHandler = () => {
     const nextSectionPage = getNextSectionPage()
     if (!isLinear) {
       sendToPage(nextSectionPage)

--- a/src/components/Application/ProgressBar.tsx
+++ b/src/components/Application/ProgressBar.tsx
@@ -13,6 +13,7 @@ import { useRouter } from '../../utils/hooks/useRouter'
 import { validatePage } from '../../utils/helpers/validation/validatePage'
 import getPreviousPage from '../../utils/helpers/application/getPreviousPage'
 
+// TODO: Remove this
 interface ProgressBarProps {
   serialNumber: string
   current: CurrentPage

--- a/src/components/Application/SectionSummary.tsx
+++ b/src/components/Application/SectionSummary.tsx
@@ -6,6 +6,8 @@ import strings from '../../utils/constants'
 import { TemplateElementCategory } from '../../utils/generated/graphql'
 import { ResponsesByCode, SectionState } from '../../utils/types'
 
+// TODO: Remove this
+
 interface SectionSummaryProps {
   sectionPages: SectionState
   serialNumber: string

--- a/src/components/Application/index.ts
+++ b/src/components/Application/index.ts
@@ -2,6 +2,7 @@ import ApplicationEdit from './ApplicationEdit'
 import ApplicationHeader from './ApplicationHeader'
 import ApplicationSelectType from './ApplicationSelectType'
 import ApplicationStart from './ApplicationStart'
+import Navigation from './Navigation'
 import SectionSummary from './SectionSummary'
 import ProgressBar from './ProgressBar'
 import PageElements from './PageElements'
@@ -11,6 +12,7 @@ export {
   ApplicationHeader,
   ApplicationSelectType,
   ApplicationStart,
+  Navigation,
   SectionSummary,
   PageElements,
   ProgressBar,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,7 @@ import {
   ApplicationHeader,
   ApplicationSelectType,
   ApplicationStart,
+  Navigation,
   SectionSummary,
   ProgressBar,
 } from './Application'
@@ -43,6 +44,7 @@ export {
   Login,
   Loading,
   ModalWarning,
+  Navigation,
   Notification,
   NotificationsList,
   NoMatch,

--- a/src/containers/Application/ApplicationCreate.tsx
+++ b/src/containers/Application/ApplicationCreate.tsx
@@ -8,6 +8,8 @@ import useCreateApplication from '../../utils/hooks/useCreateApplication'
 import { useUserState } from '../../contexts/UserState'
 import strings from '../../utils/constants'
 
+// TODO: Remove this
+
 const ApplicationCreate: React.FC = () => {
   const { applicationState, setApplicationState } = useApplicationState()
   const { serialNumber } = applicationState

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -18,6 +18,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
   const {
     query: { serialNumber },
     push,
+    replace,
   } = useRouter()
   const {
     userState: { currentUser },
@@ -39,7 +40,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
   }
 
   const handleSummaryClicked = () => {
-    push(`/applicationNEW/${serialNumber}/summary`)
+    replace(`/applicationNEW/${serialNumber}/summary`)
   }
 
   if (!fullStructure || !fullStructure.responsesByCode) return <Loading />

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -19,7 +19,6 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
   const {
     query: { serialNumber },
     push,
-    replace,
   } = useRouter()
   const {
     userState: { currentUser },
@@ -41,7 +40,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
   }
 
   const handleSummaryClicked = () => {
-    replace(`/applicationNEW/${serialNumber}/summary`)
+    push(`/applicationNEW/${serialNumber}/summary`)
   }
 
   if (!fullStructure || !fullStructure.responsesByCode) return <Loading />

--- a/src/containers/Application/ApplicationOverview.tsx
+++ b/src/containers/Application/ApplicationOverview.tsx
@@ -13,6 +13,8 @@ import useRevalidateApplication from '../../utils/hooks/useRevalidateApplication
 import { checkSectionsProgress } from '../../utils/helpers/structure/checkSectionsProgress'
 import { getResponsesInStrucutre } from '../../utils/helpers/structure/getElementsInStructure'
 
+// TODO: Remove this
+
 const ApplicationOverview: React.FC = () => {
   const [isRevalidated, setIsRevalidated] = useState(false)
   const [isSubmittedClicked, setIsSubmittedClicked] = useState(false)

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -121,6 +121,10 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
   if (error) return <Message error header={strings.ERROR_APPLICATION_PAGE} list={[error]} />
   if (!fullStructure || !fullStructure.responsesByCode) return <Loading />
 
+  const {
+    info: { isLinear },
+  } = fullStructure
+
   return (
     <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>
       {/* <ModalWarning showModal={showModal} /> */}
@@ -162,6 +166,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
       </Grid>
       <Navigation
         current={{ sectionCode, pageNumber }}
+        isLinear={isLinear}
         sections={fullStructure.sections}
         serialNumber={serialNumber}
         requestRevalidation={requestRevalidation}

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -13,7 +13,7 @@ import { useUserState } from '../../contexts/UserState'
 import { useRouter } from '../../utils/hooks/useRouter'
 import { Loading } from '../../components'
 import strings from '../../utils/constants'
-import { Button, Grid, Header, Message, Segment, Sticky } from 'semantic-ui-react'
+import { Grid, Header, Message, Segment } from 'semantic-ui-react'
 import ProgressBarNEW from '../../components/Application/ProgressBarNEW'
 import { PageElements } from '../../components/Application'
 import { useFormElementUpdateTracker } from '../../contexts/FormElementUpdateTrackerState'
@@ -164,6 +164,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
         current={{ sectionCode, pageNumber }}
         sections={fullStructure.sections}
         serialNumber={serialNumber}
+        requestRevalidation={requestRevalidation}
       />
     </Segment.Group>
   )

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -145,39 +145,26 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
           />
         </Grid.Column>
         <Grid.Column width={10} stretched>
-          <Segment basic>
-            <Segment vertical style={{ marginBottom: 20 }}>
-              <Header content={fullStructure.sections[sectionCode].details.title} />
-              <PageElements
-                elements={getCurrentPageElements(fullStructure, sectionCode, pageNumber)}
-                responsesByCode={fullStructure.responsesByCode}
-                isStrictPage={
-                  sectionCode === strictSectionPage?.sectionCode &&
-                  pageNumber === strictSectionPage?.pageNumber
-                }
-                isEditable
-              />
-            </Segment>
-            <Navigation
-              current={{ sectionCode, pageNumber }}
-              sections={fullStructure.sections}
-              serialNumber={serialNumber}
+          <Segment vertical style={{ marginBottom: 20 }}>
+            <Header content={fullStructure.sections[sectionCode].details.title} />
+            <PageElements
+              elements={getCurrentPageElements(fullStructure, sectionCode, pageNumber)}
+              responsesByCode={fullStructure.responsesByCode}
+              isStrictPage={
+                sectionCode === strictSectionPage?.sectionCode &&
+                pageNumber === strictSectionPage?.pageNumber
+              }
+              isEditable
             />
           </Segment>
         </Grid.Column>
         <Grid.Column width={2} />
       </Grid>
-      <Sticky
-        pushing
-        style={{ backgroundColor: 'white', boxShadow: ' 0px -5px 8px 0px rgba(0,0,0,0.1)' }}
-      >
-        <Segment basic textAlign="right">
-          <Button color="blue" onClick={() => {}}>
-            {/* TO-DO */}
-            {strings.BUTTON_SUMMARY}
-          </Button>
-        </Segment>
-      </Sticky>
+      <Navigation
+        current={{ sectionCode, pageNumber }}
+        sections={fullStructure.sections}
+        serialNumber={serialNumber}
+      />
     </Segment.Group>
   )
 }

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -18,6 +18,7 @@ import ProgressBarNEW from '../../components/Application/ProgressBarNEW'
 import { PageElements } from '../../components/Application'
 import { useFormElementUpdateTracker } from '../../contexts/FormElementUpdateTrackerState'
 import checkPageIsAccessible from '../../utils/helpers/structure/checkPageIsAccessible'
+import { Navigation } from '../../components'
 
 interface ApplicationProps {
   structure: FullStructure
@@ -39,7 +40,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
     userState: { currentUser },
   } = useUserState()
   const {
-    query: { sectionCode, page },
+    query: { serialNumber, sectionCode, page },
     push,
   } = useRouter()
 
@@ -157,7 +158,11 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
                 isEditable
               />
             </Segment>
-            <NavigationBox />
+            <Navigation
+              current={{ sectionCode, pageNumber }}
+              sections={fullStructure.sections}
+              serialNumber={serialNumber}
+            />
           </Segment>
         </Grid.Column>
         <Grid.Column width={2} />
@@ -175,11 +180,6 @@ const ApplicationPage: React.FC<ApplicationProps> = ({ structure }) => {
       </Sticky>
     </Segment.Group>
   )
-}
-
-const NavigationBox: React.FC = () => {
-  // Placeholder -- to be replaced with new component
-  return <p>Navigation Buttons</p>
 }
 
 export default ApplicationPage

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -36,6 +36,8 @@ import useRevalidateApplication from '../../utils/hooks/useRevalidateApplication
 import { getPageElementsInStructure } from '../../utils/helpers/structure/getElementsInStructure'
 import { checkSectionsProgress } from '../../utils/helpers/structure/checkSectionsProgress'
 
+// TODO: Remove this
+
 const ApplicationPageWrapper: React.FC = () => {
   const [isRevalidated, setIsRevalidated] = useState(false)
   const [pageElements, setPageElements] = useState<Page>()

--- a/src/containers/Application/ApplicationSubmission.tsx
+++ b/src/containers/Application/ApplicationSubmission.tsx
@@ -11,6 +11,8 @@ import { Link } from 'react-router-dom'
 import evaluate from '@openmsupply/expression-evaluator'
 import Markdown from '../../utils/helpers/semanticReactMarkdown'
 
+// TODO: Remove this
+
 const ApplicationSubmission: React.FC = () => {
   const [submissionMessageEvaluated, setSubmissionMessageEvaluated] = useState('')
   const {

--- a/src/containers/Application/ElementsBox.tsx
+++ b/src/containers/Application/ElementsBox.tsx
@@ -4,6 +4,7 @@ import { ApplicationViewWrapper } from '../../formElementPlugins'
 import { Page, ResponsesByCode } from '../../utils/types'
 import strings from '../../utils/constants'
 
+// TODO: Remove this
 interface ElementsBoxProps {
   sectionTitle: string
   responsesByCode: ResponsesByCode

--- a/src/containers/Application/NavigationBox.tsx
+++ b/src/containers/Application/NavigationBox.tsx
@@ -5,6 +5,8 @@ import { useRouter } from '../../utils/hooks/useRouter'
 import { CurrentPage, SectionDetails } from '../../utils/types'
 import strings from '../../utils/constants'
 import messages from '../../utils/messages'
+
+// TODO: Remove this
 interface NavigationBoxProps {
   sections: SectionDetails[]
   currentSection: SectionDetails


### PR DESCRIPTION
Fixes #350 

### Branched from
- ~~#375~~ MERGED

### Changes
- Create new `Navigation` component to display **Previous** and **Next** button along with **Review & Summary** (to be implemented in #365) in a raised (using Sticky) component on the bottom of the current page.
- Uses `revalidateMethod` on the Next button handler to catch any problems in the current page (using the same approach from ProgressBar - that triggers a revalidation and calls the method received once it's done).

### Unrelated changes
- Add TODOs on various components/containers to be destroyed once Re-structure for Applications is completed - pretty soon.