### PR TITLE
#377 Create Review nested routes

### DIFF
--- a/src/components/Review/ReviewSection.tsx
+++ b/src/components/Review/ReviewSection.tsx
@@ -17,6 +17,8 @@ import { ReviewResponseDecision, TemplateElementCategory } from '../../utils/gen
 import messages from '../../utils/messages'
 import { ReviewQuestionDecision, ResponsesByCode, SectionState } from '../../utils/types'
 
+// TODO: Remove this
+
 interface ReviewSectionProps {
   allResponses: ResponsesByCode
   assignedToYou: boolean

--- a/src/components/Review/ReviewSubmission.tsx
+++ b/src/components/Review/ReviewSubmission.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Segment } from 'semantic-ui-react'
 
+// TODO: Remove this
+
 const ReviewSubmission: React.FC = () => {
   return (
     <Segment>

--- a/src/containers/Application/ApplicationWrapper.tsx
+++ b/src/containers/Application/ApplicationWrapper.tsx
@@ -9,11 +9,13 @@ import { useRouter } from '../../utils/hooks/useRouter'
 import { FullStructure, User } from '../../utils/types'
 import { ApplicationHome, ApplicationPage } from './'
 import strings from '../../utils/constants'
+import { ReviewWrapper } from '../Review'
 
 const ApplicationWrapper: React.FC = () => {
-  const { match, query } = useRouter()
-  const { serialNumber } = query
-  const { path } = match
+  const {
+    match: { path },
+    query: { serialNumber },
+  } = useRouter()
   const {
     userState: { currentUser },
   } = useUserState()
@@ -41,6 +43,9 @@ const ApplicationWrapper: React.FC = () => {
       </Route>
       <Route exact path={`${path}/summary/submission`}>
         <ApplicationSubmissionNEW structure={structure} />
+      </Route>
+      <Route path={`${path}/review`}>
+        <ReviewWrapper />
       </Route>
       <Route>
         <NoMatch />

--- a/src/containers/Application/ApplicationWrapper.tsx
+++ b/src/containers/Application/ApplicationWrapper.tsx
@@ -45,7 +45,7 @@ const ApplicationWrapper: React.FC = () => {
         <ApplicationSubmissionNEW structure={structure} />
       </Route>
       <Route path={`${path}/review`}>
-        <ReviewWrapper />
+        <ReviewWrapper structure={structure} />
       </Route>
       <Route>
         <NoMatch />

--- a/src/containers/Main/SiteLayout.tsx
+++ b/src/containers/Main/SiteLayout.tsx
@@ -56,7 +56,7 @@ const SiteLayout: React.FC = () => {
             <ApplicationWrapper />
           </FormElementUpdateTrackerProvider>
         </Route>
-        {/* Application current routes */}
+        {/* Application current routes - to be removed */}
         <Route exact path="/application/:serialNumber">
           <ApplicationProvider>
             <ApplicationPageWrapper />
@@ -73,7 +73,7 @@ const SiteLayout: React.FC = () => {
         <Route exact path="/application/:serialNumber/summary">
           <ApplicationOverview />
         </Route>
-        {/* Review */}
+        {/* Review current routes - to be removed */}
         <Route exact path="/application/:serialNumber/review">
           <ReviewOverview />
         </Route>
@@ -89,6 +89,7 @@ const SiteLayout: React.FC = () => {
         <Route exact path="/application/:serialNumber/consolidation/:consolidationId">
           <NoMatch />
         </Route>
+        {/* End of Review routes */}
         <Route exact path="/application/:serialNumber/approval">
           <Approval />
         </Route>

--- a/src/containers/Review/ReviewOverview.tsx
+++ b/src/containers/Review/ReviewOverview.tsx
@@ -21,6 +21,8 @@ import { useUserState } from '../../contexts/UserState'
 import getReviewStartLabel from '../../utils/helpers/review/getReviewStartLabel'
 import { REVIEW_STATUS } from '../../utils/data/reviewStatus'
 
+// TODO: Remove this
+
 const ReviewOverview: React.FC = () => {
   const {
     push,

--- a/src/containers/Review/ReviewPageWrapper.tsx
+++ b/src/containers/Review/ReviewPageWrapper.tsx
@@ -14,6 +14,8 @@ import useUpdateReviewResponse from '../../utils/hooks/useUpdateReviewResponse'
 import { validateReview } from '../../utils/helpers/validation/validateReview'
 import listReviewResponses from '../../utils/helpers/review/listReviewResponses'
 
+// TODO: Remove this
+
 const decisionAreaInitialState = { open: false, review: null, summaryViewProps: null }
 
 const ReviewPageWrapper: React.FC = () => {

--- a/src/containers/Review/ReviewWrapper.tsx
+++ b/src/containers/Review/ReviewWrapper.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { Route, Switch } from 'react-router'
+import { Header } from 'semantic-ui-react'
+import { NoMatch } from '../../components'
+import { useRouter } from '../../utils/hooks/useRouter'
+import { FullStructure } from '../../utils/types'
+
+const ReviewWrapper: React.FC = () => {
+  const {
+    match: { path },
+    query: { reviewId },
+  } = useRouter()
+
+  return (
+    <Switch>
+      <Route exact path={path}>
+        <ReviewHomeNEW />
+      </Route>
+      <Route exact path={`${path}/:reviewId`}>
+        <ReviewPageNEW reviewId={Number(reviewId)} />
+      </Route>
+      <Route exact path={`${path}/:reviewId/summary`}>
+        <ReviewSummaryNEW reviewId={Number(reviewId)} />
+      </Route>
+      <Route>
+        <NoMatch />
+      </Route>
+    </Switch>
+  )
+}
+
+interface ReviewHomeProps {
+  fullStructure?: FullStructure
+}
+
+const ReviewHomeNEW: React.FC<ReviewHomeProps> = ({ fullStructure }) => {
+  return <Header>REVIEW HOME PAGE</Header>
+}
+
+interface ReviewProps {
+  reviewId: number
+}
+
+const ReviewPageNEW: React.FC<ReviewProps> = ({ reviewId }) => {
+  return <Header>REVIEW PAGE</Header>
+}
+
+// To be used in case the decision step is in a separated page...
+const ReviewSummaryNEW: React.FC<ReviewProps> = ({ reviewId }) => {
+  return <Header>REVIEW SUMMARY PAGE</Header>
+}
+
+export default ReviewWrapper

--- a/src/containers/Review/ReviewWrapper.tsx
+++ b/src/containers/Review/ReviewWrapper.tsx
@@ -5,11 +5,16 @@ import { NoMatch } from '../../components'
 import { useRouter } from '../../utils/hooks/useRouter'
 import { FullStructure } from '../../utils/types'
 
-const ReviewWrapper: React.FC = () => {
+interface ReviewWrapperProps {
+  structure: FullStructure
+}
+
+const ReviewWrapper: React.FC<ReviewWrapperProps> = ({ structure }) => {
   const {
     match: { path },
-    query: { reviewId },
   } = useRouter()
+
+  console.log('Strcture', structure)
 
   return (
     <Switch>
@@ -29,11 +34,7 @@ const ReviewWrapper: React.FC = () => {
   )
 }
 
-interface ReviewHomeProps {
-  fullStructure?: FullStructure
-}
-
-const ReviewHomeNEW: React.FC<ReviewHomeProps> = ({ fullStructure }) => {
+const ReviewHomeNEW: React.FC = () => {
   return <Header>REVIEW HOME PAGE</Header>
 }
 

--- a/src/containers/Review/ReviewWrapper.tsx
+++ b/src/containers/Review/ReviewWrapper.tsx
@@ -17,10 +17,10 @@ const ReviewWrapper: React.FC = () => {
         <ReviewHomeNEW />
       </Route>
       <Route exact path={`${path}/:reviewId`}>
-        <ReviewPageNEW reviewId={Number(reviewId)} />
+        <ReviewPageNEW />
       </Route>
       <Route exact path={`${path}/:reviewId/summary`}>
-        <ReviewSummaryNEW reviewId={Number(reviewId)} />
+        <ReviewSummaryNEW />
       </Route>
       <Route>
         <NoMatch />
@@ -37,16 +37,12 @@ const ReviewHomeNEW: React.FC<ReviewHomeProps> = ({ fullStructure }) => {
   return <Header>REVIEW HOME PAGE</Header>
 }
 
-interface ReviewProps {
-  reviewId: number
-}
-
-const ReviewPageNEW: React.FC<ReviewProps> = ({ reviewId }) => {
+const ReviewPageNEW: React.FC = () => {
   return <Header>REVIEW PAGE</Header>
 }
 
 // To be used in case the decision step is in a separated page...
-const ReviewSummaryNEW: React.FC<ReviewProps> = ({ reviewId }) => {
+const ReviewSummaryNEW: React.FC = () => {
   return <Header>REVIEW SUMMARY PAGE</Header>
 }
 

--- a/src/containers/Review/index.ts
+++ b/src/containers/Review/index.ts
@@ -1,4 +1,5 @@
 import ReviewOverview from './ReviewOverview'
 import ReviewPageWrapper from './ReviewPageWrapper'
+import ReviewWrapper from './ReviewWrapper'
 
-export { ReviewOverview, ReviewPageWrapper }
+export { ReviewOverview, ReviewPageWrapper, ReviewWrapper }


### PR DESCRIPTION
Fixes #377 

### Changes
- Add `ReviewWrapper` with routes to new pages to be using new structure to render in UI
- Call `ReviewWrapper` from `ApplicationWrapper` to display nested routes (temporally) using paths:
  - Review Home [localhost:3000/applicationNEW/12345/review](http://localhost:3000/applicationNEW/12345/review)
  - Review Page [localhost:3000/applicationNEW/12345/review/1](http://ocalhost:3000/applicationNEW/12345/review/1)
  - Review Summary [localhost:3000/applicationNEW/12345/review/1/summary](http://localhost:3000/applicationNEW/12345/review/1/summary)

### Unrelated changes
- Add TODOs to remove container/components when re-structure is finished