### PR TITLE
#365 New submission page

### DIFF
--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -6,6 +6,7 @@ import {
   SectionAndPage,
   MethodRevalidate,
   MethodToCallProps,
+  ApplicationProps,
 } from '../../utils/types'
 import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
 import { ApplicationStatus } from '../../utils/generated/graphql'
@@ -18,11 +19,6 @@ import ProgressBarNEW from '../../components/Application/ProgressBarNEW'
 import { PageElements } from '../../components/Application'
 import { useFormElementUpdateTracker } from '../../contexts/FormElementUpdateTrackerState'
 import checkPageIsAccessible from '../../utils/helpers/structure/checkPageIsAccessible'
-
-interface ApplicationProps {
-  structure: FullStructure
-  responses?: ResponsesByCode
-}
 
 interface MethodToCall {
   (props: MethodToCallProps): void

--- a/src/containers/Application/ApplicationSubmissionNEW.tsx
+++ b/src/containers/Application/ApplicationSubmissionNEW.tsx
@@ -1,9 +1,92 @@
-import React from 'react'
-import { Header } from 'semantic-ui-react'
-import { ApplicationProps } from '../../utils/types'
+import React, { useState } from 'react'
+import { Button, Header, Icon, Label, List, Message, Segment } from 'semantic-ui-react'
+import evaluate from '@openmsupply/expression-evaluator'
+import Markdown from '../../utils/helpers/semanticReactMarkdown'
+import { ApplicationProps, EvaluatorParameters } from '../../utils/types'
+import { useUserState } from '../../contexts/UserState'
+import { useRouter } from '../../utils/hooks/useRouter'
+import strings from '../../utils/constants'
+import { Link } from 'react-router-dom'
 
 const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
-  return <Header>SUBMISSION PAGE</Header>
+  const [submissionMessageEvaluated, setSubmissionMessageEvaluated] = useState('')
+  const {
+    userState: { currentUser },
+  } = useUserState()
+
+  const {
+    query: { serialNumber },
+    push,
+  } = useRouter()
+  const {
+    info: { submissionMessage, type },
+    stages,
+  } = structure
+
+  const evaluatorParams: EvaluatorParameters = {
+    objects: { currentUser },
+    APIfetch: fetch,
+  }
+  evaluate(submissionMessage || '', evaluatorParams).then((result: any) =>
+    setSubmissionMessageEvaluated(result)
+  )
+
+  // useEffect(() => {
+  //   if (!isApplicationReady) return
+  //   const status = application?.current?.status
+  //   // Check if application is in Draft or Changes required status and redirect to the summary page
+  //   // Note: The summary page has its own redirection logic to a specific page (with invalid items).
+  //   if (status === ApplicationStatus.Draft || status === ApplicationStatus.ChangesRequired) {
+  //     push(`/application/${serialNumber}/summary`)
+  //   }
+  // }, [isApplicationReady])
+
+  return (
+    <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>
+      <Header textAlign="center">
+        {currentUser?.organisation?.orgName || strings.TITLE_NO_ORGANISATION}
+      </Header>
+      <Segment
+        textAlign="center"
+        style={{
+          backgroundColor: 'white',
+          padding: 10,
+          margin: '0px 50px',
+          minHeight: 500,
+          flex: 1,
+        }}
+      >
+        <Header icon>
+          <Icon name="clock outline" color="blue" size="huge" />
+          {strings.LABEL_PROCESSING}
+        </Header>
+        <Markdown text={submissionMessageEvaluated} />
+        <Segment basic textAlign="left" style={{ margin: '50px 50px', padding: 10 }}>
+          <Header as="h5">{strings.SUBTITLE_SUBMISSION_STEPS}</Header>
+          <List>
+            {stages.map(({ title, description }) =>
+              title ? (
+                <List.Item key={`list_stage_${title}`}>
+                  <List.Header>{title}</List.Header>
+                  {description}
+                </List.Item>
+              ) : null
+            )}
+          </List>
+        </Segment>
+        <Segment basic textAlign="center" style={{ margin: '50px 50px', padding: 10 }}>
+          <Button
+            color="blue"
+            as={Link}
+            to={`/applicationNEW/${serialNumber}/summary`}
+            style={{ minWidth: 200 }}
+            content={`${strings.BUTTON_BACK_TO} ${type}`}
+          />
+          <Label as={Link} to={'/'} content={strings.BUTTON_BACK_DASHBOARD} />
+        </Segment>
+      </Segment>
+    </Segment.Group>
+  )
 }
 
 export default ApplicationSubmission

--- a/src/containers/Application/ApplicationSubmissionNEW.tsx
+++ b/src/containers/Application/ApplicationSubmissionNEW.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { Header } from 'semantic-ui-react'
+import { ApplicationProps } from '../../utils/types'
+
+const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
+  return <Header>SUBMISSION PAGE</Header>
+}
+
+export default ApplicationSubmission

--- a/src/containers/Application/ApplicationSubmissionNEW.tsx
+++ b/src/containers/Application/ApplicationSubmissionNEW.tsx
@@ -7,6 +7,7 @@ import { useUserState } from '../../contexts/UserState'
 import { useRouter } from '../../utils/hooks/useRouter'
 import strings from '../../utils/constants'
 import { Link } from 'react-router-dom'
+import { ApplicationStatus } from '../../utils/generated/graphql'
 
 const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
   const [submissionMessageEvaluated, setSubmissionMessageEvaluated] = useState('')
@@ -19,9 +20,17 @@ const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
     push,
   } = useRouter()
   const {
-    info: { submissionMessage, type },
+    info: { current, submissionMessage, type },
     stages,
   } = structure
+
+  // Check if application not submitted and redirect to the summary page
+  // Note: The summary page has its own redirection logic to a specific page (with invalid items).
+  if (
+    current?.status === ApplicationStatus.Draft ||
+    current?.status === ApplicationStatus.ChangesRequired
+  )
+    push(`/applicationNEW/${serialNumber}/summary`)
 
   const evaluatorParams: EvaluatorParameters = {
     objects: { currentUser },
@@ -30,16 +39,6 @@ const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
   evaluate(submissionMessage || '', evaluatorParams).then((result: any) =>
     setSubmissionMessageEvaluated(result)
   )
-
-  // useEffect(() => {
-  //   if (!isApplicationReady) return
-  //   const status = application?.current?.status
-  //   // Check if application is in Draft or Changes required status and redirect to the summary page
-  //   // Note: The summary page has its own redirection logic to a specific page (with invalid items).
-  //   if (status === ApplicationStatus.Draft || status === ApplicationStatus.ChangesRequired) {
-  //     push(`/application/${serialNumber}/summary`)
-  //   }
-  // }, [isApplicationReady])
 
   return (
     <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>

--- a/src/containers/Application/ApplicationWrapper.tsx
+++ b/src/containers/Application/ApplicationWrapper.tsx
@@ -7,7 +7,7 @@ import { useUserState } from '../../contexts/UserState'
 import useLoadApplication from '../../utils/hooks/useLoadApplicationNEW'
 import { useRouter } from '../../utils/hooks/useRouter'
 import { FullStructure, User } from '../../utils/types'
-import { ApplicationHome, ApplicationPage } from './'
+import { ApplicationHome, ApplicationPage, ApplicationSubmission } from './'
 import strings from '../../utils/constants'
 
 const ApplicationWrapper: React.FC = () => {
@@ -39,8 +39,8 @@ const ApplicationWrapper: React.FC = () => {
       <Route exact path={`${path}/summary`}>
         <ApplicationSummaryNEW structure={structure} />
       </Route>
-      <Route exact path={`${path}/summary/submission`}>
-        <ApplicationSubmissionNEW structure={structure} />
+      <Route exact path={`${path}/submission`}>
+        <ApplicationSubmission structure={structure} />
       </Route>
       <Route>
         <NoMatch />
@@ -57,10 +57,6 @@ interface ApplicationProps {
 
 const ApplicationSummaryNEW: React.FC<ApplicationProps> = ({ structure }) => {
   return <Header>SUMMARY PAGE</Header>
-}
-
-const ApplicationSubmissionNEW: React.FC<ApplicationProps> = ({ structure }) => {
-  return <Header>SUBMISSION PAGE</Header>
 }
 
 export default ApplicationWrapper

--- a/src/containers/Application/index.ts
+++ b/src/containers/Application/index.ts
@@ -4,6 +4,7 @@ import ElementsBox from './ElementsBox'
 import NavigationBox from './NavigationBox'
 import ApplicationWrapper from './ApplicationWrapper'
 import ApplicationHome from './ApplicationHome'
+import ApplicationSubmission from './ApplicationSubmissionNEW'
 import ApplicationPage from './ApplicationPage'
 
 export {
@@ -11,6 +12,7 @@ export {
   ApplicationPageWrapper,
   ApplicationHome,
   ApplicationPage,
+  ApplicationSubmission,
   ApplicationWrapper,
   ElementsBox,
   NavigationBox,

--- a/src/utils/hooks/useLoadApplicationNEW.ts
+++ b/src/utils/hooks/useLoadApplicationNEW.ts
@@ -84,17 +84,6 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
     const applicationSection = application.applicationSections.nodes as ApplicationSection[]
     const sections = getApplicationSections(applicationSection)
 
-    const templateStages = application.template?.templateStages.nodes as TemplateStage[]
-
-    const stagesDetails: ApplicationStages = {
-      stages: templateStages.map((stage) => ({
-        number: stage.number as number,
-        title: stage.title as string,
-        description: stage.description ? stage.description : undefined,
-      })),
-      submissionMessage: application.template?.submissionMessage as string,
-    }
-
     const stages = data.applicationStageStatusLatests?.nodes as ApplicationStageStatusAll[]
     if (stages.length > 1) console.log('StageStatusAll More than one results for 1 application!')
     const { stageId, stage, status, statusHistoryTimeCreated } = stages[0] // Should only have one result
@@ -115,6 +104,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
         date: DateTime.fromISO(statusHistoryTimeCreated),
       },
       firstStrictInvalidPage: null,
+      submissionMessage: application.template?.submissionMessage as string,
     }
 
     const baseElements: ElementBaseNEW[] = []
@@ -144,9 +134,15 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
       })
     })
 
+    const templateStages = application.template?.templateStages.nodes as TemplateStage[]
+
     setFullStructure({
       info: applicationDetails,
-      stages: stagesDetails,
+      stages: templateStages.map((stage) => ({
+        number: stage.number as number,
+        title: stage.title as string,
+        description: stage.description ? stage.description : undefined,
+      })),
       sections: buildSectionsStructure({ sections, baseElements }),
     })
     setIsLoading(false)

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -19,6 +19,7 @@ export {
   ApplicationDetails,
   ApplicationElementStates,
   ApplicationListRow,
+  ApplicationProps,
   ApplicationStage,
   ApplicationStageMap,
   ApplicationStages,
@@ -106,6 +107,11 @@ interface ApplicationElementStates {
 
 interface ApplicationListRow extends ApplicationList {
   isExpanded: boolean
+}
+
+interface ApplicationProps {
+  structure: FullStructure
+  responses?: ResponsesByCode
 }
 
 interface ApplicationStage {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -22,7 +22,7 @@ export {
   ApplicationProps,
   ApplicationStage,
   ApplicationStageMap,
-  ApplicationStages,
+  ApplicationStages, // TODO: Remove this
   AssignmentDetails,
   CellProps,
   ColumnDetails,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -99,6 +99,7 @@ interface ApplicationDetails {
   isLinear: boolean
   current?: StageAndStatus // TODO: Change to compulsory after re-strcture is finished
   firstStrictInvalidPage: SectionAndPage | null
+  submissionMessage?: string // TODO: Change to compulsory after re-structure is finished
 }
 
 interface ApplicationElementStates {
@@ -247,7 +248,7 @@ interface FullStructure {
   lastValidationTimestamp?: number
   info: ApplicationDetails
   sections: SectionsStructureNEW
-  stages: ApplicationStages
+  stages: StageDetails[]
   responsesByCode?: ResponsesByCode
 }
 


### PR DESCRIPTION
Fixes #365 

### Changes
- Create new `ApplicationSubmission` page container that receives the structure and only display the page - I wasn't sure if that might be just a component - since there isn't much logic going on here. But I guess we might have later on.
- Change type **FullStructure.info** to also keep the `submissionMessage` used in the Submission page for an application
- Change type **FullStructure.stages** to be replaced with what was agreed on the new [Naming Changes Structure Diagram](https://app.diagrams.net/#G1wEk_eH1uWd8LC0JeKAM58bUkGncxKDgW). 
- Disclaimer: Although changes were done to same structure in use by old Application pages, I didn't have to change anything since the previous `stages` with `submissionMessage` was stored in a different object with type `ApplicationStages` that hasn't changes. And the addition to `submissionMessage` in the `ApplicationDetails` is using the temporary set to be optional field, so not required for previous use.
- Set redirect to the `ApplicationSummary` page when the application latest status isn't SUBMITTED/RE-SUBMITTED
- Links to Application list (based on **application.type**) and home page from the Submission page. 