### PR TITLE
#378 New hook useGetReviewInfo

### DIFF
--- a/src/containers/Review/ReviewWrapper.tsx
+++ b/src/containers/Review/ReviewWrapper.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { Route, Switch } from 'react-router'
-import { Header } from 'semantic-ui-react'
-import { NoMatch } from '../../components'
+import { Header, Message } from 'semantic-ui-react'
+import { Loading, NoMatch } from '../../components'
+import { useUserState } from '../../contexts/UserState'
+import useGetReviewInfo from '../../utils/hooks/useGetReviewInfo'
 import { useRouter } from '../../utils/hooks/useRouter'
-import { FullStructure } from '../../utils/types'
+import { AssignmentDetailsNEW, FullStructure } from '../../utils/types'
 
 interface ReviewWrapperProps {
   structure: FullStructure
@@ -13,13 +15,25 @@ const ReviewWrapper: React.FC<ReviewWrapperProps> = ({ structure }) => {
   const {
     match: { path },
   } = useRouter()
+  const {
+    userState: { currentUser },
+  } = useUserState()
 
-  console.log('Strcture', structure)
+  const { error, loading, assignments } = useGetReviewInfo({
+    applicationId: structure.info.id,
+    userId: currentUser?.userId as number,
+  })
+
+  if (error) return <Message error />
+
+  if (loading) return <Loading />
+
+  if (!assignments || assignments.length === 0) return <NoMatch />
 
   return (
     <Switch>
       <Route exact path={path}>
-        <ReviewHomeNEW />
+        <ReviewHomeNEW assignments={assignments} />
       </Route>
       <Route exact path={`${path}/:reviewId`}>
         <ReviewPageNEW />
@@ -34,7 +48,12 @@ const ReviewWrapper: React.FC<ReviewWrapperProps> = ({ structure }) => {
   )
 }
 
-const ReviewHomeNEW: React.FC = () => {
+interface ReviewHomeProps {
+  assignments: AssignmentDetailsNEW[]
+}
+
+const ReviewHomeNEW: React.FC<ReviewHomeProps> = ({ assignments }) => {
+  console.log(assignments) // To be continued in #379
   return <Header>REVIEW HOME PAGE</Header>
 }
 

--- a/src/containers/Review/ReviewWrapper.tsx
+++ b/src/containers/Review/ReviewWrapper.tsx
@@ -33,7 +33,7 @@ const ReviewWrapper: React.FC<ReviewWrapperProps> = ({ structure }) => {
   return (
     <Switch>
       <Route exact path={path}>
-        <ReviewHomeNEW assignments={assignments} />
+        <ReviewHomeNEW assignments={assignments} structure={structure} />
       </Route>
       <Route exact path={`${path}/:reviewId`}>
         <ReviewPageNEW />
@@ -50,9 +50,10 @@ const ReviewWrapper: React.FC<ReviewWrapperProps> = ({ structure }) => {
 
 interface ReviewHomeProps {
   assignments: AssignmentDetailsNEW[]
+  structure: FullStructure
 }
 
-const ReviewHomeNEW: React.FC<ReviewHomeProps> = ({ assignments }) => {
+const ReviewHomeNEW: React.FC<ReviewHomeProps> = ({ assignments, structure }) => {
   console.log(assignments) // To be continued in #379
   return <Header>REVIEW HOME PAGE</Header>
 }

--- a/src/containers/Review/ReviewWrapper.tsx
+++ b/src/containers/Review/ReviewWrapper.tsx
@@ -6,6 +6,7 @@ import { useUserState } from '../../contexts/UserState'
 import useGetReviewInfo from '../../utils/hooks/useGetReviewInfo'
 import { useRouter } from '../../utils/hooks/useRouter'
 import { AssignmentDetailsNEW, FullStructure } from '../../utils/types'
+import strings from '../../utils/constants'
 
 interface ReviewWrapperProps {
   structure: FullStructure
@@ -24,7 +25,7 @@ const ReviewWrapper: React.FC<ReviewWrapperProps> = ({ structure }) => {
     userId: currentUser?.userId as number,
   })
 
-  if (error) return <Message error />
+  if (error) return <Message error header={strings.ERROR_REVIEW_PAGE} list={[error]} />
 
   if (loading) return <Loading />
 

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -2533,6 +2533,8 @@ export type ReviewFilter = {
   isLastLevel?: Maybe<BooleanFilter>;
   /** Filter by the object’s `status` field. */
   status?: Maybe<ReviewStatusFilter>;
+  /** Filter by the object’s `timeCreated` field. */
+  timeCreated?: Maybe<DatetimeFilter>;
   /** Filter by the object’s `reviewResponses` relation. */
   reviewResponses?: Maybe<ReviewToManyReviewResponseFilter>;
   /** Some related `reviewResponses` exist. */
@@ -4648,6 +4650,7 @@ export type Review = Node & {
   /** Reads and enables pagination through a set of `Notification`. */
   notifications: NotificationsConnection;
   status?: Maybe<ReviewStatus>;
+  timeCreated?: Maybe<Scalars['Datetime']>;
 };
 
 
@@ -19775,6 +19778,39 @@ export type GetReviewAssignmentQuery = (
   )> }
 );
 
+export type GetReviewInfoQueryVariables = Exact<{
+  reviewerId: Scalars['Int'];
+  applicationId?: Maybe<Scalars['Int']>;
+}>;
+
+
+export type GetReviewInfoQuery = (
+  { __typename?: 'Query' }
+  & { reviewAssignments?: Maybe<(
+    { __typename?: 'ReviewAssignmentsConnection' }
+    & { nodes: Array<Maybe<(
+      { __typename?: 'ReviewAssignment' }
+      & Pick<ReviewAssignment, 'id' | 'timeCreated'>
+      & { reviewer?: Maybe<(
+        { __typename?: 'User' }
+        & Pick<User, 'id' | 'username' | 'firstName' | 'lastName'>
+      )>, reviews: (
+        { __typename?: 'ReviewsConnection' }
+        & { nodes: Array<Maybe<(
+          { __typename?: 'Review' }
+          & Pick<Review, 'id' | 'status' | 'timeCreated'>
+        )>> }
+      ), stage?: Maybe<(
+        { __typename?: 'TemplateStage' }
+        & Pick<TemplateStage, 'title' | 'id'>
+      )>, reviewQuestionAssignments: (
+        { __typename?: 'ReviewQuestionAssignmentsConnection' }
+        & Pick<ReviewQuestionAssignmentsConnection, 'totalCount'>
+      ) }
+    )>> }
+  )> }
+);
+
 export type GetReviewStatusQueryVariables = Exact<{
   reviewId: Scalars['Int'];
 }>;
@@ -20676,6 +20712,63 @@ export function useGetReviewAssignmentLazyQuery(baseOptions?: Apollo.LazyQueryHo
 export type GetReviewAssignmentQueryHookResult = ReturnType<typeof useGetReviewAssignmentQuery>;
 export type GetReviewAssignmentLazyQueryHookResult = ReturnType<typeof useGetReviewAssignmentLazyQuery>;
 export type GetReviewAssignmentQueryResult = Apollo.QueryResult<GetReviewAssignmentQuery, GetReviewAssignmentQueryVariables>;
+export const GetReviewInfoDocument = gql`
+    query getReviewInfo($reviewerId: Int!, $applicationId: Int) {
+  reviewAssignments(condition: {reviewerId: $reviewerId, applicationId: $applicationId}) {
+    nodes {
+      id
+      timeCreated
+      reviewer {
+        id
+        username
+        firstName
+        lastName
+      }
+      reviews {
+        nodes {
+          id
+          status
+          timeCreated
+        }
+      }
+      stage {
+        title
+        id
+      }
+      reviewQuestionAssignments {
+        totalCount
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useGetReviewInfoQuery__
+ *
+ * To run a query within a React component, call `useGetReviewInfoQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetReviewInfoQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetReviewInfoQuery({
+ *   variables: {
+ *      reviewerId: // value for 'reviewerId'
+ *      applicationId: // value for 'applicationId'
+ *   },
+ * });
+ */
+export function useGetReviewInfoQuery(baseOptions?: Apollo.QueryHookOptions<GetReviewInfoQuery, GetReviewInfoQueryVariables>) {
+        return Apollo.useQuery<GetReviewInfoQuery, GetReviewInfoQueryVariables>(GetReviewInfoDocument, baseOptions);
+      }
+export function useGetReviewInfoLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetReviewInfoQuery, GetReviewInfoQueryVariables>) {
+          return Apollo.useLazyQuery<GetReviewInfoQuery, GetReviewInfoQueryVariables>(GetReviewInfoDocument, baseOptions);
+        }
+export type GetReviewInfoQueryHookResult = ReturnType<typeof useGetReviewInfoQuery>;
+export type GetReviewInfoLazyQueryHookResult = ReturnType<typeof useGetReviewInfoLazyQuery>;
+export type GetReviewInfoQueryResult = Apollo.QueryResult<GetReviewInfoQuery, GetReviewInfoQueryVariables>;
 export const GetReviewStatusDocument = gql`
     query getReviewStatus($reviewId: Int!) {
   reviewStatusHistories(condition: {isCurrent: true, reviewId: $reviewId}) {

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -19807,7 +19807,7 @@ export type GetReviewInfoQuery = (
         { __typename?: 'ReviewsConnection' }
         & { nodes: Array<Maybe<(
           { __typename?: 'Review' }
-          & Pick<Review, 'id' | 'status' | 'timeCreated'>
+          & Pick<Review, 'id' | 'status' | 'timeCreated' | 'level'>
         )>> }
       ), stage?: Maybe<(
         { __typename?: 'TemplateStage' }
@@ -20797,6 +20797,7 @@ export const GetReviewInfoDocument = gql`
           id
           status
           timeCreated
+          level
         }
       }
       stage {

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -19802,12 +19802,12 @@ export type GetReviewInfoQuery = (
     { __typename?: 'ReviewAssignmentsConnection' }
     & { nodes: Array<Maybe<(
       { __typename?: 'ReviewAssignment' }
-      & Pick<ReviewAssignment, 'id' | 'status' | 'timeCreated'>
+      & Pick<ReviewAssignment, 'id' | 'level' | 'status' | 'timeCreated'>
       & { reviews: (
         { __typename?: 'ReviewsConnection' }
         & { nodes: Array<Maybe<(
           { __typename?: 'Review' }
-          & Pick<Review, 'id' | 'level' | 'status' | 'timeCreated' | 'trigger'>
+          & Pick<Review, 'id' | 'status' | 'timeCreated' | 'trigger'>
         )>> }
       ), stage?: Maybe<(
         { __typename?: 'TemplateStage' }
@@ -20791,12 +20791,12 @@ export const GetReviewInfoDocument = gql`
   reviewAssignments(condition: {reviewerId: $reviewerId, applicationId: $applicationId}, orderBy: TIME_CREATED_DESC) {
     nodes {
       id
+      level
       status
       timeCreated
       reviews {
         nodes {
           id
-          level
           status
           timeCreated
           trigger

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -19791,10 +19791,7 @@ export type GetReviewInfoQuery = (
     & { nodes: Array<Maybe<(
       { __typename?: 'ReviewAssignment' }
       & Pick<ReviewAssignment, 'id' | 'timeCreated'>
-      & { reviewer?: Maybe<(
-        { __typename?: 'User' }
-        & Pick<User, 'id' | 'username' | 'firstName' | 'lastName'>
-      )>, reviews: (
+      & { reviews: (
         { __typename?: 'ReviewsConnection' }
         & { nodes: Array<Maybe<(
           { __typename?: 'Review' }
@@ -20718,12 +20715,6 @@ export const GetReviewInfoDocument = gql`
     nodes {
       id
       timeCreated
-      reviewer {
-        id
-        username
-        firstName
-        lastName
-      }
       reviews {
         nodes {
           id

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -19802,7 +19802,7 @@ export type GetReviewInfoQuery = (
     { __typename?: 'ReviewAssignmentsConnection' }
     & { nodes: Array<Maybe<(
       { __typename?: 'ReviewAssignment' }
-      & Pick<ReviewAssignment, 'id' | 'timeCreated'>
+      & Pick<ReviewAssignment, 'id' | 'status' | 'timeCreated'>
       & { reviews: (
         { __typename?: 'ReviewsConnection' }
         & { nodes: Array<Maybe<(
@@ -20788,9 +20788,10 @@ export type GetReviewAssignmentLazyQueryHookResult = ReturnType<typeof useGetRev
 export type GetReviewAssignmentQueryResult = Apollo.QueryResult<GetReviewAssignmentQuery, GetReviewAssignmentQueryVariables>;
 export const GetReviewInfoDocument = gql`
     query getReviewInfo($reviewerId: Int!, $applicationId: Int) {
-  reviewAssignments(condition: {reviewerId: $reviewerId, applicationId: $applicationId}) {
+  reviewAssignments(condition: {reviewerId: $reviewerId, applicationId: $applicationId}, orderBy: TIME_CREATED_DESC) {
     nodes {
       id
+      status
       timeCreated
       reviews {
         nodes {

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -19807,7 +19807,7 @@ export type GetReviewInfoQuery = (
         { __typename?: 'ReviewsConnection' }
         & { nodes: Array<Maybe<(
           { __typename?: 'Review' }
-          & Pick<Review, 'id' | 'status' | 'timeCreated' | 'level'>
+          & Pick<Review, 'id' | 'level' | 'status' | 'timeCreated' | 'trigger'>
         )>> }
       ), stage?: Maybe<(
         { __typename?: 'TemplateStage' }
@@ -20796,9 +20796,10 @@ export const GetReviewInfoDocument = gql`
       reviews {
         nodes {
           id
+          level
           status
           timeCreated
-          level
+          trigger
         }
       }
       stage {

--- a/src/utils/graphql/queries/getApplication.query.ts
+++ b/src/utils/graphql/queries/getApplication.query.ts
@@ -1,5 +1,7 @@
 import { gql } from '@apollo/client'
 
+// TODO: Remove this
+
 export default gql`
   query getApplication($serial: String!) {
     applicationBySerial(serial: $serial) {

--- a/src/utils/graphql/queries/getReview.query.ts
+++ b/src/utils/graphql/queries/getReview.query.ts
@@ -1,5 +1,7 @@
 import { gql } from '@apollo/client'
 
+// TODO: Remove this
+
 export default gql`
   query getReview($reviewId: Int!) {
     review(id: $reviewId) {

--- a/src/utils/graphql/queries/getReviewAssignment.query.ts
+++ b/src/utils/graphql/queries/getReviewAssignment.query.ts
@@ -1,5 +1,7 @@
 import { gql } from '@apollo/client'
 
+// TODO: Remove this
+
 export default gql`
   query getReviewAssignment($reviewerId: Int!, $applicationId: Int, $stageId: Int) {
     reviewAssignments(

--- a/src/utils/graphql/queries/getReviewInfo.query.ts
+++ b/src/utils/graphql/queries/getReviewInfo.query.ts
@@ -6,12 +6,6 @@ export default gql`
       nodes {
         id
         timeCreated
-        reviewer {
-          id
-          username
-          firstName
-          lastName
-        }
         reviews {
           nodes {
             id

--- a/src/utils/graphql/queries/getReviewInfo.query.ts
+++ b/src/utils/graphql/queries/getReviewInfo.query.ts
@@ -13,9 +13,10 @@ export default gql`
         reviews {
           nodes {
             id
+            level
             status
             timeCreated
-            level
+            trigger
           }
         }
         stage {

--- a/src/utils/graphql/queries/getReviewInfo.query.ts
+++ b/src/utils/graphql/queries/getReviewInfo.query.ts
@@ -2,9 +2,13 @@ import { gql } from '@apollo/client'
 
 export default gql`
   query getReviewInfo($reviewerId: Int!, $applicationId: Int) {
-    reviewAssignments(condition: { reviewerId: $reviewerId, applicationId: $applicationId }) {
+    reviewAssignments(
+      condition: { reviewerId: $reviewerId, applicationId: $applicationId }
+      orderBy: TIME_CREATED_DESC
+    ) {
       nodes {
         id
+        status
         timeCreated
         reviews {
           nodes {

--- a/src/utils/graphql/queries/getReviewInfo.query.ts
+++ b/src/utils/graphql/queries/getReviewInfo.query.ts
@@ -1,0 +1,32 @@
+import { gql } from '@apollo/client'
+
+export default gql`
+  query getReviewInfo($reviewerId: Int!, $applicationId: Int) {
+    reviewAssignments(condition: { reviewerId: $reviewerId, applicationId: $applicationId }) {
+      nodes {
+        id
+        timeCreated
+        reviewer {
+          id
+          username
+          firstName
+          lastName
+        }
+        reviews {
+          nodes {
+            id
+            status
+            timeCreated
+          }
+        }
+        stage {
+          title
+          id
+        }
+        reviewQuestionAssignments {
+          totalCount
+        }
+      }
+    }
+  }
+`

--- a/src/utils/graphql/queries/getReviewInfo.query.ts
+++ b/src/utils/graphql/queries/getReviewInfo.query.ts
@@ -8,12 +8,12 @@ export default gql`
     ) {
       nodes {
         id
+        level
         status
         timeCreated
         reviews {
           nodes {
             id
-            level
             status
             timeCreated
             trigger

--- a/src/utils/graphql/queries/getReviewInfo.query.ts
+++ b/src/utils/graphql/queries/getReviewInfo.query.ts
@@ -11,6 +11,7 @@ export default gql`
             id
             status
             timeCreated
+            level
           }
         }
         stage {

--- a/src/utils/graphql/queries/getReviewStatus.query.ts
+++ b/src/utils/graphql/queries/getReviewStatus.query.ts
@@ -1,5 +1,7 @@
 import { gql } from '@apollo/client'
 
+// TODO: Remove this
+
 export default gql`
   query getReviewStatus($reviewId: Int!) {
     reviewStatusHistories(condition: { isCurrent: true, reviewId: $reviewId }) {

--- a/src/utils/hooks/useGetResponsesAndElementState.tsx
+++ b/src/utils/hooks/useGetResponsesAndElementState.tsx
@@ -17,6 +17,8 @@ import {
 } from '../types'
 import evaluateExpression from '@openmsupply/expression-evaluator'
 
+// TODO: Remove this
+
 const useGetResponsesAndElementState = ({
   serialNumber,
   isApplicationReady,

--- a/src/utils/hooks/useGetReviewAssignment.tsx
+++ b/src/utils/hooks/useGetReviewAssignment.tsx
@@ -15,6 +15,7 @@ import getAssignedQuestions from '../helpers/review/getAssignedQuestions'
 import { useUserState } from '../../contexts/UserState'
 import updateSectionsReviews from '../helpers/structure/updateSectionsReviews'
 
+// TODO: Remove this
 interface UseGetReviewAssignmentProps {
   reviewerId: number
   serialNumber: string

--- a/src/utils/hooks/useGetReviewInfo.tsx
+++ b/src/utils/hooks/useGetReviewInfo.tsx
@@ -24,7 +24,9 @@ const useGetReviewInfo = ({ applicationId, userId }: UseGetReviewInfoProps) => {
   })
 
   useEffect(() => {
-    if (!data || loading) return
+    if (loading) return setIsFetching(true)
+    if (!data) return
+
     const reviewAssigments = data.reviewAssignments?.nodes as ReviewAssignment[]
 
     // Current user has no assignments

--- a/src/utils/hooks/useGetReviewInfo.tsx
+++ b/src/utils/hooks/useGetReviewInfo.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react'
+import { AssignmentDetailsNEW } from '../types'
+import { Review, ReviewAssignment, ReviewStatus, useGetReviewInfoQuery } from '../generated/graphql'
+
+interface UseGetReviewInfoProps {
+  applicationId: number
+  userId: number
+}
+
+const useGetReviewInfo = ({ applicationId, userId }: UseGetReviewInfoProps) => {
+  const [assignments, setAssignments] = useState<AssignmentDetailsNEW[]>()
+
+  const { data, loading, error } = useGetReviewInfoQuery({
+    variables: {
+      reviewerId: userId,
+      applicationId,
+    },
+  })
+
+  useEffect(() => {
+    if (!data) return
+
+    const reviewAssigments = data.reviewAssignments?.nodes as ReviewAssignment[]
+    const assignments: AssignmentDetailsNEW[] = reviewAssigments.map((reviewAssignment) => {
+      // There will always just be one review assignment linked to a review.
+      const review = reviewAssignment.reviews.nodes[0] as Review
+      if (reviewAssignment.reviews.nodes.length > 1)
+        console.error(
+          'More then one review associated with reviewAssignment with id',
+          reviewAssignment.id
+        )
+
+      const stage = reviewAssignment.stage
+
+      // Extra field just to use in initial example - might conflict with future queries
+      // to get reviewQuestionAssignment
+      const totalAssignedQuestions = reviewAssignment.reviewQuestionAssignments.totalCount
+
+      const { id, status, timeCreated } = review
+
+      return {
+        id: reviewAssignment.id,
+        review: {
+          id,
+          status: status as ReviewStatus,
+          timeCreated,
+          stage: { id: stage?.id as number, name: stage?.title as string },
+        },
+        totalAssignedQuestions,
+      }
+    })
+
+    setAssignments(assignments)
+  }, [data])
+
+  return {
+    error: error?.message,
+    loading,
+    assignments,
+  }
+}
+
+export default useGetReviewInfo

--- a/src/utils/hooks/useGetReviewInfo.tsx
+++ b/src/utils/hooks/useGetReviewInfo.tsx
@@ -30,24 +30,25 @@ const useGetReviewInfo = ({ applicationId, userId }: UseGetReviewInfoProps) => {
           reviewAssignment.id
         )
 
-      const stage = reviewAssignment.stage
+      const { id, status, stage, timeCreated } = reviewAssignment
 
       // Extra field just to use in initial example - might conflict with future queries
       // to get reviewQuestionAssignment
       const totalAssignedQuestions = reviewAssignment.reviewQuestionAssignments.totalCount
 
-      const { id, status, timeCreated } = review
-
       return {
-        id: reviewAssignment.id,
+        id,
         review: review
           ? {
-              id,
-              status: status as ReviewStatus,
-              timeCreated,
+              id: review.id,
+              status: review.status as ReviewStatus,
+              timeCreated: review.timeCreated,
               stage: { id: stage?.id as number, name: stage?.title as string },
             }
           : null,
+        status,
+        stage,
+        timeCreated,
         totalAssignedQuestions,
       }
     })

--- a/src/utils/hooks/useGetReviewInfo.tsx
+++ b/src/utils/hooks/useGetReviewInfo.tsx
@@ -39,7 +39,7 @@ const useGetReviewInfo = ({ applicationId, userId }: UseGetReviewInfoProps) => {
 
     // Checking if any of reviews trigger is running before refetching assignments
     // This is done to get latest status for reviews (afte trigger finishes to run)
-    if (reviews.length === 0 || reviews.every(({ trigger }) => trigger === null)) {
+    if (reviews.every((review) => !review || review?.trigger === null)) {
       setRefetchAttempts(0)
     } else {
       if (refetchAttempts < MAX_REFETCH) {

--- a/src/utils/hooks/useGetReviewInfo.tsx
+++ b/src/utils/hooks/useGetReviewInfo.tsx
@@ -40,12 +40,14 @@ const useGetReviewInfo = ({ applicationId, userId }: UseGetReviewInfoProps) => {
 
       return {
         id: reviewAssignment.id,
-        review: {
-          id,
-          status: status as ReviewStatus,
-          timeCreated,
-          stage: { id: stage?.id as number, name: stage?.title as string },
-        },
+        review: review
+          ? {
+              id,
+              status: status as ReviewStatus,
+              timeCreated,
+              stage: { id: stage?.id as number, name: stage?.title as string },
+            }
+          : null,
         totalAssignedQuestions,
       }
     })

--- a/src/utils/hooks/useGetReviewInfo.tsx
+++ b/src/utils/hooks/useGetReviewInfo.tsx
@@ -37,7 +37,7 @@ const useGetReviewInfo = ({ applicationId, userId }: UseGetReviewInfoProps) => {
 
     // Checking if any of reviews trigger is running before refetching assignments
     // This is done to get latest status for reviews (afte trigger finishes to run)
-    if (reviews.every(({ trigger }) => trigger === null)) {
+    if (reviews.length === 0 || reviews.every(({ trigger }) => trigger === null)) {
       setRefetchAttempts(0)
     } else {
       if (refetchAttempts < MAX_REFETCH) {

--- a/src/utils/hooks/useLoadApplication.tsx
+++ b/src/utils/hooks/useLoadApplication.tsx
@@ -20,6 +20,8 @@ import {
   UseGetApplicationProps,
 } from '../types'
 
+// TODO: Remove this
+
 const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationProps) => {
   const [application, setApplication] = useState<ApplicationDetails>()
   const [template, setTemplate] = useState<TemplateDetails>()

--- a/src/utils/hooks/useLoadApplicationNEW.ts
+++ b/src/utils/hooks/useLoadApplicationNEW.ts
@@ -67,7 +67,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
           setRefetchAttempts(refetchAttempts + 1)
           refetch()
         }, 500)
-      } else setStructureError(messages.APPLICATION_TRIGGER_RUNNING)
+      } else setStructureError(messages.TRIGGER_RUNNING)
       return
     }
 

--- a/src/utils/hooks/useLoadApplicationNEW.ts
+++ b/src/utils/hooks/useLoadApplicationNEW.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import {
   ApplicationDetails,
-  ApplicationStages,
   ElementBaseNEW,
   FullStructure,
   TemplateDetails,

--- a/src/utils/hooks/useLoadReview.tsx
+++ b/src/utils/hooks/useLoadReview.tsx
@@ -13,6 +13,7 @@ import { useUserState } from '../../contexts/UserState'
 import useLoadSectionsStructure from './useLoadSectionsStructure'
 import updateSectionsReviews from '../helpers/structure/updateSectionsReviews'
 
+// TODO: Remove this
 interface UseLoadReviewProps {
   reviewId: number
   serialNumber: string

--- a/src/utils/hooks/useLoadSectionsStructure.ts
+++ b/src/utils/hooks/useLoadSectionsStructure.ts
@@ -4,6 +4,8 @@ import { SectionDetails, SectionsStructure, UseGetApplicationProps } from '../ty
 import useGetResponsesAndElementState from './useGetResponsesAndElementState'
 import useLoadApplication from './useLoadApplication'
 
+// TODO: Remove this
+
 const useLoadSectionsStructure = ({
   serialNumber,
   currentUser,

--- a/src/utils/hooks/useRevalidateApplication.ts
+++ b/src/utils/hooks/useRevalidateApplication.ts
@@ -3,6 +3,7 @@ import updateSectionsProgress from '../helpers/structure/updateSectionsProgress'
 import { ValidatedSections, SectionsStructure, User } from '../types'
 import useGetResponsesAndElementState from './useGetResponsesAndElementState'
 
+// TODO: Remove this
 interface UseRevalidateApplicationProps {
   serialNumber: string
   currentUser: User

--- a/src/utils/hooks/useTriggerProcessing.tsx
+++ b/src/utils/hooks/useTriggerProcessing.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import { useGetTriggersQuery } from '../../utils/generated/graphql'
 
+// TODO: Remove this
+
 type TriggerType = 'applicationTrigger' | 'reviewAssignmentTrigger' | 'reviewTrigger'
 
 interface TriggerApplication {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -2,7 +2,7 @@ export default {
   APPLICATIONS_LIST_EMPTY: 'No applications found',
   APPLICATIONS_MISSING_USER_ROLE: 'No user role found',
   APPLICATION_MISSING_TEMPLATE: '',
-  APPLICATION_TRIGGER_RUNNING: 'Trigger is running. Please wait to reload page again.',
+  LOGIN_WELCOME_SELECT_ORG: 'Welcome back, %1. Please select your organisation.',
   VALIDATION_FAIL: {
     title: 'Validation failed',
     message: 'Please fix invalid fields before continuing',
@@ -17,6 +17,6 @@ export default {
   REVIEW_COMPLETE_SECTION: 'Please complete this section',
   REVIEW_SUBMIT_FAIL: 'Not all sections have been reviewed',
   REVIEW_RESUBMIT_COMMENT: 'Please enter a comment before asking for a re-submission',
-  LOGIN_WELCOME_SELECT_ORG: 'Welcome back, %1. Please select your organisation.',
+  TRIGGER_RUNNING: 'Trigger is running. Please wait to reload page again.',
 }
 // To-do: create a generic string substitution function here.

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -2,6 +2,7 @@ import {
   ApplicationList,
   ApplicationStatus,
   PermissionPolicyType,
+  ReviewAssignmentStatus,
   ReviewResponse,
   ReviewResponseDecision,
   ReviewStatus,
@@ -141,6 +142,8 @@ interface AssignmentDetails {
 
 interface AssignmentDetailsNEW {
   id: number
+  status: ReviewAssignmentStatus
+  timeCreated: DateTime
   review: ReviewDetails | null
   totalAssignedQuestions: number
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -135,13 +135,13 @@ interface ApplicationStages {
 
 interface AssignmentDetails {
   id: number
-  review: ReviewDetails | null
+  review?: ReviewDetails
   questions: ReviewQuestion[]
 }
 
 interface AssignmentDetailsNEW {
   id: number
-  review?: ReviewDetails
+  review: ReviewDetails | null
   totalAssignedQuestions: number
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -135,7 +135,7 @@ interface ApplicationStages {
 
 interface AssignmentDetails {
   id: number
-  review?: ReviewDetails
+  review: ReviewDetails | null
   questions: ReviewQuestion[]
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -23,6 +23,7 @@ export {
   ApplicationStageMap,
   ApplicationStages,
   AssignmentDetails,
+  AssignmentDetailsNEW,
   CellProps,
   ColumnDetails,
   ColumnsPerRole,
@@ -126,6 +127,12 @@ interface AssignmentDetails {
   id: number
   review?: ReviewDetails
   questions: ReviewQuestion[]
+}
+
+interface AssignmentDetailsNEW {
+  id: number
+  review?: ReviewDetails
+  totalAssignedQuestions: number
 }
 
 interface BasicStringObject {
@@ -329,6 +336,8 @@ interface ResumeSection {
 interface ReviewDetails {
   id: number
   status: ReviewStatus
+  timeCreated?: DateTime
+  stage?: ApplicationStage
 }
 
 interface ReviewerDetails {


### PR DESCRIPTION
Fixes #378 

### Back-end branch
Use new back-end in [PR#229](https://github.com/openmsupply/application-manager-server/pull/229) to get `timeCreated` field for the current `status` in each review.

### Summary
To be continue in #379 (Hopefully PR today) and display all ReviewAssignment/Reviews associated to current user in the ReviewHome page. There will be no sections displayed yet, and the reason why the `getReviewInfo` query only return the number of ReviewQuestionAssignment so far (out of curiosity).  

### Changes
- Add query `getReviewInfo.query` to simply get all reviewAssignments based on current reviewer and application id
- Add hook `useGetReviewInfo` which will create the array of AssignmentDetails (new type based on existing one), with fields to display on #379 for each row of Review
- Passed on the `assignments` array to new `ReviewHome` page just logging the result for now
- Returns **NoMatch** in `ReviewWrapper` if no ReviewAssignment is found for current user
- Show error page if something goes wrong with query or loading while loading

### Unrelated changes
- Continue to add some "TODO: Remove this" to help us when removing old methods/hook/queries now replace to use the new structure.