### PR TITLE
fix bug with revalidation

### DIFF
--- a/src/contexts/FormElementUpdateTrackerState.tsx
+++ b/src/contexts/FormElementUpdateTrackerState.tsx
@@ -16,7 +16,11 @@ type FormElementUpdateTrackerProps = { children: React.ReactNode }
 // TODO will have to think about storing elementEnteredTimestamp and elementUpdatedTimestamp by element code/application
 // think of a use case where API query take a long time, and focus is changed to another field and submit is pressed
 // straight away
-const reducer = (state: ContextFormElementUpdateTrackerState, action: UpdateAction) => {
+const reducer = (
+  state: ContextFormElementUpdateTrackerState,
+  action: UpdateAction
+): ContextFormElementUpdateTrackerState => {
+  console.log(state, action)
   switch (action.type) {
     case 'setElementUpdated': {
       const newState = {
@@ -28,7 +32,7 @@ const reducer = (state: ContextFormElementUpdateTrackerState, action: UpdateActi
         ...newState,
         isLastElementUpdateProcessed:
           newState.elementUpdatedTimestamp >= newState.elementEnteredTimestamp,
-        wasValueChange: newState.elementUpdatedTextValue !== newState.elementEnteredTextValue,
+        wasElementChange: newState.elementUpdatedTextValue !== newState.elementEnteredTextValue,
       }
     }
     case 'setElementEntered': {

--- a/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
@@ -123,7 +123,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperPropsNEW> = (props)
   const setIsActive = () => {
     // Tells application state that a plugin field is in focus
     setUpdateTrackerState({
-      type: 'setElementUpdated',
+      type: 'setElementEntered',
       textValue: value || '',
     })
   }


### PR DESCRIPTION
Fixes #413 
@CarlosNZ noticed an issue with slow internet connection and different browser.

found that entered wasn't set properly in plugin wrapper, and found that context wasn't working (allowing changes to look like they haven't occurred and revalidation to happen straight away instead of waiting for updates)