### PR TITLE
#418 Evaluate messages in separated hook

### DIFF
--- a/src/containers/Application/ApplicationCreateNEW.tsx
+++ b/src/containers/Application/ApplicationCreateNEW.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { Button, Divider, Header, Message, Segment } from 'semantic-ui-react'
-import evaluate from '@openmsupply/expression-evaluator'
 import Markdown from '../../utils/helpers/semanticReactMarkdown'
 import { ApplicationHeader, ApplicationSelectType, Loading } from '../../components'
 import { useApplicationState } from '../../contexts/ApplicationState'
@@ -9,7 +8,7 @@ import useCreateApplication from '../../utils/hooks/useCreateApplication'
 import useLoadTemplate from '../../utils/hooks/useLoadTemplateNEW'
 import { useRouter } from '../../utils/hooks/useRouter'
 import strings from '../../utils/constants'
-import { EvaluatorParameters } from '../../utils/types'
+import { User } from '../../utils/types'
 import { SectionsList } from '../../components/Application/Sections'
 
 const ApplicationCreateNEW: React.FC = () => {
@@ -21,21 +20,21 @@ const ApplicationCreateNEW: React.FC = () => {
     push,
     query: { type },
   } = useRouter()
-  const [startMessageEvaluated, setStartMessageEvaluated] = useState('')
-
-  const { error, loading, template } = useLoadTemplate({
-    templateCode: type,
-  })
-
   const {
     userState: { currentUser },
   } = useUserState()
 
+  // const [startMessageEvaluated, setStartMessageEvaluated] = useState('')
+
+  const { error, loading, isMessageEvaluated, startMessage, template } = useLoadTemplate({
+    currentUser: currentUser as User,
+    templateCode: type,
+  })
+
   // If template has no start message, go straight to first page of new application
   useEffect(() => {
-    if (template && !template.startMessage) handleCreate()
-    else evaluateMessage()
-  }, [template])
+    if (isMessageEvaluated && !startMessage) handleCreate()
+  }, [isMessageEvaluated])
 
   const { processing, error: creationError, create } = useCreateApplication({
     onCompleted: () => {
@@ -47,16 +46,6 @@ const ApplicationCreateNEW: React.FC = () => {
       }
     },
   })
-
-  const evaluateMessage = async () => {
-    const evaluatorParams: EvaluatorParameters = {
-      objects: { currentUser },
-      APIfetch: fetch,
-    }
-    evaluate(template?.startMessage || '', evaluatorParams).then((result: any) =>
-      setStartMessageEvaluated(result)
-    )
-  }
 
   const handleCreate = (_?: any) => {
     setApplicationState({ type: 'reset' })
@@ -72,7 +61,7 @@ const ApplicationCreateNEW: React.FC = () => {
     const { name, elementsIds, sections } = template
 
     create({
-      name: template.name,
+      name,
       serial: serialNumber,
       templateId: template.id,
       userId: currentUser?.userId,
@@ -95,7 +84,7 @@ const ApplicationCreateNEW: React.FC = () => {
       />
     )
 
-  if (loading || !template?.startMessage) return <Loading />
+  if (loading || !isMessageEvaluated || !startMessage) return <Loading />
 
   const NewApplicationInfo: React.FC = () => {
     return template?.sections ? (
@@ -104,7 +93,7 @@ const ApplicationCreateNEW: React.FC = () => {
         <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
         <SectionsList sections={template.sections} />
         <Divider />
-        <Markdown text={startMessageEvaluated} semanticComponent="Message" info />
+        <Markdown text={startMessage} semanticComponent="Message" info />
         <Button color="blue" loading={processing} onClick={handleCreate}>
           {strings.BUTTON_APPLICATION_START}
         </Button>

--- a/src/containers/Application/ApplicationSubmissionNEW.tsx
+++ b/src/containers/Application/ApplicationSubmissionNEW.tsx
@@ -1,16 +1,19 @@
-import React, { useState } from 'react'
-import { Button, Header, Icon, Label, List, Message, Segment } from 'semantic-ui-react'
-import evaluate from '@openmsupply/expression-evaluator'
+import React from 'react'
+import { Button, Header, Icon, Label, List, Segment } from 'semantic-ui-react'
 import Markdown from '../../utils/helpers/semanticReactMarkdown'
-import { ApplicationProps, EvaluatorParameters } from '../../utils/types'
 import { useUserState } from '../../contexts/UserState'
 import { useRouter } from '../../utils/hooks/useRouter'
 import strings from '../../utils/constants'
 import { Link } from 'react-router-dom'
 import { ApplicationStatus } from '../../utils/generated/graphql'
+import { FullStructure } from '../../utils/types'
 
-const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
-  const [submissionMessageEvaluated, setSubmissionMessageEvaluated] = useState('')
+interface SubmissionProps {
+  structure: FullStructure
+  submissionMessage?: string
+}
+
+const ApplicationSubmission: React.FC<SubmissionProps> = ({ structure, submissionMessage }) => {
   const {
     userState: { currentUser },
   } = useUserState()
@@ -20,7 +23,7 @@ const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
     push,
   } = useRouter()
   const {
-    info: { current, submissionMessage, type },
+    info: { current, type },
     stages,
   } = structure
 
@@ -31,14 +34,6 @@ const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
     current?.status === ApplicationStatus.ChangesRequired
   )
     push(`/applicationNEW/${serialNumber}/summary`)
-
-  const evaluatorParams: EvaluatorParameters = {
-    objects: { currentUser },
-    APIfetch: fetch,
-  }
-  evaluate(submissionMessage || '', evaluatorParams).then((result: any) =>
-    setSubmissionMessageEvaluated(result)
-  )
 
   return (
     <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>
@@ -59,7 +54,7 @@ const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
           <Icon name="clock outline" color="blue" size="huge" />
           {strings.LABEL_PROCESSING}
         </Header>
-        <Markdown text={submissionMessageEvaluated} />
+        {submissionMessage && <Markdown text={submissionMessage} />}
         <Segment basic textAlign="left" style={{ margin: '50px 50px', padding: 10 }}>
           <Header as="h5">{strings.SUBTITLE_SUBMISSION_STEPS}</Header>
           <List>

--- a/src/containers/Application/ApplicationWrapper.tsx
+++ b/src/containers/Application/ApplicationWrapper.tsx
@@ -1,12 +1,11 @@
 import React from 'react'
 import { Switch, Route } from 'react-router-dom'
-import { Header, Message } from 'semantic-ui-react'
-
+import { Message } from 'semantic-ui-react'
 import { Loading, NoMatch } from '../../components'
 import { useUserState } from '../../contexts/UserState'
 import useLoadApplication from '../../utils/hooks/useLoadApplicationNEW'
 import { useRouter } from '../../utils/hooks/useRouter'
-import { FullStructure, User } from '../../utils/types'
+import { User } from '../../utils/types'
 import { ApplicationHome, ApplicationPage, ApplicationSubmission, ApplicationSummary } from './'
 import strings from '../../utils/constants'
 import { ReviewWrapper } from '../Review'
@@ -20,7 +19,14 @@ const ApplicationWrapper: React.FC = () => {
     userState: { currentUser },
   } = useUserState()
 
-  const { error, isLoading, structure, template } = useLoadApplication({
+  const {
+    error,
+    isLoading,
+    isMessageEvaluated,
+    submissionMessage,
+    structure,
+    template,
+  } = useLoadApplication({
     serialNumber,
     currentUser: currentUser as User,
     networkFetch: true,
@@ -28,7 +34,7 @@ const ApplicationWrapper: React.FC = () => {
 
   return error ? (
     <Message error header={strings.ERROR_APPLICATION_PAGE} list={[error]} />
-  ) : isLoading ? (
+  ) : isLoading || !isMessageEvaluated ? (
     <Loading />
   ) : structure && template ? (
     <Switch>
@@ -42,7 +48,7 @@ const ApplicationWrapper: React.FC = () => {
         <ApplicationSummary structure={structure} />
       </Route>
       <Route exact path={`${path}/submission`}>
-        <ApplicationSubmission structure={structure} />
+        <ApplicationSubmission structure={structure} submissionMessage={submissionMessage} />
       </Route>
       <Route path={`${path}/review`}>
         <ReviewWrapper structure={structure} />

--- a/src/utils/hooks/useEvaluateMessage.ts
+++ b/src/utils/hooks/useEvaluateMessage.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react'
+import evaluate from '@openmsupply/expression-evaluator'
+import { EvaluatorParameters, User } from '../types'
+
+interface UseEvaluateMessage {
+  currentUser: User
+  message?: string
+  shouldEvaluate: boolean
+}
+
+const useEvaluateMessage = ({ currentUser, message, shouldEvaluate }: UseEvaluateMessage) => {
+  const [evaluatedMessage, setEvaluatedMessage] = useState('')
+  const [isMessageEvaluated, setIsMessageEvaluated] = useState(false)
+
+  useEffect(() => {
+    if (!shouldEvaluate) setIsMessageEvaluated(true)
+    if (!message) return
+    setIsMessageEvaluated(false)
+    const evaluatorParams: EvaluatorParameters = {
+      objects: { currentUser },
+      APIfetch: fetch,
+    }
+    evaluate(message || '', evaluatorParams).then((result: any) => {
+      setEvaluatedMessage(result)
+      setIsMessageEvaluated(true)
+    })
+  }, [message, shouldEvaluate])
+
+  return {
+    evaluatedMessage,
+    isMessageEvaluated,
+  }
+}
+
+export default useEvaluateMessage


### PR DESCRIPTION
Fixes #418 

### Changes
- New hook `useEvaluateMessage` to evaluate some message send as props and return result as `evaluatedMessage` and flag `isMessageEvaluated` to help with loading progress in caller component
- Update `useLoadApplication` and `useLoadTemplate` new hooks to call this hook and return the expected evaluated message and flag `isMessageEvaluated` to the component to display.

### Tests
- Start message defined in Template: should load ApplicationCreate Page: [http://localhost:3000/applicationNEW/new?type=ReviewTest](http://localhost:3000/applicationNEW/new?type=ReviewTest)
- Start message not defined in Template: should create application after template is loaded: [http://localhost:3000/applicationNEW/new?type=UserRegistration](http://localhost:3000/applicationNEW/new?type=UserRegistration)
- Submission message displayed after application is submitted: [http://localhost:3000/applicationNEW/ABC123/submission](http://localhost:3000/applicationNEW/ABC123/submission)