### PR TITLE
#418 Evaluate start and submission messages in existing Loading hooks (simplified)

### DIFF
--- a/src/containers/Application/ApplicationCreateNEW.tsx
+++ b/src/containers/Application/ApplicationCreateNEW.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { Button, Divider, Header, Message, Segment } from 'semantic-ui-react'
-import evaluate from '@openmsupply/expression-evaluator'
 import Markdown from '../../utils/helpers/semanticReactMarkdown'
 import { ApplicationHeader, ApplicationSelectType, Loading } from '../../components'
 import { useApplicationState } from '../../contexts/ApplicationState'
@@ -9,7 +8,6 @@ import useCreateApplication from '../../utils/hooks/useCreateApplication'
 import useLoadTemplate from '../../utils/hooks/useLoadTemplateNEW'
 import { useRouter } from '../../utils/hooks/useRouter'
 import strings from '../../utils/constants'
-import { EvaluatorParameters } from '../../utils/types'
 import { SectionsList } from '../../components/Application/Sections'
 
 const ApplicationCreateNEW: React.FC = () => {
@@ -21,7 +19,6 @@ const ApplicationCreateNEW: React.FC = () => {
     push,
     query: { type },
   } = useRouter()
-  const [startMessageEvaluated, setStartMessageEvaluated] = useState('')
 
   const { error, loading, template } = useLoadTemplate({
     templateCode: type,
@@ -34,7 +31,6 @@ const ApplicationCreateNEW: React.FC = () => {
   // If template has no start message, go straight to first page of new application
   useEffect(() => {
     if (template && !template.startMessage) handleCreate()
-    else evaluateMessage()
   }, [template])
 
   const { processing, error: creationError, create } = useCreateApplication({
@@ -47,16 +43,6 @@ const ApplicationCreateNEW: React.FC = () => {
       }
     },
   })
-
-  const evaluateMessage = async () => {
-    const evaluatorParams: EvaluatorParameters = {
-      objects: { currentUser },
-      APIfetch: fetch,
-    }
-    evaluate(template?.startMessage || '', evaluatorParams).then((result: any) =>
-      setStartMessageEvaluated(result)
-    )
-  }
 
   const handleCreate = (_?: any) => {
     setApplicationState({ type: 'reset' })
@@ -72,7 +58,7 @@ const ApplicationCreateNEW: React.FC = () => {
     const { name, elementsIds, sections } = template
 
     create({
-      name: template.name,
+      name,
       serial: serialNumber,
       templateId: template.id,
       userId: currentUser?.userId,
@@ -104,7 +90,7 @@ const ApplicationCreateNEW: React.FC = () => {
         <Header as="h5">{strings.TITLE_STEPS.toUpperCase()}</Header>
         <SectionsList sections={template.sections} />
         <Divider />
-        <Markdown text={startMessageEvaluated} semanticComponent="Message" info />
+        <Markdown text={template.startMessage || ''} semanticComponent="Message" info />
         <Button color="blue" loading={processing} onClick={handleCreate}>
           {strings.BUTTON_APPLICATION_START}
         </Button>

--- a/src/containers/Application/ApplicationSubmissionNEW.tsx
+++ b/src/containers/Application/ApplicationSubmissionNEW.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react'
-import { Button, Header, Icon, Label, List, Message, Segment } from 'semantic-ui-react'
-import evaluate from '@openmsupply/expression-evaluator'
+import React from 'react'
+import { Button, Header, Icon, Label, List, Segment } from 'semantic-ui-react'
 import Markdown from '../../utils/helpers/semanticReactMarkdown'
-import { ApplicationProps, EvaluatorParameters } from '../../utils/types'
+import { ApplicationProps } from '../../utils/types'
 import { useUserState } from '../../contexts/UserState'
 import { useRouter } from '../../utils/hooks/useRouter'
 import strings from '../../utils/constants'
@@ -10,7 +9,6 @@ import { Link } from 'react-router-dom'
 import { ApplicationStatus } from '../../utils/generated/graphql'
 
 const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
-  const [submissionMessageEvaluated, setSubmissionMessageEvaluated] = useState('')
   const {
     userState: { currentUser },
   } = useUserState()
@@ -32,14 +30,6 @@ const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
   )
     push(`/applicationNEW/${serialNumber}/summary`)
 
-  const evaluatorParams: EvaluatorParameters = {
-    objects: { currentUser },
-    APIfetch: fetch,
-  }
-  evaluate(submissionMessage || '', evaluatorParams).then((result: any) =>
-    setSubmissionMessageEvaluated(result)
-  )
-
   return (
     <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>
       <Header textAlign="center">
@@ -59,7 +49,7 @@ const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
           <Icon name="clock outline" color="blue" size="huge" />
           {strings.LABEL_PROCESSING}
         </Header>
-        <Markdown text={submissionMessageEvaluated} />
+        <Markdown text={submissionMessage || ''} />
         <Segment basic textAlign="left" style={{ margin: '50px 50px', padding: 10 }}>
           <Header as="h5">{strings.SUBTITLE_SUBMISSION_STEPS}</Header>
           <List>

--- a/src/contexts/FormElementUpdateTrackerState.tsx
+++ b/src/contexts/FormElementUpdateTrackerState.tsx
@@ -20,7 +20,6 @@ const reducer = (
   state: ContextFormElementUpdateTrackerState,
   action: UpdateAction
 ): ContextFormElementUpdateTrackerState => {
-  console.log(state, action)
   switch (action.type) {
     case 'setElementUpdated': {
       const newState = {

--- a/src/utils/hooks/useLoadApplicationNEW.ts
+++ b/src/utils/hooks/useLoadApplicationNEW.ts
@@ -7,6 +7,9 @@ import {
   TemplateElementStateNEW,
   UseGetApplicationProps,
 } from '../types'
+import evaluate from '@openmsupply/expression-evaluator'
+import { useUserState } from '../../contexts/UserState'
+import { EvaluatorParameters } from '../../utils/types'
 import { getApplicationSections } from '../helpers/application/getSectionsDetails'
 import { buildSectionsStructure } from '../helpers/structure/buildSectionsStructureNEW'
 import {
@@ -30,6 +33,9 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
   const [structure, setFullStructure] = useState<FullStructure>()
   const [template, setTemplate] = useState<TemplateDetails>()
   const [refetchAttempts, setRefetchAttempts] = useState(0)
+  const {
+    userState: { currentUser },
+  } = useUserState()
 
   const { data, loading, error, refetch } = useGetApplicationNewQuery({
     variables: {
@@ -108,7 +114,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
         date: DateTime.fromISO(statusHistoryTimeCreated),
       },
       firstStrictInvalidPage: null,
-      submissionMessage: application.template?.submissionMessage as string,
+      // submissionMessage: application.template?.submissionMessage as string,
     }
 
     const baseElements: ElementBaseNEW[] = []
@@ -141,16 +147,24 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
 
     const templateStages = application.template?.templateStages.nodes as TemplateStage[]
 
-    setFullStructure({
-      info: applicationDetails,
-      stages: templateStages.map((stage) => ({
-        number: stage.number as number,
-        title: stage.title as string,
-        description: stage.description ? stage.description : undefined,
-      })),
-      sections: buildSectionsStructure({ sections, baseElements }),
-    })
-    setIsLoading(false)
+    const evaluatorParams: EvaluatorParameters = {
+      objects: { currentUser },
+      APIfetch: fetch,
+    }
+    evaluate(application.template?.submissionMessage || '', evaluatorParams).then(
+      (submissionMessage: any) => {
+        setFullStructure({
+          info: { ...applicationDetails, submissionMessage },
+          stages: templateStages.map((stage) => ({
+            number: stage.number as number,
+            title: stage.title as string,
+            description: stage.description ? stage.description : undefined,
+          })),
+          sections: buildSectionsStructure({ sections, baseElements }),
+        })
+        setIsLoading(false)
+      }
+    )
   }, [data, loading])
 
   return {

--- a/src/utils/hooks/useLoadApplicationNEW.ts
+++ b/src/utils/hooks/useLoadApplicationNEW.ts
@@ -114,7 +114,6 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
         date: DateTime.fromISO(statusHistoryTimeCreated),
       },
       firstStrictInvalidPage: null,
-      // submissionMessage: application.template?.submissionMessage as string,
     }
 
     const baseElements: ElementBaseNEW[] = []

--- a/src/utils/hooks/useLoadTemplateNEW.tsx
+++ b/src/utils/hooks/useLoadTemplateNEW.tsx
@@ -18,7 +18,6 @@ interface useLoadTemplateProps {
 const useLoadTemplate = ({ templateCode }: useLoadTemplateProps) => {
   const [template, setTemplate] = useState<TemplateDetails>()
   const [error, setError] = useState('')
-
   const {
     userState: { currentUser },
   } = useUserState()

--- a/src/utils/hooks/useLoadTemplateNEW.tsx
+++ b/src/utils/hooks/useLoadTemplateNEW.tsx
@@ -47,7 +47,7 @@ const useLoadTemplate = ({ templateCode }: useLoadTemplateProps) => {
       return
     }
 
-    const { id, code, name, startMessage } = template
+    const { id, code, name } = template
     const templateSections = template.templateSections.nodes as TemplateSection[]
     const sections = getTemplateSections(templateSections)
     const elementsIds: number[] = []

--- a/src/utils/hooks/useLoadTemplateNEW.tsx
+++ b/src/utils/hooks/useLoadTemplateNEW.tsx
@@ -5,8 +5,11 @@ import {
   TemplateSection,
   useGetTemplateQuery,
 } from '../generated/graphql'
+import evaluate from '@openmsupply/expression-evaluator'
+import { useUserState } from '../../contexts/UserState'
+import { EvaluatorParameters } from '../../utils/types'
 import { getTemplateSections } from '../helpers/application/getSectionsDetails'
-import { SectionDetails, TemplateDetails } from '../types'
+import { TemplateDetails } from '../types'
 
 interface useLoadTemplateProps {
   templateCode?: string
@@ -16,6 +19,10 @@ const useLoadTemplate = ({ templateCode }: useLoadTemplateProps) => {
   const [template, setTemplate] = useState<TemplateDetails>()
   const [error, setError] = useState('')
 
+  const {
+    userState: { currentUser },
+  } = useUserState()
+
   const { data, loading: apolloLoading, error: apolloError } = useGetTemplateQuery({
     variables: {
       code: templateCode || '',
@@ -24,7 +31,7 @@ const useLoadTemplate = ({ templateCode }: useLoadTemplateProps) => {
   })
 
   useEffect(() => {
-    if (!data) return
+    if (!data || !currentUser) return
 
     // Check that only one template matched
     let error = checkForTemplateErrors(data)
@@ -53,15 +60,21 @@ const useLoadTemplate = ({ templateCode }: useLoadTemplateProps) => {
       })
     })
 
-    setTemplate({
-      id,
-      code,
-      name: name as string,
-      elementsIds,
-      sections,
-      startMessage: startMessage ? startMessage : undefined,
+    const evaluatorParams: EvaluatorParameters = {
+      objects: { currentUser },
+      APIfetch: fetch,
+    }
+    evaluate(template?.startMessage || '', evaluatorParams).then((startMessage: any) => {
+      setTemplate({
+        id,
+        code,
+        name: name as string,
+        elementsIds,
+        sections,
+        startMessage,
+      })
     })
-  }, [data])
+  }, [data, currentUser])
 
   return {
     loading: apolloLoading,


### PR DESCRIPTION
Simplified version that doesn't require extra hook.

**URLs to test:**
http://localhost:3000/applicationNEW/new?type=ReviewTest (static Start message)
http://localhost:3000/applicationNEW/new?type=TestRego (dynamic Start message)
http://localhost:3000/applicationNEW/new?type=UserRegistration (should skip Start page and go to application)
(and their Submission messages at the end)

Only difference in terms of function between this version and [the other one](#419) is that this won't start rendering anything until message is evaluated. Shouldn't make much difference in practice, though, unless there was a slow API look-up or something in the expression, which is quite unlikely considering use cases.
