### PR TITLE
Replace NEW routes

### DIFF
--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -64,7 +64,7 @@ const Navigation: React.FC<NavigationProps> = ({
 
   const sendToPage = (sectionPage: SectionAndPage) => {
     const { sectionCode, pageNumber } = sectionPage
-    push(`/applicationNEW/${serialNumber}/${sectionCode}/Page${pageNumber}`)
+    push(`/application/${serialNumber}/${sectionCode}/Page${pageNumber}`)
   }
 
   const previousButtonHandler = () => {
@@ -100,7 +100,7 @@ const Navigation: React.FC<NavigationProps> = ({
       if (firstStrictInvalidPage) {
         setStrictSectionPage(firstStrictInvalidPage)
         sendToPage(firstStrictInvalidPage)
-      } else push(`/applicationNEW/${serialNumber}/summary`)
+      } else push(`/application/${serialNumber}/summary`)
     })
   }
 

--- a/src/components/Application/ProgressBarNEW.tsx
+++ b/src/components/Application/ProgressBarNEW.tsx
@@ -38,7 +38,7 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({
 
   const handleChangeToPage = (sectionCode: string, pageNumber: number) => {
     if (!isLinear) {
-      push(`/applicationNEW/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
+      push(`/application/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
       return
     }
 
@@ -47,7 +47,7 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({
     requestRevalidation(({ firstStrictInvalidPage, setStrictSectionPage }: MethodToCallProps) => {
       if (!firstStrictInvalidPage) {
         setStrictSectionPage(null)
-        push(`/applicationNEW/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
+        push(`/application/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
         return
       }
       if (
@@ -58,11 +58,11 @@ const ProgressBarNEW: React.FC<ProgressBarProps> = ({
         })
       ) {
         setStrictSectionPage(null)
-        push(`/applicationNEW/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
+        push(`/application/${structure.info.serial}/${sectionCode}/Page${pageNumber}`)
       } else {
         setStrictSectionPage(firstStrictInvalidPage)
         push(
-          `/applicationNEW/${structure.info.serial}/${firstStrictInvalidPage.sectionCode}/Page${firstStrictInvalidPage.pageNumber}`
+          `/application/${structure.info.serial}/${firstStrictInvalidPage.sectionCode}/Page${firstStrictInvalidPage.pageNumber}`
         )
       }
     })

--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -32,15 +32,15 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
     if (!fullStructure) return
     const { status } = fullStructure.info.current as StageAndStatus
     if (status !== ApplicationStatus.Draft && status !== ApplicationStatus.ChangesRequired)
-      push(`/applicationNEW/${serialNumber}/summary`)
+      push(`/application/${serialNumber}/summary`)
   }, [fullStructure])
 
   const handleResumeClick = ({ sectionCode, pageNumber }: SectionAndPage) => {
-    push(`/applicationNEW/${serialNumber}/${sectionCode}/Page${pageNumber}`)
+    push(`/application/${serialNumber}/${sectionCode}/Page${pageNumber}`)
   }
 
   const handleSummaryClicked = () => {
-    push(`/applicationNEW/${serialNumber}/summary`)
+    push(`/application/${serialNumber}/summary`)
   }
 
   if (!fullStructure || !fullStructure.responsesByCode) return <Loading />

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -38,7 +38,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({
 
     // Re-direct based on application status
     if (fullStructure.info.current?.status !== ApplicationStatus.Draft)
-      replace(`/applicationNEW/${fullStructure.info.serial}`)
+      replace(`/application/${fullStructure.info.serial}`)
 
     // Re-direct if trying to access page higher than allowed
     if (!fullStructure.info.isLinear || !fullStructure.info?.firstStrictInvalidPage) return
@@ -46,7 +46,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({
     const current = { sectionCode, pageNumber }
     if (!checkPageIsAccessible({ fullStructure, firstIncomplete, current })) {
       const { sectionCode, pageNumber } = firstIncomplete
-      push(`/applicationNEW/${fullStructure.info.serial}/${sectionCode}/Page${pageNumber}`)
+      push(`/application/${fullStructure.info.serial}/${sectionCode}/Page${pageNumber}`)
     }
   }, [fullStructure, sectionCode, page])
 

--- a/src/containers/Application/ApplicationSubmissionNEW.tsx
+++ b/src/containers/Application/ApplicationSubmissionNEW.tsx
@@ -28,7 +28,7 @@ const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
     current?.status === ApplicationStatus.Draft ||
     current?.status === ApplicationStatus.ChangesRequired
   )
-    push(`/applicationNEW/${serialNumber}/summary`)
+    push(`/application/${serialNumber}/summary`)
 
   return (
     <Segment.Group style={{ backgroundColor: 'Gainsboro', display: 'flex' }}>
@@ -67,7 +67,7 @@ const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
           <Button
             color="blue"
             as={Link}
-            to={`/applicationNEW/${serialNumber}/summary`}
+            to={`/application/${serialNumber}/summary`}
             style={{ minWidth: 200 }}
             content={`${strings.BUTTON_BACK_TO} ${type}`}
           />

--- a/src/containers/Application/ApplicationSummary.tsx
+++ b/src/containers/Application/ApplicationSummary.tsx
@@ -35,12 +35,12 @@ const ApplicationSummary: React.FC<ApplicationProps> = ({
 
     // Re-direct based on application status
     if (fullStructure.info.current?.status === ApplicationStatus.ChangesRequired)
-      replace(`/applicationNEW/${fullStructure.info.serial}`)
+      replace(`/application/${fullStructure.info.serial}`)
 
     // Re-direct if application is not valid
     if (fullStructure.info.firstStrictInvalidPage) {
       const { sectionCode, pageNumber } = fullStructure.info.firstStrictInvalidPage
-      replace(`/applicationNEW/${fullStructure.info.serial}/${sectionCode}/Page${pageNumber}`)
+      replace(`/application/${fullStructure.info.serial}/${sectionCode}/Page${pageNumber}`)
     }
   }, [fullStructure])
 
@@ -51,12 +51,12 @@ const ApplicationSummary: React.FC<ApplicationProps> = ({
           if (firstStrictInvalidPage) {
             const { sectionCode, pageNumber } = firstStrictInvalidPage
             setStrictSectionPage(firstStrictInvalidPage)
-            replace(`/applicationNEW/${fullStructure.info.serial}/${sectionCode}/Page${pageNumber}`)
+            replace(`/application/${fullStructure.info.serial}/${sectionCode}/Page${pageNumber}`)
           } else {
             try {
               fullStructure?.responsesByCode &&
                 (await submit(Object.values(fullStructure?.responsesByCode)))
-              push(`/applicationNEW/${fullStructure?.info.serial}/submission`)
+              push(`/application/${fullStructure?.info.serial}/submission`)
             } catch {
               setError(true)
             }

--- a/src/containers/Main/SiteLayout.tsx
+++ b/src/containers/Main/SiteLayout.tsx
@@ -51,53 +51,53 @@ const SiteLayout: React.FC = () => {
         </Route>
         {/* Application router NEW*/}
         {/* Create application new route */}
-        <Route path="/applicationNEW/new">
+        <Route path="/application/new">
           <ApplicationProvider>
             <ApplicationCreateNEW />
           </ApplicationProvider>
         </Route>
         {/* Other application routes nested in ApplicationWrapper */}
-        <Route path="/applicationNEW/:serialNumber">
+        <Route path="/application/:serialNumber">
           <FormElementUpdateTrackerProvider>
             <ApplicationWrapper />
           </FormElementUpdateTrackerProvider>
         </Route>
         {/* Application current routes - to be removed */}
-        <Route exact path="/application/new">
+        <Route exact path="/applicationOLD/new">
           <ApplicationProvider>
             <ApplicationCreate />
           </ApplicationProvider>
         </Route>
-        <Route exact path="/application/:serialNumber">
+        <Route exact path="/applicationOLD/:serialNumber">
           <ApplicationProvider>
             <ApplicationPageWrapper />
           </ApplicationProvider>
         </Route>
-        <Route exact path="/application/:serialNumber/:sectionCode/Page:page">
+        <Route exact path="/applicationOLD/:serialNumber/:sectionCode/Page:page">
           <ApplicationProvider>
             <ApplicationPageWrapper />
           </ApplicationProvider>
         </Route>
-        <Route exact path="/application/:serialNumber/submission">
+        <Route exact path="/applicationOLD/:serialNumber/submission">
           <ApplicationSubmission />
         </Route>
-        <Route exact path="/application/:serialNumber/summary">
+        <Route exact path="/applicationOLD/:serialNumber/summary">
           <ApplicationOverview />
         </Route>
         {/* Review current routes - to be removed */}
-        <Route exact path="/application/:serialNumber/review">
+        <Route exact path="/applicationOLD/:serialNumber/review">
           <ReviewOverview />
         </Route>
-        <Route exact path="/application/:serialNumber/review/:reviewId">
+        <Route exact path="/applicationOLD/:serialNumber/review/:reviewId">
           <ReviewPageWrapper />
         </Route>
-        <Route exact path="/application/:serialNumber/review/:reviewId/submission">
+        <Route exact path="/applicationOLD/:serialNumber/review/:reviewId/submission">
           <ReviewSubmission />
         </Route>
-        <Route exact path="/application/:serialNumber/consolidation/">
+        <Route exact path="/applicationOLD/:serialNumber/consolidation/">
           <NoMatch />
         </Route>
-        <Route exact path="/application/:serialNumber/consolidation/:consolidationId">
+        <Route exact path="/applicationOLD/:serialNumber/consolidation/:consolidationId">
           <NoMatch />
         </Route>
         {/* End of Review routes */}


### PR DESCRIPTION
Quick update to just replace the NEW routes with the "standard" routes, and have changed the previous "standard" to have OLD in the URL, so we can still get to them if we want.

Replaced all the links throughout that were pointing to a NEW url to now point to standard urls

No changes to file names or component names, that can be done later. This is just to make our life a bit easier in the meantime.