### PR TITLE
#499 - Tiny bug fix

### DIFF
--- a/src/components/Application/PageElements.tsx
+++ b/src/components/Application/PageElements.tsx
@@ -47,15 +47,22 @@ const PageElements: React.FC<PageElementProps> = ({
       <Form>
         {visibleElements.map(
           ({ element, isChangeRequest, isChanged, previousApplicationResponse }) => {
-            const visibleReviews = previousApplicationResponse?.reviewResponses.nodes
+            const currentReview = previousApplicationResponse?.reviewResponses.nodes[0]
+            const changesRequired =
+              isChangeRequest || isChanged
+                ? {
+                    isChangeRequest: isChangeRequest as boolean,
+                    isChanged: isChanged as boolean,
+                    reviewerComment: currentReview?.comment || '',
+                  }
+                : undefined
+
             const props: ApplicationViewWrapperPropsNEW = {
               element,
               isStrictPage,
-              isNonRequiredChange: (isChanged as boolean) && !(isChangeRequest as boolean),
+              changesRequired,
               allResponses: responsesByCode,
               currentResponse: responsesByCode?.[element.code],
-              currentReview:
-                visibleReviews?.length > 0 ? (visibleReviews[0] as ReviewResponse) : undefined,
             }
             // Wrapper displays response & changes requested warning for LOQ re-submission
             return <ApplicationViewWrapper key={`question_${element.code}`} {...props} />

--- a/src/components/Application/PageElements.tsx
+++ b/src/components/Application/PageElements.tsx
@@ -51,7 +51,7 @@ const PageElements: React.FC<PageElementProps> = ({
             const props: ApplicationViewWrapperPropsNEW = {
               element,
               isStrictPage,
-              isChanged: !!isChanged && !!isChangeRequest,
+              isNonRequiredChange: (isChanged as boolean) && !(isChangeRequest as boolean),
               allResponses: responsesByCode,
               currentResponse: responsesByCode?.[element.code],
               currentReview:

--- a/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapperNEW.tsx
@@ -23,7 +23,14 @@ import globalConfig from '../config.json'
 const graphQLEndpoint = globalConfig.serverGraphQL
 
 const ApplicationViewWrapper: React.FC<ApplicationViewWrapperPropsNEW> = (props) => {
-  const { element, isStrictPage, isChanged, currentResponse, currentReview, allResponses } = props
+  const {
+    element,
+    isStrictPage,
+    isNonRequiredChange,
+    currentResponse,
+    currentReview,
+    allResponses,
+  } = props
 
   const {
     code,
@@ -159,11 +166,11 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperPropsNEW> = (props)
 
   const changesToResponseProps: ChangesToResponseWarningProps = {
     currentReview,
-    isChanged,
+    isNonRequiredChange,
     isValid: validationState ? (validationState.isValid as boolean) : true,
   }
 
-  const displayResponseWarning = !!currentReview || (isChanged && validationState.isValid)
+  const displayResponseWarning = !!currentReview || (isNonRequiredChange && validationState.isValid)
 
   return (
     <ErrorBoundary pluginCode={pluginCode}>
@@ -171,7 +178,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperPropsNEW> = (props)
         <div
           style={{
             border: displayResponseWarning ? 'solid 1px' : 'transparent',
-            borderColor: isChanged ? 'blue' : !!currentReview ? 'red' : 'black',
+            borderColor: isNonRequiredChange ? 'blue' : !!currentReview ? 'red' : 'black',
             borderRadius: 7,
             padding: displayResponseWarning ? 4 : 5,
             margin: 5,
@@ -187,33 +194,33 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperPropsNEW> = (props)
 
 interface ChangesToResponseWarningProps {
   currentReview?: ReviewResponse
-  isChanged: boolean
+  isNonRequiredChange: boolean
   isValid: boolean
 }
 
 const ChangesToResponseWarning: React.FC<ChangesToResponseWarningProps> = ({
   currentReview,
-  isChanged,
+  isNonRequiredChange,
   isValid,
 }) => {
-  const displayResponseWarning = currentReview || (isChanged && isValid)
+  const displayResponseWarning = !!currentReview || (isNonRequiredChange && isValid)
 
   return (
     <div
       style={{
-        color: isChanged ? 'grey' : 'red',
+        color: isNonRequiredChange ? 'grey' : 'red',
         visibility: displayResponseWarning ? 'visible' : 'hidden',
       }}
     >
       <Icon
         name={
           currentReview
-            ? isChanged
+            ? isNonRequiredChange
               ? 'comment alternate outline'
               : 'exclamation circle'
             : 'info circle'
         }
-        color={currentReview ? (isChanged ? 'grey' : 'red') : 'blue'}
+        color={currentReview ? (isNonRequiredChange ? 'grey' : 'red') : 'blue'}
       />
       {currentReview ? currentReview.comment : messages.APPLICATION_OTHER_CHANGES_MADE}
     </div>

--- a/src/formElementPlugins/types.ts
+++ b/src/formElementPlugins/types.ts
@@ -36,7 +36,7 @@ interface ApplicationViewWrapperPropsNEW {
   // isRequired: boolean
   // isValid: boolean
   isStrictPage: boolean | undefined
-  isChanged: boolean
+  isNonRequiredChange: boolean
   // // parameters: any // TODO: Create type for existing pre-defined types for parameters (TemplateElement)
   // validationExpression: IQueryNode
   // validationMessage: string | null

--- a/src/formElementPlugins/types.ts
+++ b/src/formElementPlugins/types.ts
@@ -36,7 +36,11 @@ interface ApplicationViewWrapperPropsNEW {
   // isRequired: boolean
   // isValid: boolean
   isStrictPage: boolean | undefined
-  isNonRequiredChange: boolean
+  changesRequired?: {
+    isChangeRequest: boolean
+    isChanged: boolean
+    reviewerComment: string
+  }
   // // parameters: any // TODO: Create type for existing pre-defined types for parameters (TemplateElement)
   // validationExpression: IQueryNode
   // validationMessage: string | null

--- a/src/utils/helpers/structure/addApplicantChangeRequestStatusToElement.ts
+++ b/src/utils/helpers/structure/addApplicantChangeRequestStatusToElement.ts
@@ -7,6 +7,19 @@ import {
 import { FullStructure } from '../../types'
 
 const addApplicantChangeRequestStatusToElement = (structure: FullStructure) => {
+  const checkHasAnyReviewResponses = Object.values(structure?.sortedPages || {}).flatMap(
+    ({ state }) =>
+      state.filter(({ latestApplicationResponse, previousApplicationResponse }) =>
+        // For application not in draft - check if any latestApplicationResponse has been reviewed
+        // For applications in draft - check if any previousApplicationResponse has been reviewed
+        structure?.info?.current?.status !== ApplicationStatus.Draft
+          ? latestApplicationResponse?.reviewResponses.nodes[0] !== undefined
+          : previousApplicationResponse?.reviewResponses.nodes[0]
+      )
+  )
+  // No reviews, then don't set isChanged and isChangeRequested fields
+  if (checkHasAnyReviewResponses.length === 0) return
+
   const questionElements = Object.values(structure?.elementsById || {}).filter(
     ({ element }) => element?.category === TemplateElementCategory.Question
   )


### PR DESCRIPTION
Fixes #499 

### Changes
- Fix problem not showing warning on Application changes required - for responses without changes required.
**Edited on 30/03**
- Bug fix to stop displaying the "This is a new submission and will require a review." warning on a new Application.
- To fix unwanted warning I removed `isChanged` and `isChangeRequired` fields getting set on `addApplicantChangeRequestStatusToElement`, so it only get set to each `state` element in the fullStructure when there is at least one review done in the full structure. This prevents a new application to display warnings - since they use the same component `PageElements` and `ApplicationViewWrapper`.