### PR TITLE
#396 Rename hooks to get FullStructure

### DIFF
--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react'
 import { Button, Divider, Header, Message, Segment, Sticky } from 'semantic-ui-react'
 import { FullStructure, SectionAndPage, StageAndStatus, TemplateDetails } from '../../utils/types'
-import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
+import useGetApplicationStructure from '../../utils/hooks/useGetApplicationStructure'
 import { ApplicationHeader, Loading } from '../../components'
 import strings from '../../utils/constants'
 import { useUserState } from '../../contexts/UserState'
@@ -26,7 +26,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
     userState: { currentUser },
   } = useUserState()
 
-  const { error, fullStructure } = useGetFullApplicationStructure({
+  const { error, fullStructure } = useGetApplicationStructure({
     structure,
   })
 

--- a/src/containers/Application/ApplicationPageWrapper.tsx
+++ b/src/containers/Application/ApplicationPageWrapper.tsx
@@ -11,7 +11,7 @@ import {
 import strings from '../../utils/constants'
 import { Message } from 'semantic-ui-react'
 import { ApplicationPage, ApplicationSummary } from '.'
-import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
+import useGetApplicationStructure from '../../utils/hooks/useGetApplicationStructure'
 import { useFormElementUpdateTracker } from '../../contexts/FormElementUpdateTrackerState'
 
 interface MethodToCall {
@@ -44,7 +44,7 @@ const ApplicationPageWrapper: React.FC<ApplicationProps> = ({ structure }) => {
   const minRefetchTimestampForRevalidation =
     shouldRevalidate && wasElementChanged ? elementUpdatedTimestamp : 0
 
-  const { error, fullStructure } = useGetFullApplicationStructure({
+  const { error, fullStructure } = useGetApplicationStructure({
     structure,
     shouldRevalidate,
     minRefetchTimestampForRevalidation,

--- a/src/containers/Review/ReviewHome.tsx
+++ b/src/containers/Review/ReviewHome.tsx
@@ -3,7 +3,7 @@ import { Message, Segment, Header, Dropdown, Grid } from 'semantic-ui-react'
 import { Loading } from '../../components'
 import { useUserState } from '../../contexts/UserState'
 import strings from '../../utils/constants'
-import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
+import useGetApplicationStructure from '../../utils/hooks/useGetApplicationStructure'
 import { AssignmentDetails, FullStructure } from '../../utils/types'
 import AssignmentSectionRow from './AssignmentSectionRow'
 import ReviewSectionRow from './ReviewSectionRow'
@@ -21,7 +21,7 @@ type Filters = {
 const ALL_REVIEWERS = 0
 
 const ReviewHome: React.FC<ReviewHomeProps> = ({ assignments, structure }) => {
-  const { error, fullStructure: fullApplicationStructure } = useGetFullApplicationStructure({
+  const { error, fullStructure: fullApplicationStructure } = useGetApplicationStructure({
     structure,
     firstRunValidation: false,
     shouldCalculateProgress: false,

--- a/src/containers/Review/ReviewPage.tsx
+++ b/src/containers/Review/ReviewPage.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../utils/generated/graphql'
 import strings from '../../utils/constants'
 
-import useGetFullReviewStructure from '../../utils/hooks/useGetFullReviewStructure'
+import useGetReviewStructureForSections from '../../utils/hooks/useGetReviewStructureForSection'
 import SectionWrapper from '../../components/Application/SectionWrapper'
 import React from 'react'
 import useQuerySectionActivation from '../../utils/hooks/useQuerySectionActivation'
@@ -36,7 +36,7 @@ const ReviewPage: React.FC<{
     userState: { currentUser },
   } = useUserState()
 
-  const { fullReviewStructure, error } = useGetFullReviewStructure({
+  const { fullReviewStructure, error } = useGetReviewStructureForSections({
     reviewAssignment,
     fullApplicationStructure,
   })

--- a/src/containers/Review/ReviewPageWrapper.tsx
+++ b/src/containers/Review/ReviewPageWrapper.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Route, Switch } from 'react-router'
 import { Message } from 'semantic-ui-react'
 import { Loading, NoMatch } from '../../components'
-import useGetFullApplicationStructure from '../../utils/hooks/useGetFullApplicationStructure'
+import useGetApplicationStructure from '../../utils/hooks/useGetApplicationStructure'
 import { useRouter } from '../../utils/hooks/useRouter'
 import strings from '../../utils/constants'
 import { AssignmentDetails, FullStructure } from '../../utils/types'
@@ -18,7 +18,7 @@ const ReviewPageWrapper: React.FC<{
   } = useRouter()
 
   // Get application structure with evaluated properties (i.e visibility)
-  const { error, fullStructure: fullApplicationStructure } = useGetFullApplicationStructure({
+  const { error, fullStructure: fullApplicationStructure } = useGetApplicationStructure({
     structure,
     firstRunValidation: false,
     shouldCalculateProgress: false,

--- a/src/containers/Review/ReviewSectionRow.tsx
+++ b/src/containers/Review/ReviewSectionRow.tsx
@@ -8,7 +8,7 @@ import {
   ReviewSectionRowAction,
 } from '../../components/Review'
 import strings from '../../utils/constants'
-import useGetFullReviewStructure from '../../utils/hooks/useGetFullReviewStructure'
+import useGetReviewStructureForSections from '../../utils/hooks/useGetReviewStructureForSection'
 import {
   AssignmentDetails,
   FullStructure,
@@ -29,7 +29,7 @@ const ReviewSectionRow: React.FC<ReviewSectionRowProps> = ({
   assignment,
   fullApplicationStructure,
 }) => {
-  const { fullReviewStructure, error } = useGetFullReviewStructure({
+  const { fullReviewStructure, error } = useGetReviewStructureForSections({
     reviewAssignment: assignment,
     fullApplicationStructure,
     filteredSectionIds: [sectionId],

--- a/src/utils/hooks/useGetApplicationStructure.tsx
+++ b/src/utils/hooks/useGetApplicationStructure.tsx
@@ -17,7 +17,7 @@ import {
   generateResponsesProgress,
 } from '../helpers/structure'
 
-interface UseGetFullApplicationStructureProps {
+interface UseGetApplicationStructureProps {
   structure: FullStructure
   shouldRevalidate?: boolean
   minRefetchTimestampForRevalidation?: number
@@ -26,14 +26,14 @@ interface UseGetFullApplicationStructureProps {
   shouldGetDraftResponses?: boolean
 }
 
-const useGetFullApplicationStructure = ({
+const useGetApplicationStructure = ({
   structure,
   shouldRevalidate = false,
   minRefetchTimestampForRevalidation = 0,
   firstRunValidation = true,
   shouldCalculateProgress = true,
   shouldGetDraftResponses = true,
-}: UseGetFullApplicationStructureProps) => {
+}: UseGetApplicationStructureProps) => {
   const {
     info: { serial },
   } = structure
@@ -131,4 +131,4 @@ const useGetFullApplicationStructure = ({
   }
 }
 
-export default useGetFullApplicationStructure
+export default useGetApplicationStructure

--- a/src/utils/hooks/useGetFullReviewStructure/index.tsx
+++ b/src/utils/hooks/useGetFullReviewStructure/index.tsx
@@ -1,5 +1,0 @@
-import useGetFullReviewStructure from './useGetFullReviewStructure'
-import useGetFullReviewStructureAsync from './useGetFullReviewStructureAsync'
-
-export default useGetFullReviewStructure
-export { useGetFullReviewStructureAsync }

--- a/src/utils/hooks/useGetReviewStructureForSection/helpers.tsx
+++ b/src/utils/hooks/useGetReviewStructureForSection/helpers.tsx
@@ -12,18 +12,23 @@ import {
   generateReviewProgress,
   generateReviewSectionActions,
 } from '../../helpers/structure'
-import { UseGetFullReviewStructureProps, User, FullStructure, SectionState } from '../../types'
+import {
+  UseGetReviewStructureForSectionProps,
+  User,
+  FullStructure,
+  SectionState,
+} from '../../types'
 
 const getSectionIds = ({
   fullApplicationStructure,
   filteredSectionIds,
-}: UseGetFullReviewStructureProps) =>
+}: UseGetReviewStructureForSectionProps) =>
   filteredSectionIds ||
   Object.values(fullApplicationStructure.sections).map((section) => section.details.id) ||
   []
 
 type GenerateReviewStructure = (
-  props: UseGetFullReviewStructureProps & {
+  props: UseGetReviewStructureForSectionProps & {
     currentUser?: User | null
     sectionIds: number[]
     data: GetReviewResponsesQuery

--- a/src/utils/hooks/useGetReviewStructureForSection/index.tsx
+++ b/src/utils/hooks/useGetReviewStructureForSection/index.tsx
@@ -1,0 +1,5 @@
+import useGetReviewStructureForSections from './useGetReviewStructureForSection'
+import useGetReviewStructureForSectionAsync from './useGetReviewStructureForSectionAsync'
+
+export default useGetReviewStructureForSections
+export { useGetReviewStructureForSectionAsync as useGetFullReviewStructureAsync }

--- a/src/utils/hooks/useGetReviewStructureForSection/useGetReviewStructureForSection.tsx
+++ b/src/utils/hooks/useGetReviewStructureForSection/useGetReviewStructureForSection.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react'
 import { useUserState } from '../../../contexts/UserState'
 import { useGetReviewResponsesQuery } from '../../generated/graphql'
-import { UseGetFullReviewStructureProps, FullStructure } from '../../types'
+import { UseGetReviewStructureForSectionProps, FullStructure } from '../../types'
 import { getSectionIds, generateReviewStructure } from './helpers'
 
-const useGetFullReviewStructure = (props: UseGetFullReviewStructureProps) => {
+const useGetReviewStructureForSections = (props: UseGetReviewStructureForSectionProps) => {
   const [fullReviewStructure, setFullReviewStructure] = useState<FullStructure>()
   const {
     userState: { currentUser },
@@ -34,4 +34,4 @@ const useGetFullReviewStructure = (props: UseGetFullReviewStructureProps) => {
   }
 }
 
-export default useGetFullReviewStructure
+export default useGetReviewStructureForSections

--- a/src/utils/hooks/useGetReviewStructureForSection/useGetReviewStructureForSectionAsync.tsx
+++ b/src/utils/hooks/useGetReviewStructureForSection/useGetReviewStructureForSectionAsync.tsx
@@ -1,14 +1,14 @@
 import { useState, useEffect } from 'react'
 import { useUserState } from '../../../contexts/UserState'
 import { useGetReviewResponsesQuery } from '../../generated/graphql'
-import { UseGetFullReviewStructureProps, FullStructure } from '../../types'
+import { UseGetReviewStructureForSectionProps, FullStructure } from '../../types'
 import { getSectionIds, generateReviewStructure } from './helpers'
 
 interface AwaitModeResolver {
   awaitMethod: (result: FullStructure | null) => void
 }
 
-const useGetFullReviewStructureAsync = (props: UseGetFullReviewStructureProps) => {
+const useGetReviewStructureForSectionAsync = (props: UseGetReviewStructureForSectionProps) => {
   const {
     userState: { currentUser },
   } = useUserState()
@@ -53,4 +53,4 @@ const useGetFullReviewStructureAsync = (props: UseGetFullReviewStructureProps) =
   return getFullReviewStructureAsync
 }
 
-export default useGetFullReviewStructureAsync
+export default useGetReviewStructureForSectionAsync

--- a/src/utils/hooks/useRestartReview.ts
+++ b/src/utils/hooks/useRestartReview.ts
@@ -1,6 +1,6 @@
 import { useUpdateReviewMutation, ReviewPatch, Trigger, Decision } from '../generated/graphql'
 import { AssignmentDetails, FullStructure } from '../types'
-import { useGetFullReviewStructureAsync } from './useGetFullReviewStructure'
+import { useGetFullReviewStructureAsync } from './useGetReviewStructureForSection'
 
 // below lines are used to get return type of the function that is returned by useRestartReviewMutation
 type UseUpdateReviewMutationReturnType = ReturnType<typeof useUpdateReviewMutation>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -10,7 +10,6 @@ import {
   ReviewResponse,
   ReviewResponseDecision,
   ReviewStatus,
-  TemplateElement,
   TemplateElementCategory,
   User as GraphQLUser,
 } from './generated/graphql'
@@ -63,7 +62,7 @@ export {
   TemplatesDetails,
   UseGetApplicationProps,
   User,
-  UseGetFullReviewStructureProps,
+  UseGetReviewStructureForSectionProps,
   OrganisationSimple,
   Organisation,
   LoginPayload,
@@ -456,7 +455,7 @@ interface LoginPayload {
   orgList?: OrganisationSimple[]
 }
 
-interface UseGetFullReviewStructureProps {
+interface UseGetReviewStructureForSectionProps {
   fullApplicationStructure: FullStructure
   reviewAssignment: AssignmentDetails
   filteredSectionIds?: number[]


### PR DESCRIPTION
Fixes #396 

### Branched of
#568 - Remove old router and files used for Application

### Changes
Renamed `hook` and files/folder (from-to):
- useGetFullReviewStructure => useGetReviewStructureForSection
- useGetFullApplicationStructure => UseGetApplicationStructure

### Pending
- Should I also rename the type `FullStructure` to `Structure` or leave it as it is?
