### PR TITLE
#580 Show company logo in Header

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -46,6 +46,7 @@ p strong {
 #user-area-left {
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
 }
 
 #menu-bar {

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -4,11 +4,15 @@ import { useUserState } from '../../contexts/UserState'
 import { Link } from 'react-router-dom'
 import strings from '../../utils/constants'
 import { User } from '../../utils/types'
+import config from '../../config.json'
+import { getFullUrl } from '../../utils/helpers/utilityFunctions'
 
 const UserArea: React.FC = () => {
   const {
     userState: { currentUser },
   } = useUserState()
+
+  console.log('User', currentUser)
   return (
     <Container id="user-area">
       <div id="user-area-left">
@@ -48,7 +52,8 @@ const OrgSelector: React.FC<{ user: User }> = ({ user }) => {
   return (
     <div id="org-selector">
       {/* TO-DO: Replace with proper company logo */}
-      <Image src="/images/temp_logo.png" />
+
+      <Image src={getFullUrl(user.organisation.logoUrl)} />
       <div>
         {user?.organisation?.orgName || ''}
         <Icon size="small" name="angle down" />

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -12,7 +12,6 @@ const UserArea: React.FC = () => {
     userState: { currentUser },
   } = useUserState()
 
-  console.log('User', currentUser)
   return (
     <Container id="user-area">
       <div id="user-area-left">
@@ -51,9 +50,9 @@ const OrgSelector: React.FC<{ user: User }> = ({ user }) => {
   // TO-DO: Make into Dropdown so Org can be selected
   return (
     <div id="org-selector">
-      {/* TO-DO: Replace with proper company logo */}
-
-      <Image src={getFullUrl(user.organisation.logoUrl)} />
+      {user?.organisation?.logoUrl && (
+        <Image src={getFullUrl(user?.organisation?.logoUrl, config.serverREST)} />
+      )}
       <div>
         {user?.organisation?.orgName || ''}
         <Icon size="small" name="angle down" />

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -1209,8 +1209,6 @@ export enum ActionPluginsOrderBy {
   DescriptionDesc = 'DESCRIPTION_DESC',
   PathAsc = 'PATH_ASC',
   PathDesc = 'PATH_DESC',
-  FunctionNameAsc = 'FUNCTION_NAME_ASC',
-  FunctionNameDesc = 'FUNCTION_NAME_DESC',
   RequiredParametersAsc = 'REQUIRED_PARAMETERS_ASC',
   RequiredParametersDesc = 'REQUIRED_PARAMETERS_DESC',
   OutputPropertiesAsc = 'OUTPUT_PROPERTIES_ASC',
@@ -1229,8 +1227,6 @@ export type ActionPluginCondition = {
   description?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `path` field. */
   path?: Maybe<Scalars['String']>;
-  /** Checks for equality with the object’s `functionName` field. */
-  functionName?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `requiredParameters` field. */
   requiredParameters?: Maybe<Array<Maybe<Scalars['String']>>>;
   /** Checks for equality with the object’s `outputProperties` field. */
@@ -1247,8 +1243,6 @@ export type ActionPluginFilter = {
   description?: Maybe<StringFilter>;
   /** Filter by the object’s `path` field. */
   path?: Maybe<StringFilter>;
-  /** Filter by the object’s `functionName` field. */
-  functionName?: Maybe<StringFilter>;
   /** Filter by the object’s `requiredParameters` field. */
   requiredParameters?: Maybe<StringListFilter>;
   /** Filter by the object’s `outputProperties` field. */
@@ -1400,7 +1394,6 @@ export type ActionPlugin = Node & {
   name?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   path?: Maybe<Scalars['String']>;
-  functionName?: Maybe<Scalars['String']>;
   requiredParameters?: Maybe<Array<Maybe<Scalars['String']>>>;
   outputProperties?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
@@ -9109,7 +9102,6 @@ export type ActionPluginInput = {
   name?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   path?: Maybe<Scalars['String']>;
-  functionName?: Maybe<Scalars['String']>;
   requiredParameters?: Maybe<Array<Maybe<Scalars['String']>>>;
   outputProperties?: Maybe<Array<Maybe<Scalars['String']>>>;
 };
@@ -19373,7 +19365,6 @@ export type ActionPluginPatch = {
   name?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   path?: Maybe<Scalars['String']>;
-  functionName?: Maybe<Scalars['String']>;
   requiredParameters?: Maybe<Array<Maybe<Scalars['String']>>>;
   outputProperties?: Maybe<Array<Maybe<Scalars['String']>>>;
 };

--- a/src/utils/helpers/utilityFunctions.ts
+++ b/src/utils/helpers/utilityFunctions.ts
@@ -12,7 +12,5 @@ If local/relative, it prepends it with a specified host, else it
 returns it unchanged.
 */
 export const getFullUrl = (baseUrl: string | undefined, host: string) => {
-  const fullUrl = baseUrl?.startsWith('http') ? baseUrl : host + baseUrl
-  if (baseUrl?.startsWith('http')) console.log('url', baseUrl)
-  return fullUrl
+  return baseUrl?.startsWith('http') ? baseUrl : host + baseUrl
 }

--- a/src/utils/helpers/utilityFunctions.ts
+++ b/src/utils/helpers/utilityFunctions.ts
@@ -5,3 +5,7 @@ export const isArraySorted = (array: any[], ascending = true) => {
       (element, index) => index === array.length - 1 || element >= array[index + 1]
     )
 }
+
+export const getFullUrl = (baseUrl: string, host: string) => {
+  return baseUrl
+}

--- a/src/utils/helpers/utilityFunctions.ts
+++ b/src/utils/helpers/utilityFunctions.ts
@@ -6,6 +6,13 @@ export const isArraySorted = (array: any[], ascending = true) => {
     )
 }
 
-export const getFullUrl = (baseUrl: string, host: string) => {
-  return baseUrl
+/*
+Checks if a URL string is an external URL or a local/relative one
+If local/relative, it prepends it with a specified host, else it
+returns it unchanged.
+*/
+export const getFullUrl = (baseUrl: string | undefined, host: string) => {
+  const fullUrl = baseUrl?.startsWith('http') ? baseUrl : host + baseUrl
+  if (baseUrl?.startsWith('http')) console.log('url', baseUrl)
+  return fullUrl
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -454,8 +454,9 @@ interface OrganisationSimple {
 }
 
 interface Organisation extends OrganisationSimple {
-  licenceNumber: string
+  registration: string
   address: string
+  logoUrl: string
 }
 
 interface LoginPayload {


### PR DESCRIPTION
Implements #580 

Please use back-end branch `#583-final-tidyups-for-create-join-org`

Note, I've also merged front-end `#583-final-tidy-ups-for-create-join-org'`, so there's currently a few little changes showing in the diff that don't belong in this issue -- the only files I've changed here are:
- UserArea.tsx
- utiltityFunctions.ts

To get logos for existing orgs into the database, please use this snapshot, and these files:
[581_logos.graphql.zip](https://github.com/openmsupply/application-manager-web-app/files/6339747/581_logos.graphql.zip) - snapshot 
[files-#580.zip](https://github.com/openmsupply/application-manager-web-app/files/6322123/files-.580.zip) - files folder

Then you should see logos for 3 of the 4 available orgs in the Header.

Note that one of them (Drug Dealers West) has an external URL, and that shows up fine, too -- I wrote a small utility function to check if the URL is an external one or a relative local one.