### PR TITLE
change permission checking in application list to use alligned types

### DIFF
--- a/src/utils/data/reviewStatus.ts
+++ b/src/utils/data/reviewStatus.ts
@@ -1,7 +1,0 @@
-export enum REVIEW_STATUS {
-  DRAFT = 'Draft',
-  PENDING = 'Pending',
-  CHANGES_REQUESTED = 'Changes Requested',
-  SUBMITTED = 'Submitted',
-  LOCKED = 'Locked',
-}

--- a/src/utils/helpers/list/findUserRole.ts
+++ b/src/utils/helpers/list/findUserRole.ts
@@ -27,11 +27,10 @@ const getUserRolesForType = (templatePermissions: TemplatePermissions, type: str
   if (!found) return []
 
   const [_, permissions] = found
-  const comparePermissions = permissions.map((permissionType) => permissionType.toUpperCase())
 
   // Compare array of permission checking if are the same
-  const matching = Object.entries(userRoles).filter(([role, permissionList]) => {
-    const common = permissionList.filter((permission) => comparePermissions.includes(permission))
+  const matching = Object.entries(userRoles).filter(([_, permissionList]) => {
+    const common = permissionList.filter((permission) => permissions.includes(permission))
     return common.length > 0
   })
   const filteredRoles = matching.map(([role]) => role)

--- a/src/utils/helpers/structure/generateReviewProgress.ts
+++ b/src/utils/helpers/structure/generateReviewProgress.ts
@@ -18,7 +18,8 @@ const isLatestReviewResponseUpToDate = (element: PageElement) =>
 
 const generatePageReviewProgress = (page: Page) => {
   const totalReviewable = page.state.filter(
-    (element) => element.isAssigned && element?.element.isVisible
+    (element) =>
+      element.isAssigned && element?.element.isVisible && element?.latestApplicationResponse?.id
   )
 
   // Only consider review responses that are linked to latest application response


### PR DESCRIPTION
Required for back end [back end pr](https://github.com/openmsupply/application-manager-server/pull/337)

Permission policies returned by getUser API are now in correct graphQL matching format