### PR TITLE
#662(1) Review decision area -- part 1

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -381,8 +381,24 @@ a:hover {
 }
 
 #review-decision-content {
+  display: flex;
+}
+
+#document-viewer {
+  background-color: #6f6f6f5e;
+  width: 800px;
+}
+
+#details-panel {
   background-color: @surfacesWhite;
-  // width: 350px;
+  width: 400px;
+  padding: 15px;
+}
+
+#history-panel {
+  // Temp - replace when real History Panel built
+  border: 1px solid lightgray;
+  height: 250px;
 }
 
 /*--------------------------------

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -374,6 +374,17 @@ a:hover {
   padding-left: 0;
 }
 
+#review-decision-container {
+  display: flex;
+  justify-content: flex-end;
+  height: 100vh;
+}
+
+#review-decision-content {
+  background-color: @surfacesWhite;
+  // width: 350px;
+}
+
 /*--------------------------------
       Application List
 ---------------------------------*/

--- a/semantic/src/site/modules/checkbox.overrides
+++ b/semantic/src/site/modules/checkbox.overrides
@@ -5,5 +5,5 @@
 .ui.checkbox {
   // font-size: @fontXsmall;
   color: @headersInteractiveLow;
-  padding-left: 10px;
+  // padding-left: 10px;
 }

--- a/semantic/src/site/modules/dimmer.overrides
+++ b/semantic/src/site/modules/dimmer.overrides
@@ -1,3 +1,8 @@
 /*******************************
         User Overrides
 *******************************/
+
+// Make modal fill to edge of window
+.ui.dimmer {
+  padding: 0;
+}

--- a/semantic/src/site/modules/modal.overrides
+++ b/semantic/src/site/modules/modal.overrides
@@ -1,3 +1,8 @@
 /*******************************
          Site Overrides
 *******************************/
+
+// Make full-screen modal fill the whole window
+.ui.fullscreen.modal {
+  width: 100% !important;
+}

--- a/semantic/src/site/modules/modal.variables
+++ b/semantic/src/site/modules/modal.variables
@@ -1,3 +1,6 @@
 /*******************************
          Site Overrides
 *******************************/
+
+// Prevent rounded corners of full-screen modal
+@borderRadius: 0;

--- a/src/components/PageElements/Elements/ReviewDecisionElement.tsx
+++ b/src/components/PageElements/Elements/ReviewDecisionElement.tsx
@@ -1,6 +1,7 @@
 import React, { useState, CSSProperties } from 'react'
 import { Icon, Label, Grid } from 'semantic-ui-react'
 import { SummaryViewWrapperProps } from '../../../formElementPlugins/types'
+import { useRouter } from '../../../utils/hooks/useRouter'
 import getSimplifiedTimeDifference from '../../../utils/dateAndTime/getSimplifiedTimeDifference'
 import {
   ApplicationResponse,
@@ -22,7 +23,7 @@ const ReviewDecisionElement: React.FC<ReviewDecisionElementProps> = ({
   summaryViewProps,
   latestApplicationResponse,
 }) => {
-  const [toggleDecisionArea, setToggleDecisionArea] = useState(false)
+  const { updateQuery } = useRouter()
 
   if (!reviewResponse) return null
   if (!reviewResponse?.decision) return null
@@ -36,6 +37,7 @@ const ReviewDecisionElement: React.FC<ReviewDecisionElementProps> = ({
       <Grid columns="equal" className="review-comment-grid">
         <Grid.Column width={2} textAlign="left">
           {reviewResponse.review?.reviewer?.firstName} {reviewResponse.review?.reviewer?.lastName}
+          STUFF GOES HERE
         </Grid.Column>
         <Grid.Column width={12} textAlign="left">
           <div>
@@ -68,17 +70,13 @@ const ReviewDecisionElement: React.FC<ReviewDecisionElementProps> = ({
               name="pencil"
               className="clickable"
               color="blue"
-              onClick={() => setToggleDecisionArea(!toggleDecisionArea)}
+              onClick={() => {
+                updateQuery({ openResponse: latestApplicationResponse.templateElement?.code })
+              }}
             />
           )}
         </Grid.Column>
       </Grid>
-
-      <DecisionArea
-        reviewResponse={reviewResponse}
-        toggle={toggleDecisionArea}
-        summaryViewProps={summaryViewProps}
-      />
     </div>
   )
 }

--- a/src/components/PageElements/Elements/ReviewDecisionElement.tsx
+++ b/src/components/PageElements/Elements/ReviewDecisionElement.tsx
@@ -37,7 +37,6 @@ const ReviewDecisionElement: React.FC<ReviewDecisionElementProps> = ({
       <Grid columns="equal" className="review-comment-grid">
         <Grid.Column width={2} textAlign="left">
           {reviewResponse.review?.reviewer?.firstName} {reviewResponse.review?.reviewer?.lastName}
-          STUFF GOES HERE
         </Grid.Column>
         <Grid.Column width={12} textAlign="left">
           <div>

--- a/src/components/PageElements/Elements/ReviewResponseElement.tsx
+++ b/src/components/PageElements/Elements/ReviewResponseElement.tsx
@@ -1,5 +1,6 @@
-import React, { CSSProperties, useState } from 'react'
-import { Button, Grid } from 'semantic-ui-react'
+import React from 'react'
+import { Grid } from 'semantic-ui-react'
+import { useRouter } from '../../../utils/hooks/useRouter'
 import { SummaryViewWrapper } from '../../../formElementPlugins'
 import { SummaryViewWrapperProps } from '../../../formElementPlugins/types'
 import {
@@ -9,7 +10,6 @@ import {
 } from '../../../utils/generated/graphql'
 import DecisionArea from '../../Review/DecisionArea'
 import strings from '../../../utils/constants'
-import { Link } from 'react-router-dom'
 
 interface ReviewResponseElementProps {
   isNewApplicationResponse: boolean
@@ -20,11 +20,12 @@ interface ReviewResponseElementProps {
 
 const ReviewResponseElement: React.FC<ReviewResponseElementProps> = ({
   isNewApplicationResponse,
+  latestApplicationResponse,
   thisReviewLatestResponse,
   summaryProps,
 }) => {
-  const decisionArea = useState(false)
-  const [toggle] = decisionArea
+  const { query, updateQuery } = useRouter()
+  const toggle = query?.openResponse === latestApplicationResponse.templateElement?.code
 
   return (
     <>
@@ -38,7 +39,8 @@ const ReviewResponseElement: React.FC<ReviewResponseElementProps> = ({
             !thisReviewLatestResponse.decision && (
               <ReviewButton
                 isNewApplicationResponse={isNewApplicationResponse}
-                decisionArea={decisionArea}
+                elementCode={latestApplicationResponse.templateElement?.code as string}
+                updateQuery={updateQuery}
               />
             )}
         </Grid.Column>
@@ -56,9 +58,10 @@ const ReviewResponseElement: React.FC<ReviewResponseElementProps> = ({
 
 const ReviewButton: React.FC<{
   isNewApplicationResponse?: boolean
-  decisionArea: [boolean, React.Dispatch<React.SetStateAction<boolean>>]
-}> = ({ isNewApplicationResponse, decisionArea: [toggleDecisionArea, setToggleDecisionArea] }) => (
-  <p className="link-style" onClick={() => setToggleDecisionArea(!toggleDecisionArea)}>
+  elementCode: string
+  updateQuery: Function
+}> = ({ isNewApplicationResponse, elementCode, updateQuery }) => (
+  <p className="link-style clickable" onClick={() => updateQuery({ openResponse: elementCode })}>
     <strong>
       {isNewApplicationResponse
         ? strings.BUTTON_RE_REVIEW_RESPONSE

--- a/src/components/Review/DecisionArea.tsx
+++ b/src/components/Review/DecisionArea.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
-import { Button, Header, Modal, Radio, Segment, TextArea } from 'semantic-ui-react'
-
+import { Button, Form, Header, Modal, Radio, Segment, TextArea } from 'semantic-ui-react'
+import { useRouter } from '../../utils/hooks/useRouter'
 import { ReviewResponse, ReviewResponseDecision } from '../../utils/generated/graphql'
 import strings from '../../utils/constants'
 import messages from '../../utils/messages'
@@ -19,6 +19,7 @@ const DecisionArea: React.FC<DecisionAreaProps> = ({
   reviewResponse,
   summaryViewProps,
 }) => {
+  const { updateQuery } = useRouter()
   const [isOpen, setIsOpen] = useState(false)
   const [previousToggle, setPreviousToggle] = useState(false)
   const [review, setReview] = useState(reviewResponse)
@@ -35,14 +36,16 @@ const DecisionArea: React.FC<DecisionAreaProps> = ({
   const submit = async () => {
     // TODO do we need to handle update error ?
     await updateResponse(review)
-    setIsOpen(false)
+    updateQuery({ openResponse: null })
   }
 
   return (
     <Modal
       closeIcon
       open={isOpen}
-      onClose={() => setIsOpen(false)}
+      onClose={() => {
+        updateQuery({ openResponse: null })
+      }}
       size="fullscreen"
       style={{ margin: 0, background: 'transparent' }}
     >
@@ -59,58 +62,60 @@ const DecisionArea: React.FC<DecisionAreaProps> = ({
             <Header>{strings.TITLE_DETAILS}</Header>
             <SummaryViewWrapper {...summaryViewProps} />
           </Segment>
-          <Segment basic>
-            <Header as="h3">{strings.LABEL_REVIEW}</Header>
-            {/* // TODO: Change to list options dynamically? */}
-            <Radio
-              label={strings.LABEL_REVIEW_APPROVE}
-              value={strings.LABEL_REVIEW_APPROVE}
-              name="decisionGroup"
-              checked={review.decision === ReviewResponseDecision.Approve}
-              onChange={() =>
-                setReview({
-                  ...review,
-                  decision: ReviewResponseDecision.Approve,
-                })
-              }
-            />
-            <Radio
-              label={strings.LABEL_REVIEW_RESSUBMIT}
-              value={strings.LABEL_REVIEW_RESSUBMIT}
-              name="decisionGroup"
-              checked={review.decision === ReviewResponseDecision.Decline}
-              onChange={() =>
-                setReview({
-                  ...review,
-                  decision: ReviewResponseDecision.Decline,
-                })
-              }
-            />
-          </Segment>
-          <Segment basic>
-            <Header as="h3">{strings.LABEL_COMMENT}</Header>
-            <TextArea
-              rows={6}
-              style={{ width: '100%' }}
-              defaultValue={review.comment}
-              onChange={(_, { value }) => setReview({ ...review, comment: String(value) })}
-            />
-          </Segment>
-          <Segment basic>
-            <Button
-              color="blue"
-              basic
-              onClick={submit}
-              disabled={
-                !review.decision ||
-                (review.decision === ReviewResponseDecision.Decline && !review.comment)
-              }
-              content={strings.BUTTON_SUBMIT}
-            />
-            {review.decision === ReviewResponseDecision.Decline && !review.comment && (
-              <p style={{ color: 'red' }}>{messages.REVIEW_RESUBMIT_COMMENT}</p>
-            )}
-          </Segment>
+          <Form>
+            <Segment basic>
+              <Header as="h3">{strings.LABEL_REVIEW}</Header>
+              {/* // TODO: Change to list options dynamically? */}
+              <Radio
+                label={strings.LABEL_REVIEW_APPROVE}
+                value={strings.LABEL_REVIEW_APPROVE}
+                name="decisionGroup"
+                checked={review.decision === ReviewResponseDecision.Approve}
+                onChange={() =>
+                  setReview({
+                    ...review,
+                    decision: ReviewResponseDecision.Approve,
+                  })
+                }
+              />
+              <Radio
+                label={strings.LABEL_REVIEW_RESSUBMIT}
+                value={strings.LABEL_REVIEW_RESSUBMIT}
+                name="decisionGroup"
+                checked={review.decision === ReviewResponseDecision.Decline}
+                onChange={() =>
+                  setReview({
+                    ...review,
+                    decision: ReviewResponseDecision.Decline,
+                  })
+                }
+              />
+            </Segment>
+            <Segment basic>
+              <Header as="h3">{strings.LABEL_COMMENT}</Header>
+              <TextArea
+                rows={6}
+                style={{ width: '100%' }}
+                defaultValue={review.comment}
+                onChange={(_, { value }) => setReview({ ...review, comment: String(value) })}
+              />
+            </Segment>
+            <Segment basic>
+              <Button
+                color="blue"
+                basic
+                onClick={submit}
+                disabled={
+                  !review.decision ||
+                  (review.decision === ReviewResponseDecision.Decline && !review.comment)
+                }
+                content={strings.BUTTON_SUBMIT}
+              />
+              {review.decision === ReviewResponseDecision.Decline && !review.comment && (
+                <p style={{ color: 'red' }}>{messages.REVIEW_RESUBMIT_COMMENT}</p>
+              )}
+            </Segment>
+          </Form>
         </Segment>
       )}
     </Modal>

--- a/src/components/Review/DecisionArea.tsx
+++ b/src/components/Review/DecisionArea.tsx
@@ -52,65 +52,80 @@ const DecisionArea: React.FC<DecisionAreaProps> = ({
       {!isOpen ? null : (
         <div id="review-decision-container">
           <div id="review-decision-content">
-            {/* <Container id="document-viewer" style={{}}></Container> */}
+            <div id="document-viewer" className="hidden-element">
+              TO-DO: DOCUMENT VIEWER
+            </div>
             <div id="details-panel">
               <Form>
                 <Segment basic>
-                  <Header>{strings.TITLE_DETAILS}</Header>
+                  <Header as="h3">{strings.TITLE_DETAILS}</Header>
                   <SummaryViewWrapper {...summaryViewProps} />
                 </Segment>
-
                 <Segment basic>
-                  <Header as="h3">{strings.LABEL_REVIEW}</Header>
+                  <Form.Field>
+                    <strong>{strings.LABEL_REVIEW}</strong>
+                  </Form.Field>
                   {/* // TODO: Change to list options dynamically? */}
-                  <Radio
-                    label={strings.LABEL_REVIEW_APPROVE}
-                    value={strings.LABEL_REVIEW_APPROVE}
-                    name="decisionGroup"
-                    checked={review.decision === ReviewResponseDecision.Approve}
-                    onChange={() =>
-                      setReview({
-                        ...review,
-                        decision: ReviewResponseDecision.Approve,
-                      })
-                    }
-                  />
-                  <Radio
-                    label={strings.LABEL_REVIEW_RESSUBMIT}
-                    value={strings.LABEL_REVIEW_RESSUBMIT}
-                    name="decisionGroup"
-                    checked={review.decision === ReviewResponseDecision.Decline}
-                    onChange={() =>
-                      setReview({
-                        ...review,
-                        decision: ReviewResponseDecision.Decline,
-                      })
-                    }
-                  />
+                  <Form.Field>
+                    <Radio
+                      label={strings.LABEL_REVIEW_APPROVE}
+                      value={strings.LABEL_REVIEW_APPROVE}
+                      name="decisionGroup"
+                      checked={review.decision === ReviewResponseDecision.Approve}
+                      onChange={() =>
+                        setReview({
+                          ...review,
+                          decision: ReviewResponseDecision.Approve,
+                        })
+                      }
+                    />
+                  </Form.Field>
+                  <Form.Field>
+                    <Radio
+                      label={strings.LABEL_REVIEW_RESSUBMIT}
+                      value={strings.LABEL_REVIEW_RESSUBMIT}
+                      name="decisionGroup"
+                      checked={review.decision === ReviewResponseDecision.Decline}
+                      onChange={() =>
+                        setReview({
+                          ...review,
+                          decision: ReviewResponseDecision.Decline,
+                        })
+                      }
+                    />
+                  </Form.Field>
                 </Segment>
                 <Segment basic>
-                  <Header as="h3">{strings.LABEL_COMMENT}</Header>
+                  <Form.Field>
+                    <strong>{strings.LABEL_COMMENT}</strong>
+                  </Form.Field>
                   <TextArea
-                    rows={6}
-                    style={{ width: '100%' }}
+                    rows={8}
                     defaultValue={review.comment}
                     onChange={(_, { value }) => setReview({ ...review, comment: String(value) })}
                   />
                 </Segment>
                 <Segment basic>
-                  <Button
-                    color="blue"
-                    basic
-                    onClick={submit}
-                    disabled={
-                      !review.decision ||
-                      (review.decision === ReviewResponseDecision.Decline && !review.comment)
-                    }
-                    content={strings.BUTTON_SUBMIT}
-                  />
+                  <Form.Field>
+                    <Button
+                      primary
+                      className="button-wide"
+                      onClick={submit}
+                      disabled={
+                        !review.decision ||
+                        (review.decision === ReviewResponseDecision.Decline && !review.comment)
+                      }
+                      content={strings.BUTTON_SUBMIT}
+                    />
+                  </Form.Field>
                   {review.decision === ReviewResponseDecision.Decline && !review.comment && (
                     <p style={{ color: 'red' }}>{messages.REVIEW_RESUBMIT_COMMENT}</p>
                   )}
+                </Segment>
+                <Segment basic id="history-panel">
+                  <p>
+                    <em>History panel goes here</em>
+                  </p>
                 </Segment>
               </Form>
             </div>

--- a/src/components/Review/DecisionArea.tsx
+++ b/src/components/Review/DecisionArea.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Button, Form, Header, Modal, Radio, Segment, TextArea } from 'semantic-ui-react'
+import { Button, Container, Form, Header, Modal, Radio, Segment, TextArea } from 'semantic-ui-react'
 import { useRouter } from '../../utils/hooks/useRouter'
 import { ReviewResponse, ReviewResponseDecision } from '../../utils/generated/graphql'
 import strings from '../../utils/constants'
@@ -50,73 +50,72 @@ const DecisionArea: React.FC<DecisionAreaProps> = ({
       style={{ margin: 0, background: 'transparent' }}
     >
       {!isOpen ? null : (
-        <Segment
-          floated="right"
-          style={{
-            backgroundColor: 'white',
-            height: '100vh',
-            width: '300px',
-          }}
-        >
-          <Segment basic>
-            <Header>{strings.TITLE_DETAILS}</Header>
-            <SummaryViewWrapper {...summaryViewProps} />
-          </Segment>
-          <Form>
-            <Segment basic>
-              <Header as="h3">{strings.LABEL_REVIEW}</Header>
-              {/* // TODO: Change to list options dynamically? */}
-              <Radio
-                label={strings.LABEL_REVIEW_APPROVE}
-                value={strings.LABEL_REVIEW_APPROVE}
-                name="decisionGroup"
-                checked={review.decision === ReviewResponseDecision.Approve}
-                onChange={() =>
-                  setReview({
-                    ...review,
-                    decision: ReviewResponseDecision.Approve,
-                  })
-                }
-              />
-              <Radio
-                label={strings.LABEL_REVIEW_RESSUBMIT}
-                value={strings.LABEL_REVIEW_RESSUBMIT}
-                name="decisionGroup"
-                checked={review.decision === ReviewResponseDecision.Decline}
-                onChange={() =>
-                  setReview({
-                    ...review,
-                    decision: ReviewResponseDecision.Decline,
-                  })
-                }
-              />
-            </Segment>
-            <Segment basic>
-              <Header as="h3">{strings.LABEL_COMMENT}</Header>
-              <TextArea
-                rows={6}
-                style={{ width: '100%' }}
-                defaultValue={review.comment}
-                onChange={(_, { value }) => setReview({ ...review, comment: String(value) })}
-              />
-            </Segment>
-            <Segment basic>
-              <Button
-                color="blue"
-                basic
-                onClick={submit}
-                disabled={
-                  !review.decision ||
-                  (review.decision === ReviewResponseDecision.Decline && !review.comment)
-                }
-                content={strings.BUTTON_SUBMIT}
-              />
-              {review.decision === ReviewResponseDecision.Decline && !review.comment && (
-                <p style={{ color: 'red' }}>{messages.REVIEW_RESUBMIT_COMMENT}</p>
-              )}
-            </Segment>
-          </Form>
-        </Segment>
+        <div id="review-decision-container">
+          <div id="review-decision-content">
+            {/* <Container id="document-viewer" style={{}}></Container> */}
+            <div id="details-panel">
+              <Form>
+                <Segment basic>
+                  <Header>{strings.TITLE_DETAILS}</Header>
+                  <SummaryViewWrapper {...summaryViewProps} />
+                </Segment>
+
+                <Segment basic>
+                  <Header as="h3">{strings.LABEL_REVIEW}</Header>
+                  {/* // TODO: Change to list options dynamically? */}
+                  <Radio
+                    label={strings.LABEL_REVIEW_APPROVE}
+                    value={strings.LABEL_REVIEW_APPROVE}
+                    name="decisionGroup"
+                    checked={review.decision === ReviewResponseDecision.Approve}
+                    onChange={() =>
+                      setReview({
+                        ...review,
+                        decision: ReviewResponseDecision.Approve,
+                      })
+                    }
+                  />
+                  <Radio
+                    label={strings.LABEL_REVIEW_RESSUBMIT}
+                    value={strings.LABEL_REVIEW_RESSUBMIT}
+                    name="decisionGroup"
+                    checked={review.decision === ReviewResponseDecision.Decline}
+                    onChange={() =>
+                      setReview({
+                        ...review,
+                        decision: ReviewResponseDecision.Decline,
+                      })
+                    }
+                  />
+                </Segment>
+                <Segment basic>
+                  <Header as="h3">{strings.LABEL_COMMENT}</Header>
+                  <TextArea
+                    rows={6}
+                    style={{ width: '100%' }}
+                    defaultValue={review.comment}
+                    onChange={(_, { value }) => setReview({ ...review, comment: String(value) })}
+                  />
+                </Segment>
+                <Segment basic>
+                  <Button
+                    color="blue"
+                    basic
+                    onClick={submit}
+                    disabled={
+                      !review.decision ||
+                      (review.decision === ReviewResponseDecision.Decline && !review.comment)
+                    }
+                    content={strings.BUTTON_SUBMIT}
+                  />
+                  {review.decision === ReviewResponseDecision.Decline && !review.comment && (
+                    <p style={{ color: 'red' }}>{messages.REVIEW_RESUBMIT_COMMENT}</p>
+                  )}
+                </Segment>
+              </Form>
+            </div>
+          </div>
+        </div>
       )}
     </Modal>
   )


### PR DESCRIPTION
Since design discussion for this are ongoing, I've just done a basic layout and made the existing panel in line with designs (mostly)

I've made a container for a "document-viewer" alongside the details panel, but that's currently hidden

Also -- I was getting tired of having to reload the panel every time the page refreshed, so I made the panel open state part of the url query. So now the query is the primary source of truth for which Decision panel is open. E.g.
`http://localhost:3000/application/23456/review/5?active-sections=S1&open-response=Q1`