### PR TITLE
#645 Implement help text tips

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -467,10 +467,6 @@ a:hover {
   padding-right: 0;
 }
 
-// #form-column .ui.grid .column {
-//   padding: 0 0 0 10px !important;
-// }
-
 // Seperation between Section title and form elements
 .form-area {
   margin-top: 30px;

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -452,7 +452,7 @@ a:hover {
 }
 
 #progress-column {
-  max-width: 205px;
+  max-width: 200px;
   padding-left: 5px;
   padding-right: 0;
   padding-top: 0;
@@ -462,13 +462,52 @@ a:hover {
   padding: 0;
 }
 
+#form-column .ui.basic.segment {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+// #form-column .ui.grid .column {
+//   padding: 0 0 0 10px !important;
+// }
+
 // Seperation between Section title and form elements
 .form-area {
   margin-top: 30px;
 }
 
-#help-column {
-  max-width: 200px;
+// Contains form-element and help-tips
+.form-element-wrapper {
+  display: flex;
+  padding-left: 10px;
+  justify-content: space-between;
+}
+
+.form-element {
+  width: clamp(350px, 70%, 480px);
+}
+
+.help-tips {
+  width: clamp(50px, 30%, 250px);
+  margin-top: 20px; // height of label, so flush with input field
+  margin-right: -10px;
+  max-height: 80px; // less than element height, so overflows
+  position: relative;
+}
+
+.help-tips-content {
+  font-style: italic;
+  padding-left: 20px;
+}
+
+// Vertical accent line for help tips
+.help-tips-content::before {
+  content: '';
+  border-left: 1px solid @information;
+  height: 40px;
+  position: absolute;
+  top: 5px;
+  left: 3%;
 }
 
 // Progress Bar

--- a/src/components/PageElements/PageElements.tsx
+++ b/src/components/PageElements/PageElements.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Form, Segment } from 'semantic-ui-react'
+import { Form, Grid, Segment } from 'semantic-ui-react'
 import {
   ApplicationDetails,
   ElementState,
@@ -10,6 +10,7 @@ import {
 import { ApplicationViewWrapper } from '../../formElementPlugins'
 import { ApplicationViewWrapperProps } from '../../formElementPlugins/types'
 import { TemplateElementCategory } from '../../utils/generated/graphql'
+import Markdown from '../../utils/helpers/semanticReactMarkdown'
 import SummaryInformationElement from './Elements/SummaryInformationElement'
 import SummaryResponseElement from './Elements/SummaryResponseElement'
 import SummaryResponseChangedElement from './Elements/SummaryResponseChangedElement'
@@ -67,7 +68,20 @@ const PageElements: React.FC<PageElementProps> = ({
               currentResponse: responsesByCode?.[element.code],
             }
             // Wrapper displays response & changes requested warning for LOQ re-submission
-            return <ApplicationViewWrapper key={`question_${element.code}`} {...props} />
+            return (
+              <div className="form-element-wrapper" key={`question_${element.code}`}>
+                <div className="form-element">
+                  <ApplicationViewWrapper {...props} />
+                </div>
+                {element.helpText && (
+                  <div className="help-tips hide-on-mobile">
+                    <div className="help-tips-content">
+                      <Markdown text={element.helpText} />
+                    </div>
+                  </div>
+                )}
+              </div>
+            )
           }
         )}
       </Form>

--- a/src/components/PageElements/PageElements.tsx
+++ b/src/components/PageElements/PageElements.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Form, Grid, Segment } from 'semantic-ui-react'
+import { Form, Segment } from 'semantic-ui-react'
 import {
   ApplicationDetails,
   ElementState,

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -6,13 +6,7 @@ import {
   MethodRevalidate,
   ApplicationProps,
 } from '../../utils/types'
-import {
-  ApplicationContainer,
-  Loading,
-  Navigation,
-  PageElements,
-  ProgressArea,
-} from '../../components'
+import { Loading, Navigation, PageElements, ProgressArea } from '../../components'
 import { useUserState } from '../../contexts/UserState'
 import { ApplicationStatus } from '../../utils/generated/graphql'
 import { checkPageIsAccessible } from '../../utils/helpers/structure'
@@ -72,7 +66,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({
               strictSectionPage={strictSectionPage as SectionAndPage}
             />
           </Grid.Column>
-          <Grid.Column width={9} stretched id="form-column">
+          <Grid.Column width={12} stretched id="form-column">
             <Segment basic>
               <Header as="h4" content={fullStructure.sections[sectionCode].details.title} />
               <PageElements
@@ -86,9 +80,6 @@ const ApplicationPage: React.FC<ApplicationProps> = ({
                 }
               />
             </Segment>
-          </Grid.Column>
-          <Grid.Column width={3} id="help-column" className="dev-border">
-            Help tips go here
           </Grid.Column>
         </Grid>
       </Container>

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -2800,6 +2800,8 @@ export type TemplateElementFilter = {
   validation?: Maybe<JsonFilter>;
   /** Filter by the object’s `validationMessage` field. */
   validationMessage?: Maybe<StringFilter>;
+  /** Filter by the object’s `helpText` field. */
+  helpText?: Maybe<StringFilter>;
   /** Filter by the object’s `parameters` field. */
   parameters?: Maybe<JsonFilter>;
   /** Filter by the object’s `templateCode` field. */
@@ -5164,6 +5166,8 @@ export enum TemplateElementsOrderBy {
   ValidationDesc = 'VALIDATION_DESC',
   ValidationMessageAsc = 'VALIDATION_MESSAGE_ASC',
   ValidationMessageDesc = 'VALIDATION_MESSAGE_DESC',
+  HelpTextAsc = 'HELP_TEXT_ASC',
+  HelpTextDesc = 'HELP_TEXT_DESC',
   ParametersAsc = 'PARAMETERS_ASC',
   ParametersDesc = 'PARAMETERS_DESC',
   TemplateCodeAsc = 'TEMPLATE_CODE_ASC',
@@ -5198,6 +5202,8 @@ export type TemplateElementCondition = {
   validation?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `validationMessage` field. */
   validationMessage?: Maybe<Scalars['String']>;
+  /** Checks for equality with the object’s `helpText` field. */
+  helpText?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `parameters` field. */
   parameters?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `templateCode` field. */
@@ -5233,6 +5239,7 @@ export type TemplateElement = Node & {
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
+  helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateCode?: Maybe<Scalars['String']>;
   /** Reads a single `TemplateSection` that is related to this `TemplateElement`. */
@@ -11740,6 +11747,7 @@ export type UpdateTemplateElementOnApplicationResponseForApplicationResponseTemp
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
+  helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateCode?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
@@ -11831,6 +11839,7 @@ export type UpdateTemplateElementOnTemplateElementForTemplateElementSectionIdFke
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
+  helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateCode?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
@@ -13240,6 +13249,7 @@ export type UpdateTemplateElementOnReviewQuestionAssignmentForReviewQuestionAssi
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
+  helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateCode?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
@@ -15282,6 +15292,7 @@ export type UpdateTemplateElementOnReviewResponseForReviewResponseTemplateElemen
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
+  helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateCode?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
@@ -15422,6 +15433,7 @@ export type TemplateElementPatch = {
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
+  helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateCode?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
@@ -15444,6 +15456,7 @@ export type ReviewResponseTemplateElementIdFkeyTemplateElementCreateInput = {
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
+  helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateCode?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
@@ -16154,6 +16167,7 @@ export type ReviewQuestionAssignmentTemplateElementIdFkeyTemplateElementCreateIn
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
+  helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateCode?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
@@ -17166,6 +17180,7 @@ export type TemplateElementSectionIdFkeyTemplateElementCreateInput = {
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
+  helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateCode?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
@@ -17353,6 +17368,7 @@ export type ApplicationResponseTemplateElementIdFkeyTemplateElementCreateInput =
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
+  helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateCode?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
@@ -19397,6 +19413,7 @@ export type TemplateElementInput = {
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
+  helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
   templateCode?: Maybe<Scalars['String']>;
   templateSectionToSectionId?: Maybe<TemplateElementSectionIdFkeyInput>;
@@ -22440,7 +22457,7 @@ export type ApplicationFragment = (
 
 export type ElementFragment = (
   { __typename?: 'TemplateElement' }
-  & Pick<TemplateElement, 'id' | 'code' | 'index' | 'title' | 'elementTypePluginCode' | 'category' | 'visibilityCondition' | 'isRequired' | 'isEditable' | 'validation' | 'validationMessage' | 'parameters'>
+  & Pick<TemplateElement, 'id' | 'code' | 'index' | 'title' | 'elementTypePluginCode' | 'category' | 'visibilityCondition' | 'isRequired' | 'isEditable' | 'validation' | 'validationMessage' | 'helpText' | 'parameters'>
 );
 
 export type OrganisationFragment = (
@@ -23070,6 +23087,7 @@ export const ElementFragmentDoc = gql`
   isEditable
   validation
   validationMessage
+  helpText
   parameters
 }
     `;

--- a/src/utils/graphql/fragments/element.fragment.ts
+++ b/src/utils/graphql/fragments/element.fragment.ts
@@ -13,6 +13,7 @@ export default gql`
     isEditable
     validation
     validationMessage
+    helpText
     parameters
   }
 `

--- a/src/utils/hooks/useLoadApplication.ts
+++ b/src/utils/hooks/useLoadApplication.ts
@@ -150,6 +150,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
             parameters: element.parameters,
             validationExpression: element.validation,
             validationMessage: element.validationMessage,
+            helpText: element.helpText,
           } as TemplateElementState)
       })
     })

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -175,6 +175,7 @@ interface ElementBase {
   category: TemplateElementCategory
   validationExpression: IQueryNode
   validationMessage: string | null
+  helpText: string | null
   parameters: any
 }
 


### PR DESCRIPTION
Implements #645, using "Option 1" from [this discussion](https://github.com/openmsupply/application-manager-web-app/issues/681#issue-878183541)

Requires branch from [back-end PR #389](https://github.com/openmsupply/application-manager-server/pull/339)

<img width="1095" alt="Screen Shot 2021-05-09 at 10 13 29 PM" src="https://user-images.githubusercontent.com/5456533/117568336-cd317e80-b113-11eb-99cf-d550f2c1edd3.png">

Note that the help text can quite happily hang below the level of the next question, which means that template builders will have to mindful not to overlap them, or else this happens:

<img width="736" alt="Screen Shot 2021-05-09 at 10 16 25 PM" src="https://user-images.githubusercontent.com/5456533/117568421-39ac7d80-b114-11eb-8b05-f0137e686160.png">

Have added more "demonstration" help text to the Feature Showcase template, but I've also added some more "realistic" help tips to some of the other templates (see back-end changes)

