### PR TITLE
#662(2) Change Request styles

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -722,6 +722,10 @@ a:hover {
   color: @information !important;
 }
 
+.interactive-color {
+  color: @interactiveHigh;
+}
+
 // Position adjustments
 .shift-up-1 {
   transform: translateY(-1px);

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -301,7 +301,7 @@ a:hover {
 
 // Steps line - actions box
 .actions-box {
-  min-width: 100px;
+  min-width: 120px;
   text-align: right;
 }
 
@@ -532,6 +532,25 @@ a:hover {
 
 // .element-summary-view {
 // }
+
+// For change request borders
+.element-warning-border {
+  border: 1px solid @headersInteractiveMed;
+  padding: 10px;
+  border-radius: @borderRadius;
+  // margin-bottom: 10px !important;
+  margin-left: -10px !important;
+  margin-right: -10px !important;
+  // margin-top: 0;
+}
+
+.alert-border {
+  border-color: @attention;
+}
+
+.blue-border {
+  border-color: @interactiveHigh;
+}
 
 /*--------------------------------
       Application Navigation area

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -538,10 +538,8 @@ a:hover {
   border: 1px solid @headersInteractiveMed;
   padding: 10px;
   border-radius: @borderRadius;
-  // margin-bottom: 10px !important;
   margin-left: -10px !important;
   margin-right: -10px !important;
-  // margin-top: 0;
 }
 
 .alert-border {
@@ -550,6 +548,10 @@ a:hover {
 
 .blue-border {
   border-color: @interactiveHigh;
+}
+
+.reviewer-comment {
+  font-size: 0.9em;
 }
 
 /*--------------------------------

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -347,7 +347,7 @@ a:hover {
 
 .review-comment-grid.ui.grid {
   padding: 10px 20px;
-  font-size: 0.85em;
+  font-size: @smallerText;
   color: @headersInteractiveLow;
 }
 
@@ -360,7 +360,7 @@ a:hover {
 }
 
 #review-submit-area p {
-  font-size: 0.95em;
+  font-size: @tinyBitSmallerText;
   margin-top: 10px;
   margin-bottom: 5px;
 }
@@ -498,7 +498,7 @@ a:hover {
 // }
 
 .page-list {
-  font-size: 0.9em !important;
+  font-size: @slightlySmallerText !important;
   padding-left: 30px !important;
   margin-bottom: -30px !important;
   margin-top: -20px !important;
@@ -723,7 +723,7 @@ a:hover {
 }
 
 .interactive-color {
-  color: @interactiveHigh;
+  color: @interactiveHigh !important;
 }
 
 // Position adjustments

--- a/semantic/src/site/globals/site.variables
+++ b/semantic/src/site/globals/site.variables
@@ -104,6 +104,10 @@
 @fontLarge: 20px;
 @fontXlarge: 27px;
 @fontXXlarge: 36px;
+// Relative sizes
+@tinyBitSmallerText: 0.95em;
+@slightlySmallerText: 0.9em;
+@smallerText: 0.85em;
 
 .xx-small {
   font-size: @fontXXsmall;

--- a/src/components/List/Cells/StatusCell.tsx
+++ b/src/components/List/Cells/StatusCell.tsx
@@ -22,13 +22,14 @@ const StatusCell: React.FC<CellProps> = ({ application }) => {
       )
     case ApplicationStatus.Draft:
       return (
-        <Segment basic textAlign="center">
+        <>
           <Progress size="tiny" />
           <Link to={`/application/${serial}`} className="user-action">
             {ACTIONS.EDIT_DRAFT}
           </Link>
+          {/* TO DO: Trash icon should link to application delete */}
           <Icon name="trash alternate outline" />
-        </Segment>
+        </>
       )
     case ApplicationStatus.Expired:
       return (

--- a/src/components/List/Cells/StatusCell.tsx
+++ b/src/components/List/Cells/StatusCell.tsx
@@ -11,12 +11,12 @@ enum ACTIONS {
 }
 
 const StatusCell: React.FC<CellProps> = ({ application }) => {
-  const { serial, stage, status } = application
+  const { serial, status } = application
   switch (status) {
     case ApplicationStatus.ChangesRequired:
       return (
-        <Link to={`/application/${serial}`}>
-          <Icon name="exclamation circle" color="red" />
+        <Link to={`/application/${serial}`} className="user-action">
+          <Icon name="exclamation circle" className="alert" />
           {ACTIONS.MAKE_CHANGES}
         </Link>
       )
@@ -24,14 +24,24 @@ const StatusCell: React.FC<CellProps> = ({ application }) => {
       return (
         <Segment basic textAlign="center">
           <Progress size="tiny" />
-          <Link to={`/application/${serial}`}>{ACTIONS.EDIT_DRAFT}</Link>
-          <Icon name="trash alternate outline" style={{ marginLeft: 10 }} />
+          <Link to={`/application/${serial}`} className="user-action">
+            {ACTIONS.EDIT_DRAFT}
+          </Link>
+          <Icon name="trash alternate outline" />
         </Segment>
       )
     case ApplicationStatus.Expired:
-      return <Link to={`/application/${serial}/renew`}>{ACTIONS.RENEW}</Link> // TODO: Add Renew page (and logic)
+      return (
+        <Link to={`/application/${serial}/renew`} className="user-action">
+          {ACTIONS.RENEW}
+        </Link>
+      ) // TODO: Add Renew page (and logic)
     case ApplicationStatus.ChangesRequired:
-      return <Link to={`/application/${serial}`}>{ACTIONS.MAKE_CHANGES}</Link> // TODO: Show number of responses to make changes
+      return (
+        <Link to={`/application/${serial}`} className="user-action">
+          {ACTIONS.MAKE_CHANGES}
+        </Link>
+      ) // TODO: Show number of responses to make changes
     case undefined:
       console.log('Problem to get status of application serial ', serial)
       return null

--- a/src/components/PageElements/PageElements.tsx
+++ b/src/components/PageElements/PageElements.tsx
@@ -106,11 +106,7 @@ const PageElements: React.FC<PageElementProps> = ({
 
           return (
             <div key={`question_${element.id}`}>
-              <Segment
-                basic
-                className="summary-page-element"
-                style={inlineStyles(isChangeRequest, isSummary)}
-              >
+              <Segment basic className="summary-page-element">
                 {element.category === TemplateElementCategory.Question ? (
                   changedQuestionResponse ? (
                     <SummaryResponseElement {...props} />
@@ -152,12 +148,7 @@ const PageElements: React.FC<PageElementProps> = ({
 
             return (
               <div key={`${element.code}ReviewContainer`}>
-                <Segment
-                  basic
-                  key={`question_${element.id}`}
-                  className="summary-page-element"
-                  style={inlineStyles(isChangeRequest)}
-                >
+                <Segment basic key={`question_${element.id}`} className="summary-page-element">
                   {element.category === TemplateElementCategory.Question ? (
                     <ReviewResponseElement {...props} />
                   ) : (
@@ -180,17 +171,5 @@ const PageElements: React.FC<PageElementProps> = ({
   }
   return null
 }
-
-// Styles - TODO: Move to LESS || Global class style (semantic)
-const inlineStyles = (isChangeRequest?: boolean, isSummary?: boolean) => ({
-  // background: isSummary && isChangeRequest ? 'rgb(249, 255, 255)' : '#FFFFFF',
-  // borderRadius: 8,
-  // borderBottomLeftRadius: isChangeRequest ? 0 : 8,
-  // borderBottomRightRadius: isChangeRequest ? 0 : 8,
-  // border: 'none',
-  // boxShadow: 'none',
-  // margin: 10,
-  // marginBottom: isChangeRequest ? 0 : 10,
-})
 
 export default PageElements

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -229,21 +229,14 @@ const ChangesToResponseWarning: React.FC<ChangesToResponseWarningProps> = ({
 }) => {
   const visibilityClass = isChangeRequest || (isChanged && isValid) ? '' : 'invisible'
   const colourClass = isChangeRequest ? (!isChanged ? 'alert' : '') : 'interactive-color'
-  const icon = (
-    <Icon
-      name={
-        isChangeRequest
-          ? isChanged
-            ? 'comment alternate outline'
-            : 'exclamation circle'
-          : 'info circle'
-      }
-      className="colourClass"
-    />
-  )
+  const iconSelection = isChangeRequest
+    ? isChanged
+      ? 'comment alternate outline'
+      : 'exclamation circle'
+    : 'info circle'
   return (
     <p className={`${colourClass} ${visibilityClass} reviewer-comment`}>
-      {icon}
+      <Icon name={iconSelection} className="colourClass" />
       {isChangeRequest ? reviewerComment : messages.APPLICATION_OTHER_CHANGES_MADE}
     </p>
   )

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -177,26 +177,25 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
     if (!changesRequired) return null
     const { isChangeRequest, isChanged } = changesRequired
     const isValid = validationState ? (validationState.isValid as boolean) : true
-    const displayResponseWarning = isChangeRequest || (isChanged && isValid)
+    const borderClass = isChangeRequest || (isChanged && isValid) ? 'element-warning-border' : ''
+    const borderColorClass = isChangeRequest ? (!isChanged ? 'alert-border' : '') : 'blue-border'
+
     return (
-      <div
-        style={{
-          border: displayResponseWarning ? 'solid 1px' : 'transparent',
-          borderColor: isChangeRequest ? (isChanged ? 'black' : 'red') : 'blue',
-          borderRadius: 7,
-          padding: displayResponseWarning ? 4 : 5,
-          margin: 5,
-        }}
-      >
+      // <div className={`element-application-view ${borderClass} ${borderColorClass}`}>
+      <>
         {parametersReady ? (
-          <Form.Field className="element-application-view" required={isRequired}>
+          <Form.Field
+            className={`element-application-view ${borderClass} ${borderColorClass}`}
+            required={isRequired}
+          >
             {PluginComponent}
+            <ChangesToResponseWarning {...changesRequired} isValid={isValid} />
           </Form.Field>
         ) : (
           <Loader active inline />
         )}
-        <ChangesToResponseWarning {...changesRequired} isValid={isValid} />
-      </div>
+      </>
+      // </div>
     )
   }
 

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -228,7 +228,7 @@ const ChangesToResponseWarning: React.FC<ChangesToResponseWarningProps> = ({
   isValid,
 }) => {
   const visibilityClass = isChangeRequest || (isChanged && isValid) ? '' : 'invisible'
-  const colourClass = isChangeRequest ? (!isChanged ? 'alert' : '') : 'blue'
+  const colourClass = isChangeRequest ? (!isChanged ? 'alert' : '') : 'interactive-color'
   const icon = (
     <Icon
       name={

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -181,7 +181,6 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
     const borderColorClass = isChangeRequest ? (!isChanged ? 'alert-border' : '') : 'blue-border'
 
     return (
-      // <div className={`element-application-view ${borderClass} ${borderColorClass}`}>
       <>
         {parametersReady ? (
           <Form.Field
@@ -195,7 +194,6 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
           <Loader active inline />
         )}
       </>
-      // </div>
     )
   }
 
@@ -230,7 +228,10 @@ const ChangesToResponseWarning: React.FC<ChangesToResponseWarningProps> = ({
   isValid,
 }) => {
   const displayResponseWarning = isChangeRequest || (isChanged && isValid)
+  const visibilityClass = isChangeRequest || (isChanged && isValid) ? '' : 'invisible'
+  const colourClass = isChangeRequest ? (!isChanged ? 'alert' : '') : 'blue'
   return (
+    // TO DO -- implement styles
     <div
       style={{
         color: isChangeRequest && isChanged && isValid ? 'grey' : 'red',

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -227,29 +227,25 @@ const ChangesToResponseWarning: React.FC<ChangesToResponseWarningProps> = ({
   reviewerComment,
   isValid,
 }) => {
-  const displayResponseWarning = isChangeRequest || (isChanged && isValid)
   const visibilityClass = isChangeRequest || (isChanged && isValid) ? '' : 'invisible'
   const colourClass = isChangeRequest ? (!isChanged ? 'alert' : '') : 'blue'
+  const icon = (
+    <Icon
+      name={
+        isChangeRequest
+          ? isChanged
+            ? 'comment alternate outline'
+            : 'exclamation circle'
+          : 'info circle'
+      }
+      className="colourClass"
+    />
+  )
   return (
-    // TO DO -- implement styles
-    <div
-      style={{
-        color: isChangeRequest && isChanged && isValid ? 'grey' : 'red',
-        visibility: displayResponseWarning ? 'visible' : 'hidden',
-      }}
-    >
-      <Icon
-        name={
-          isChangeRequest
-            ? isChanged
-              ? 'comment alternate outline'
-              : 'exclamation circle'
-            : 'info circle'
-        }
-        color={isChangeRequest ? (isChanged ? 'grey' : 'red') : 'blue'}
-      />
+    <p className={`${colourClass} ${visibilityClass} reviewer-comment`}>
+      {icon}
       {isChangeRequest ? reviewerComment : messages.APPLICATION_OTHER_CHANGES_MADE}
-    </div>
+    </p>
   )
 }
 


### PR DESCRIPTION
Updates the change request styles to match the latest layout and style changes. Should look pretty much the same as before (with the coloured borders around the elements).

<img width="529" alt="Screen Shot 2021-05-09 at 10 34 31 PM" src="https://user-images.githubusercontent.com/5456533/117568842-cb1cef00-b116-11eb-8d66-a2795d074263.png">


@nmadruga -- I have tried to preserve the conditional logic for the colour/style display in ApplicationViewWrapper using simple class switching rather than inline styles, but it'd be worth having a careful look at that bit to make sure.

- Also updated the "Make Changes" style in Applications List.

**NOTE:** There is still some work to do to make these elements on the Summary page consistent with on the Review page (re-using styles, and maybe even components)