### PR TITLE
#654 Show your assignment rows and review progress rows

### DIFF
--- a/src/containers/Review/ReviewSectionRow.tsx
+++ b/src/containers/Review/ReviewSectionRow.tsx
@@ -58,7 +58,9 @@ const ReviewSectionRow: React.FC<ReviewSectionRowProps> = ({
   }
 
   const canRenderRow =
-    section?.assignment?.isReviewable || section?.assignment?.action === ReviewAction.canSelfAssign
+    section?.assignment?.isAssignedToCurrentUser ||
+    section?.assignment?.action === ReviewAction.canSelfAssign ||
+    (section?.assignment?.action === ReviewAction.canView && section?.assignment?.isReviewable)
 
   return (
     <>


### PR DESCRIPTION
Fixes #654 

Very basic changes, perhaps can be improved. I wasn't sure why `isReviewable` is set to true when the review isn't in **Draft**. Anyway, just a quick previous of the changes in this PR. Please test more cases - although to test Consolidation one it would better to first merge in PR #695.

I have test using this application:

Before the user self-assign it show other possible self-assigners:
<img width="733" alt="Screen Shot 2021-05-13 at 5 06 46 PM" src="https://user-images.githubusercontent.com/16461988/118080547-7fb45a80-b40e-11eb-90ce-edb4ab7fc4b6.png">

After the review is assigned to one and locked to the other is doesn't show to others:
<img width="730" alt="Screen Shot 2021-05-13 at 5 06 56 PM" src="https://user-images.githubusercontent.com/16461988/118080544-7f1bc400-b40e-11eb-8ccf-5da7f1af515c.png">

But the review is visible from your review home page (logged as Consolidator 2):
<img width="725" alt="Screen Shot 2021-05-13 at 5 07 08 PM" src="https://user-images.githubusercontent.com/16461988/118080535-7b883d00-b40e-11eb-9d8f-d3fb277f95f1.png">

And other reviews which are already submitted would show as well. I think that was the idea.
