### PR TITLE
#638 Fix Application Home start message

### DIFF
--- a/src/containers/Application/ApplicationHome.tsx
+++ b/src/containers/Application/ApplicationHome.tsx
@@ -65,7 +65,7 @@ const ApplicationHome: React.FC<ApplicationProps> = ({ structure, template }) =>
     <>
       <ChangesRequestedTitle status={current?.status} isChangeRequest={isChangeRequest} />
       <ApplicationHomeWrapper
-        startMessage={template.startMessage}
+        startMessage={structure.info.startMessage}
         name={template.name}
         ButtonSegment={SummaryButtonSegment}
       >

--- a/src/containers/Application/ApplicationWrapper.tsx
+++ b/src/containers/Application/ApplicationWrapper.tsx
@@ -20,7 +20,7 @@ const ApplicationWrapper: React.FC = () => {
     userState: { currentUser, isNonRegistered },
   } = useUserState()
 
-  const { error, isLoading, structure, template } = useLoadApplication({
+  const { error, isLoading, structure } = useLoadApplication({
     serialNumber,
     currentUser: currentUser as User,
     networkFetch: true,
@@ -30,23 +30,23 @@ const ApplicationWrapper: React.FC = () => {
     <Message error header={strings.ERROR_APPLICATION_PAGE} list={[error]} />
   ) : isLoading ? (
     <Loading />
-  ) : structure && template ? (
+  ) : structure ? (
     <Switch>
       <Route path={`${path}/review`}>
         <ReviewWrapper structure={structure} />
       </Route>
       <Route exact path={path}>
-        <ApplicationContainer template={template}>
-          <ApplicationHome structure={structure} template={template} />
+        <ApplicationContainer template={structure.info.template}>
+          <ApplicationHome structure={structure} template={structure.info.template} />
         </ApplicationContainer>
       </Route>
       <Route exact path={`${path}/submission`}>
-        <ApplicationContainer template={template}>
+        <ApplicationContainer template={structure.info.template}>
           <ApplicationSubmission structure={structure} />
         </ApplicationContainer>
       </Route>
       <Route>
-        <ApplicationContainer template={template}>
+        <ApplicationContainer template={structure.info.template}>
           <ApplicationPageWrapper structure={structure} />
         </ApplicationContainer>
       </Route>

--- a/src/utils/hooks/useLoadApplication.ts
+++ b/src/utils/hooks/useLoadApplication.ts
@@ -162,25 +162,27 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
       APIfetch: fetch,
       graphQLConnection: { fetch: fetch.bind(window), endpoint: graphQLEndpoint },
     }
-    evaluate(application.template?.submissionMessage || '', evaluatorParams).then(
-      (submissionMessage: any) => {
-        let newStructure: FullStructure = {
-          info: { ...applicationDetails, submissionMessage },
-          stages: templateStages.map((stage) => ({
-            number: stage.number as number,
-            id: stage.id,
-            title: stage.title as string,
-            description: stage.description ? stage.description : undefined,
-            colour: stage.colour as string,
-          })),
-          sections: buildSectionsStructure({ sections, baseElements }),
-          attemptSubmission: false,
-        }
-
-        setFullStructure(newStructure)
-        setIsLoading(false)
+    const templateMessages: any = [
+      evaluate(application.template?.startMessage || '', evaluatorParams),
+      evaluate(application.template?.submissionMessage || '', evaluatorParams),
+    ]
+    Promise.all(templateMessages).then(([startMessage, submissionMessage]: any) => {
+      let newStructure: FullStructure = {
+        info: { ...applicationDetails, submissionMessage, startMessage },
+        stages: templateStages.map((stage) => ({
+          number: stage.number as number,
+          id: stage.id,
+          title: stage.title as string,
+          description: stage.description ? stage.description : undefined,
+          colour: stage.colour as string,
+        })),
+        sections: buildSectionsStructure({ sections, baseElements }),
+        attemptSubmission: false,
       }
-    )
+
+      setFullStructure(newStructure)
+      setIsLoading(false)
+    })
   }, [data, loading])
 
   return {

--- a/src/utils/hooks/useLoadApplication.ts
+++ b/src/utils/hooks/useLoadApplication.ts
@@ -17,7 +17,6 @@ import {
   ApplicationStageStatusAll,
   ApplicationStatus,
   Organisation,
-  Template,
   TemplateElement,
   TemplateStage,
   useGetApplicationQuery,
@@ -35,7 +34,6 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
   const [isLoading, setIsLoading] = useState(true)
   const [structureError, setStructureError] = useState('')
   const [structure, setFullStructure] = useState<FullStructure>()
-  const [template, setTemplate] = useState<TemplateDetails>()
   const [refetchAttempts, setRefetchAttempts] = useState(0)
   const {
     userState: { currentUser },
@@ -85,15 +83,6 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
       } else setStructureError(messages.TRIGGER_RUNNING)
       return
     }
-
-    const { id, code, name, startMessage } = application.template as Template
-
-    setTemplate({
-      id,
-      code,
-      name: name as string,
-      startMessage: startMessage ? startMessage : undefined,
-    })
 
     const applicationSection = application.applicationSections.nodes as ApplicationSection[]
     const sections = getApplicationSections(applicationSection)

--- a/src/utils/hooks/useLoadApplication.ts
+++ b/src/utils/hooks/useLoadApplication.ts
@@ -189,7 +189,6 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
     error: structureError || error?.message,
     isLoading: loading || isLoading,
     structure,
-    template,
   }
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -83,6 +83,7 @@ interface ApplicationDetails {
   current: StageAndStatus
   firstStrictInvalidPage: SectionAndPage | null
   submissionMessage?: string
+  startMessage?: string
   user?: GraphQLUser
   org?: GraphQLOrg
   config?: any


### PR DESCRIPTION
Fixes #638.

An unevaluated "startMessage" was being passed to ApplicationHome. Have fixed so that both startMessage and submissionMessage are evaluated in `useLoadApplication` and stored in structure.info (previously it was just submissionMessage), so evaluated startMessage string can be available in ApplicationHome.

To test: start a new application. You should see a correctly rendered "Start Message" box on both the "ApplicationCreate" page `/new?...` and the "ApplicationHome" page (`/application/<serial>`).