### PR TITLE
Publish to wiki fixes

### DIFF
--- a/utils/convert_docs_to_wiki.py
+++ b/utils/convert_docs_to_wiki.py
@@ -6,7 +6,7 @@ import re
 docs_path = "./documentation"
 output_path = "./documentation/_wiki"
 markup_formats = [".md", ".markdown"]
-media_types = ["png", "jpg", "gif", "svg"]
+media_types = [".png", ".jpg", ".gif", ".svg"]
 ignore = ["external"]  # File or folder names to ignore
 ext_ignore = [".DS_Store"]  # File extensions to ignore
 
@@ -16,20 +16,18 @@ def in_ignore_list(path, ignore_list):
 
 
 def build_file_ext_regex_opts(ext_list):
-    return "|".join(["({})".format(ext) for ext in ext_list])
+    return "|".join(["(\{})".format(ext) for ext in ext_list])
 
 
 def file_convert_links(file):
     f = open(file, 'r')
     original_markup = f.read()
-    # markup_regex = re.compile(
-    #     "(!\[)(.+)(\]\()(\.\/)?(.*\.)({})\)".format(build_file_ext_regex_opts(markup_formats)))
-    # markup_substitution = r"\1\2\4)"
-    # new_markup = re.sub(markup_regex, markup_substitution, original_markup)
-    new_markup = original_markup
+    markup_regex = re.compile(
+        "(\[.+\])(\()(\S*/)?(\S+)({})\)".format(build_file_ext_regex_opts(markup_formats)))
+    markup_substitution = r"\1(\4)"
+    new_markup = re.sub(markup_regex, markup_substitution, original_markup)
     media_link_regex = re.compile(
-        "(!\[)(.+)(\]\()(\.\/)?(.*\.)({})\)".format(build_file_ext_regex_opts(media_types)))
-    print(media_link_regex)
+        "(!\[)(.+)(\]\()(\.\/)?(.*)({})\)".format(build_file_ext_regex_opts(media_types)))
     media_link_substitution = r"[[\5\6|\2]]"
     new_markup = re.sub(media_link_regex, media_link_substitution, new_markup)
     f.close()

--- a/utils/convert_docs_to_wiki.py
+++ b/utils/convert_docs_to_wiki.py
@@ -23,12 +23,12 @@ def file_convert_links(file):
     f = open(file, 'r')
     original_markup = f.read()
     markup_regex = re.compile(
-        "(\[.+\])(\()(\S*/)?(\S+)({})".format(build_file_ext_regex_opts(markup_formats)))
+        "(!\[)(.+)(\]\()(\.\/)?(.*\.)({})\)".format(build_file_ext_regex_opts(markup_formats)))
     markup_substitution = r"\1\2\4)"
     new_markup = re.sub(markup_regex, markup_substitution, original_markup)
     media_link_regex = re.compile(
         "(\[.*\])(\()(\.*\/)?(\S*/)?(\S+)({})".format(build_file_ext_regex_opts(media_types)))
-    media_link_substitution = r"\1\2\4\5\6"
+    media_link_substitution = r"[[\5\6|\2]]"
     new_markup = re.sub(media_link_regex, media_link_substitution, new_markup)
     f.close()
     return new_markup

--- a/utils/convert_docs_to_wiki.py
+++ b/utils/convert_docs_to_wiki.py
@@ -6,7 +6,7 @@ import re
 docs_path = "./documentation"
 output_path = "./documentation/_wiki"
 markup_formats = [".md", ".markdown"]
-media_types = [".png", ".jpg", ".gif", ".svg"]
+media_types = ["png", "jpg", "gif", "svg"]
 ignore = ["external"]  # File or folder names to ignore
 ext_ignore = [".DS_Store"]  # File extensions to ignore
 
@@ -16,18 +16,20 @@ def in_ignore_list(path, ignore_list):
 
 
 def build_file_ext_regex_opts(ext_list):
-    return "|".join(["(\{}\))".format(ext) for ext in ext_list])
+    return "|".join(["({})".format(ext) for ext in ext_list])
 
 
 def file_convert_links(file):
     f = open(file, 'r')
     original_markup = f.read()
-    markup_regex = re.compile(
-        "(!\[)(.+)(\]\()(\.\/)?(.*\.)({})\)".format(build_file_ext_regex_opts(markup_formats)))
-    markup_substitution = r"\1\2\4)"
-    new_markup = re.sub(markup_regex, markup_substitution, original_markup)
+    # markup_regex = re.compile(
+    #     "(!\[)(.+)(\]\()(\.\/)?(.*\.)({})\)".format(build_file_ext_regex_opts(markup_formats)))
+    # markup_substitution = r"\1\2\4)"
+    # new_markup = re.sub(markup_regex, markup_substitution, original_markup)
+    new_markup = original_markup
     media_link_regex = re.compile(
-        "(\[.*\])(\()(\.*\/)?(\S*/)?(\S+)({})".format(build_file_ext_regex_opts(media_types)))
+        "(!\[)(.+)(\]\()(\.\/)?(.*\.)({})\)".format(build_file_ext_regex_opts(media_types)))
+    print(media_link_regex)
     media_link_substitution = r"[[\5\6|\2]]"
     new_markup = re.sub(media_link_regex, media_link_substitution, new_markup)
     f.close()

--- a/utils/push_docs_to_wiki.sh
+++ b/utils/push_docs_to_wiki.sh
@@ -1,4 +1,4 @@
 python3 ./utils/convert_docs_to_wiki.py
-# git -C ./documentation/_wiki add -A
-# git -C ./documentation/_wiki commit -m "Update documentation"
-# git -C ./documentation/_wiki push
+git -C ./documentation/_wiki add -A
+git -C ./documentation/_wiki commit -m "Update documentation"
+git -C ./documentation/_wiki push

--- a/utils/push_docs_to_wiki.sh
+++ b/utils/push_docs_to_wiki.sh
@@ -1,4 +1,4 @@
 python3 ./utils/convert_docs_to_wiki.py
-git -C ./documentation/_wiki add -A
-git -C ./documentation/_wiki commit -m "Update documentation"
-git -C ./documentation/_wiki push
+# git -C ./documentation/_wiki add -A
+# git -C ./documentation/_wiki commit -m "Update documentation"
+# git -C ./documentation/_wiki push


### PR DESCRIPTION
As mentioned in Telegram chat:

> Noticed that the images for the documentation weren’t showing up in front end wiki. Turns out images must be in the format `[[relative/path/to/images | alt-text]]` format and doens’t work (needs path from root) in the `!(alt-text)[image/path]]`, which is what we’d been using. Good news is we can do without the python conversion script, but will need to go through and replace images links with the other Markdown syntax. (Better than having to specify full paths)

> But I still think we need a small script to copy to the “_wiki” folder for publishing. That way we can keep a copy in the main repo and review documentation changes along with PRs, and then “publish” them once approved. If we edit them directly int he submodule folder (/_wiki) then we won’t see the changes to docs in our PRs.

> Although I’m not super happy with that solution, since the `[[ ]]`  syntax seems to be very much non-standard markdown (_update: it's MediaWiki format_), so it won’t be compatible in many other renderers. I think we’ll still need the conversion script, but it’ll just change “standard” image links into Github wiki-friendly image link formats

To summarise: the only way to make relative links work properly when published is to use MediaWiki link syntax, or put all content at top-level of folder structure. I've opted for the former for Images (easier to convert) and the latter for other pages (they're all rendered at top-level, so don't need to actually move the files, just update the links).

BTW -- if anyone is interested in trying to make sense of what the Regexes are doing, this will help:

https://regex101.com/r/b0A6C8/1/ (for the Markdown page links)
https://regex101.com/r/nfaUlY/1 (for the image links)
