### PR TITLE
#750 #751 Radio button and shortText updates

### DIFF
--- a/documentation/internal/Element-Type-Specs.md
+++ b/documentation/internal/Element-Type-Specs.md
@@ -62,6 +62,7 @@ _Free-form, single-line text input element_
 - **placeholder**: `string`-- text to display before user input (HTML "placeholder" attribute) [Optional]
 - **default**: `string` -- value to set as response before user enters anything. Note that this is different from `placeholder` -- `placeholder` is just temporary display text, wheras `default` is an actual response that will be saved if the user doesn't explicitly change it. In general a `default` for a text input would not be desired; it would usually only be useful for editing _existing_ data.[Optional]
 - **maskedInput**: `boolean` -- if `true`, displays user input as masked (hidden) characters -- i.e. for passwords. [Optional]
+- **maxWidth**: `number` -- the maximum width (in pixels) for the text input box (defaults to fill the width of the container)
 - **maxLength**: `number` -- response must be no longer than this many characters. If the user tries to type more, the response will be truncated to the maximum length.  
    _Note_: if you want to show an error state for trying to exceed the maximum, you'll need to specify a validation expression with a REGEX operator, and the range will need to be one character less than the `maxLength`, so the error state is triggered. So to set limit of 100 characters, you'd set `maxLength` to 101 and use the following expression for "validation":
   ```
@@ -269,6 +270,7 @@ _Multi-choice question, with one allowed selection, displayed as labelled radio 
 - **options\***: `array[string | object]` -- as above (in [Drop-down](#dropdown))
 - **default**: `string`/`number` -- the value initially selected before user input. If `number`, refers to the index of the options array. If not provided, no options will be pre-selected.
 - **optionsDisplayProperty**: -- as above (in Drop-down)
+- **layout**: `string` -- if "inline", displays radio buttons horizontally, rather than stacked vertically (default)
 - **hasOther**: `boolean` (default `false`) -- if `true`, displays an additional "Other" option with a free text field for inputting additional user-defined option.
 - **otherPlaceholder**: `string` -- placeholder text to show in the text input if `hasOther` is enabled.
 

--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -57,16 +57,23 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     setCheckboxElements(checkboxElements.map((cb, i) => (i === index ? changedCheckbox : cb)))
   }
 
+  const styles =
+    layout === 'inline'
+      ? {
+          display: 'inline',
+          marginRight: 10,
+        }
+      : {}
+
   return (
     <>
       <label>
         <Markdown text={label} semanticComponent="noParagraph" />
       </label>
       <Markdown text={description} />
-      {checkboxElements.map((cb: Checkbox, index: number) => {
-        return layout === 'inline' ? (
+      {checkboxElements.map((cb: Checkbox, index: number) => (
+        <Form.Field key={`${index}_${cb.label}`} disabled={!isEditable} style={styles}>
           <Checkbox
-            key={`${index}_${cb.label}`}
             label={cb.label}
             checked={cb.selected}
             onChange={toggle}
@@ -74,19 +81,8 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
             toggle={type === 'toggle'}
             slider={type === 'slider'}
           />
-        ) : (
-          <Form.Field key={`${index}_${cb.label}`} disabled={!isEditable}>
-            <Checkbox
-              label={cb.label}
-              checked={cb.selected}
-              onChange={toggle}
-              index={index}
-              toggle={type === 'toggle'}
-              slider={type === 'slider'}
-            />
-          </Form.Field>
-        )
-      })}
+        </Form.Field>
+      ))}
     </>
   )
 }

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -109,7 +109,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       {radioButtonOptions.map((option: any, index: number) => {
         const showOther = hasOther && index === allOptions.length - 1
         return (
-          <Form.Field key={option.key} disabled={!isEditable} style={styles}>
+          <Form.Field key={option.key} disabled={!isEditable} style={styles} inline={showOther}>
             <Radio
               label={option.text}
               name={`${code}_radio_${index}`} // This is GROUP name
@@ -126,7 +126,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
                 onChange={handleOtherChange}
                 onBlur={handleOtherLoseFocus}
                 value={otherText}
-                style={{ maxWidth: 200 }}
               />
             )}
           </Form.Field>

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -8,8 +8,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   parameters,
   onUpdate,
   currentResponse,
-  // value,
-  // setValue,
   onSave,
   Markdown,
   getDefaultIndex,
@@ -94,17 +92,13 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     }
   })
 
-  const styles = {
-    display: 'inline',
-    marginRight: 10,
-  }
-  // const styles =
-  //   layout === 'inline'
-  //     ? {
-  //         display: 'inline',
-  //         marginRight: 10,
-  //       }
-  //     : {}
+  const styles =
+    layout === 'inline'
+      ? {
+          display: 'inline',
+          marginRight: 10,
+        }
+      : {}
 
   return (
     <>
@@ -132,6 +126,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
                 onChange={handleOtherChange}
                 onBlur={handleOtherLoseFocus}
                 value={otherText}
+                style={{ maxWidth: 200 }}
               />
             )}
           </Form.Field>

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -22,6 +22,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     optionsDisplayProperty,
     hasOther,
     otherPlaceholder,
+    layout,
   } = parameters
 
   const { code, isEditable } = element
@@ -93,6 +94,18 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     }
   })
 
+  const styles = {
+    display: 'inline',
+    marginRight: 10,
+  }
+  // const styles =
+  //   layout === 'inline'
+  //     ? {
+  //         display: 'inline',
+  //         marginRight: 10,
+  //       }
+  //     : {}
+
   return (
     <>
       <label>
@@ -102,7 +115,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       {radioButtonOptions.map((option: any, index: number) => {
         const showOther = hasOther && index === allOptions.length - 1
         return (
-          <Form.Field key={option.key} disabled={!isEditable} inline={showOther}>
+          <Form.Field key={option.key} disabled={!isEditable} style={styles}>
             <Radio
               label={option.text}
               name={`${code}_radio_${index}`} // This is GROUP name

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -96,7 +96,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     layout === 'inline'
       ? {
           display: 'inline',
-          marginRight: 10,
+          marginRight: 30,
         }
       : {}
 

--- a/src/formElementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/shortText/src/ApplicationView.tsx
@@ -20,6 +20,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     label,
     description,
     default: defaultValue,
+    maxWidth,
     maxLength = Infinity,
   } = parameters
 
@@ -43,6 +44,12 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     onSave({ text: value })
   }
 
+  const styles = maxWidth
+    ? {
+        maxWidth,
+      }
+    : {}
+
   return (
     <>
       <label>
@@ -58,6 +65,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         value={value ? value : ''}
         disabled={!isEditable}
         type={maskedInput ? 'password' : undefined}
+        style={styles}
         error={
           !validationState.isValid
             ? {


### PR DESCRIPTION
Fixes #750 #751

Requires back-end branch `#750F-radio-buttons-inline` ([PR #382](https://github.com/openmsupply/application-manager-server/pull/382)) -- have only implemented for elements that are part of the Ingredients list (Section 3, page 2, FeatureShowcase) -- to bring UI closer to the designs for the Ingredients list

### Summary of changes

- Add "layout: inline" parameter to radioChoice and implement custom style based on this selection
- Add "maxWidth" parameter to shortText and implement custom style based on this value
- Since this solution is more elegant than what was used in "Checkbox" element, I've updated checkbox to match this pattern, too.