### PR TITLE
#761 generic default value handling to work for all plugins

### DIFF
--- a/documentation/internal/Element-Type-Specs.md
+++ b/documentation/internal/Element-Type-Specs.md
@@ -61,7 +61,6 @@ _Free-form, single-line text input element_
 - **label\***: `string` -- Text that shows in the HTML "label" attribute of the form element (Markdown string, with dynamic expression evaluation)
 - **description\***: `string` -- additional explanatory text (usually not required) [Optional]
 - **placeholder**: `string`-- text to display before user input (HTML "placeholder" attribute) [Optional]
-- **default**: `string` -- value to set as response before user enters anything. Note that this is different from `placeholder` -- `placeholder` is just temporary display text, wheras `default` is an actual response that will be saved if the user doesn't explicitly change it. In general a `default` for a text input would not be desired; it would usually only be useful for editing _existing_ data.[Optional]
 - **maskedInput**: `boolean` -- if `true`, displays user input as masked (hidden) characters -- i.e. for passwords. [Optional]
 - **maxWidth**: `number` -- the maximum width (in pixels) for the text input box (defaults to fill the width of the container)
 - **maxLength**: `number` -- response must be no longer than this many characters. If the user tries to type more, the response will be truncated to the maximum length.  
@@ -102,7 +101,6 @@ _Free-form, multi-line text input element_
 - **label\***: `string` -- Text that shows in the HTML "label" attribute of the form element (Markdown string, with dynamic expression evaluation)
 - **description\***: `string` -- additional explanatory text (usually not required) [Optional]
 - **placeholder**: `string`-- text to display before user input (HTML "placeholder" attribute) [Optional]
-- **default**: `string` -- value to set as response before user enters anything (see [Short Text](#short-text) above for more detail) [Optional]
 - **lines**: `number` -- height of the TextArea input, in number of lines/rows (default: 5)
 - **maxLength**: `number` -- response must be no longer than this many characters. If the user tries to type more, the response will be truncated to the maximum length. (See Note in ShortText above for how to integrate `maxLength` with validation.)
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.1.4",
-    "@openmsupply/expression-evaluator": "^1.7.0",
+    "@openmsupply/expression-evaluator": "^1.8.0",
     "@types/deep-equal": "^1.0.1",
     "apollo3-cache-persist": "^0.8.0",
     "deep-equal": "^2.0.5",

--- a/src/containers/Outcomes/OutcomesDetail.tsx
+++ b/src/containers/Outcomes/OutcomesDetail.tsx
@@ -13,6 +13,7 @@ import {
   ResponseFull,
 } from '../../utils/types'
 import config from '../../config.json'
+import { defaultEvaluatedElement } from '../../utils/hooks/useLoadApplication'
 
 const OutcomeDetails: React.FC<{
   detailDisplayColumns: DetailDisplay[]
@@ -79,14 +80,13 @@ const constructElement = (detail: DetailDisplay, index: number) => ({
   parameters: detail.parameters,
   validationExpression: true,
   validationMessage: '',
-  isRequired: false,
-  isEditable: true,
-  isVisible: true,
   elementIndex: 0,
   page: 0,
   sectionIndex: 0,
   helpText: null,
   sectionCode: '0',
+  ...defaultEvaluatedElement,
+  isRequired: false,
 })
 
 export default OutcomeDetails

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -11,8 +11,8 @@ import {
 } from '../utils/types'
 import { useUserState } from '../contexts/UserState'
 import validate from './defaultValidate'
-import evaluateExpression from '@openmsupply/expression-evaluator'
-import { Form, Icon, Loader } from 'semantic-ui-react'
+import evaluateExpression, { isEvaluationExpression } from '@openmsupply/expression-evaluator'
+import { Form, Icon } from 'semantic-ui-react'
 import Markdown from '../utils/helpers/semanticReactMarkdown'
 import strings from '../utils/constants'
 import { useFormElementUpdateTracker } from '../contexts/FormElementUpdateTrackerState'
@@ -246,7 +246,7 @@ export const buildParameters = (
   const parameterExpressions: any = {}
   for (const [key, value] of Object.entries(parameters)) {
     if (internalParameters.includes(key)) simpleParameters[key] = value
-    else if (value instanceof Object && !Array.isArray(value)) {
+    else if (isEvaluationExpression(value)) {
       parameterExpressions[key] = value
       simpleParameters[key] = parameterLoadingValues?.[key] ?? 'Loading...'
     } else simpleParameters[key] = value

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -208,6 +208,8 @@ const buildElement = (field: TemplateElement, index: number) => ({
   isVisible: true,
   // "Dummy" values, but required for element props:
   elementIndex: 0,
+  isValid: undefined,
+  defaultValue: null,
   page: 0,
   sectionIndex: 0,
   helpText: null,

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -16,6 +16,7 @@ import { ResponseFull } from '../../../utils/types'
 import { TemplateElement, TemplateElementCategory } from '../../../utils/generated/graphql'
 import ApplicationViewWrapper from '../../ApplicationViewWrapper'
 import strings from '../constants'
+import { defaultEvaluatedElement } from '../../../utils/hooks/useLoadApplication'
 
 export enum DisplayType {
   CARDS = 'cards',
@@ -194,6 +195,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 export default ApplicationView
 
 const buildElement = (field: TemplateElement, index: number) => ({
+  ...defaultEvaluatedElement,
   id: index,
   code: field.code,
   pluginCode: field.elementTypePluginCode as string,
@@ -204,12 +206,9 @@ const buildElement = (field: TemplateElement, index: number) => ({
   validationMessage: field?.validationMessage || '',
   isRequired: field.isRequired ?? true,
   // Hard-coded visisbility and editability (for now)
-  isEditable: true,
-  isVisible: true,
   // "Dummy" values, but required for element props:
   elementIndex: 0,
   isValid: undefined,
-  defaultValue: null,
   page: 0,
   sectionIndex: 0,
   helpText: null,

--- a/src/formElementPlugins/longText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/longText/src/ApplicationView.tsx
@@ -14,16 +14,9 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 }) => {
   const [value, setValue] = useState<string | null | undefined>(currentResponse?.text)
 
-  const { label, description, placeholder, lines, default: defaultValue, maxLength } = parameters
+  const { label, description, placeholder, lines, maxLength } = parameters
 
   const { isEditable } = element
-
-  useEffect(() => {
-    if (!value && defaultValue) {
-      onSave({ text: defaultValue })
-      setValue(defaultValue)
-    } else onUpdate(value)
-  }, [])
 
   function handleChange(e: any) {
     let text = e.target.value

--- a/src/formElementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/shortText/src/ApplicationView.tsx
@@ -19,17 +19,9 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     maskedInput,
     label,
     description,
-    default: defaultValue,
     maxWidth,
     maxLength = Infinity,
   } = parameters
-
-  useEffect(() => {
-    if (!value && defaultValue) {
-      onSave({ text: defaultValue })
-      setValue(defaultValue)
-    } else onUpdate(value)
-  }, [defaultValue])
 
   function handleChange(e: any) {
     let text = e.target.value

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -3098,6 +3098,8 @@ export type TemplateElementFilter = {
   isEditable?: Maybe<JsonFilter>;
   /** Filter by the object’s `validation` field. */
   validation?: Maybe<JsonFilter>;
+  /** Filter by the object’s `defaultValue` field. */
+  defaultValue?: Maybe<JsonFilter>;
   /** Filter by the object’s `validationMessage` field. */
   validationMessage?: Maybe<StringFilter>;
   /** Filter by the object’s `helpText` field. */
@@ -5729,6 +5731,8 @@ export enum TemplateElementsOrderBy {
   IsEditableDesc = 'IS_EDITABLE_DESC',
   ValidationAsc = 'VALIDATION_ASC',
   ValidationDesc = 'VALIDATION_DESC',
+  DefaultValueAsc = 'DEFAULT_VALUE_ASC',
+  DefaultValueDesc = 'DEFAULT_VALUE_DESC',
   ValidationMessageAsc = 'VALIDATION_MESSAGE_ASC',
   ValidationMessageDesc = 'VALIDATION_MESSAGE_DESC',
   HelpTextAsc = 'HELP_TEXT_ASC',
@@ -5765,6 +5769,8 @@ export type TemplateElementCondition = {
   isEditable?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `validation` field. */
   validation?: Maybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `defaultValue` field. */
+  defaultValue?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `validationMessage` field. */
   validationMessage?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `helpText` field. */
@@ -5803,6 +5809,7 @@ export type TemplateElement = Node & {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -14463,6 +14470,7 @@ export type UpdateTemplateElementOnApplicationResponseForApplicationResponseTemp
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -14555,6 +14563,7 @@ export type UpdateTemplateElementOnTemplateElementForTemplateElementSectionIdFke
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -15300,6 +15309,7 @@ export type UpdateTemplateElementOnReviewQuestionAssignmentForReviewQuestionAssi
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -17809,6 +17819,7 @@ export type UpdateTemplateElementOnReviewResponseForReviewResponseTemplateElemen
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -17950,6 +17961,7 @@ export type TemplateElementPatch = {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -17973,6 +17985,7 @@ export type ReviewResponseTemplateElementIdFkeyTemplateElementCreateInput = {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -18420,6 +18433,7 @@ export type ReviewQuestionAssignmentTemplateElementIdFkeyTemplateElementCreateIn
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -18828,6 +18842,7 @@ export type TemplateElementSectionIdFkeyTemplateElementCreateInput = {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -19016,6 +19031,7 @@ export type ApplicationResponseTemplateElementIdFkeyTemplateElementCreateInput =
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -22627,6 +22643,7 @@ export type TemplateElementInput = {
   isRequired?: Maybe<Scalars['JSON']>;
   isEditable?: Maybe<Scalars['JSON']>;
   validation?: Maybe<Scalars['JSON']>;
+  defaultValue?: Maybe<Scalars['JSON']>;
   validationMessage?: Maybe<Scalars['String']>;
   helpText?: Maybe<Scalars['String']>;
   parameters?: Maybe<Scalars['JSON']>;
@@ -26235,7 +26252,7 @@ export type ConsolidatorResponseFragmentFragment = (
 
 export type ElementFragment = (
   { __typename?: 'TemplateElement' }
-  & Pick<TemplateElement, 'id' | 'code' | 'index' | 'title' | 'elementTypePluginCode' | 'category' | 'visibilityCondition' | 'isRequired' | 'isEditable' | 'validation' | 'validationMessage' | 'helpText' | 'parameters'>
+  & Pick<TemplateElement, 'id' | 'code' | 'index' | 'title' | 'elementTypePluginCode' | 'category' | 'visibilityCondition' | 'isRequired' | 'isEditable' | 'validation' | 'validationMessage' | 'helpText' | 'defaultValue' | 'parameters'>
 );
 
 export type OrganisationFragment = (
@@ -26949,6 +26966,7 @@ export const ElementFragmentDoc = gql`
   validation
   validationMessage
   helpText
+  defaultValue
   parameters
 }
     `;

--- a/src/utils/graphql/fragments/element.fragment.ts
+++ b/src/utils/graphql/fragments/element.fragment.ts
@@ -14,6 +14,7 @@ export default gql`
     validation
     validationMessage
     helpText
+    defaultValue
     parameters
   }
 `

--- a/src/utils/helpers/evaluateElements.ts
+++ b/src/utils/helpers/evaluateElements.ts
@@ -1,4 +1,4 @@
-import evaluateExpression from '@openmsupply/expression-evaluator'
+import evaluateExpression, { isEvaluationExpression } from '@openmsupply/expression-evaluator'
 import config from '../../config.json'
 import {
   EvaluatedElement,
@@ -87,10 +87,3 @@ const evaluateSingleElement: EvaluatElement = async (
 
   return evaluatedElement
 }
-
-// This method should come from evaluationExpression
-export const isEvaluationExpression = (evaluationExpression: EvaluatorNode) =>
-  evaluationExpression instanceof Object &&
-  evaluationExpression !== null &&
-  !Array.isArray(evaluationExpression) &&
-  !!evaluationExpression.operator

--- a/src/utils/helpers/evaluateElements.ts
+++ b/src/utils/helpers/evaluateElements.ts
@@ -40,13 +40,13 @@ export const evaluateElements: EvaluateElements = async (elements, evaluationOpt
   return await Promise.all<PartialEvaluatedElement>(elementPromiseArray)
 }
 
-type EvaluatElement = (
+type EvaluateElement = (
   element: ElementForEvaluation,
   evaluationOptions: EvaluationOptions,
   objects: EvaluationObject
 ) => Promise<PartialEvaluatedElement>
 
-const evaluateSingleElement: EvaluatElement = async (
+const evaluateSingleElement: EvaluateElement = async (
   element,
   evaluationOptions,
   { responseObject, currentUser, applicationData }

--- a/src/utils/helpers/evaluateElements.ts
+++ b/src/utils/helpers/evaluateElements.ts
@@ -13,7 +13,7 @@ const graphQLEndpoint = config.serverGraphQL
 
 type PartialEvaluatedElement = Partial<EvaluatedElement>
 type EvaluationObject = {
-  responseObject?: ResponsesByCode
+  responses?: ResponsesByCode
   currentUser?: User | null
   applicationData?: ApplicationDetails
 }
@@ -49,11 +49,11 @@ type EvaluateElement = (
 const evaluateSingleElement: EvaluateElement = async (
   element,
   evaluationOptions,
-  { responseObject, currentUser, applicationData }
+  { responses, currentUser, applicationData }
 ) => {
   const evaluationParameters = {
     objects: {
-      responses: { ...responseObject, thisResponse: responseObject?.[element.code]?.text },
+      responses: { ...responses, thisResponse: responses?.[element.code]?.text },
       currentUser,
       applicationData,
     },

--- a/src/utils/helpers/evaluateElements.ts
+++ b/src/utils/helpers/evaluateElements.ts
@@ -1,0 +1,96 @@
+import evaluateExpression from '@openmsupply/expression-evaluator'
+import config from '../../config.json'
+import {
+  EvaluatedElement,
+  ResponsesByCode,
+  User,
+  ApplicationDetails,
+  ElementForEvaluation,
+  EvaluationOptions,
+  EvaluatorNode,
+} from '../types'
+const graphQLEndpoint = config.serverGraphQL
+
+type PartialEvaluatedElement = Partial<EvaluatedElement>
+type EvaluationObject = {
+  responseObject?: ResponsesByCode
+  currentUser?: User | null
+  applicationData?: ApplicationDetails
+}
+
+type EvaluateElements = (
+  elements: ElementForEvaluation[],
+  evaluationOptions: EvaluationOptions,
+  objects: EvaluationObject
+) => Promise<PartialEvaluatedElement[]>
+
+const evaluationMapping: { [resultKey in keyof EvaluatedElement]: keyof ElementForEvaluation } = {
+  isEditable: 'isEditableExpression',
+  isRequired: 'isRequiredExpression',
+  isVisible: 'isVisibleExpression',
+  isValid: 'validationExpression',
+  defaultValue: 'defaultValueExpression',
+}
+
+export const evaluateElements: EvaluateElements = async (elements, evaluationOptions, objects) => {
+  const elementPromiseArray: Promise<PartialEvaluatedElement>[] = []
+  elements.forEach((element) => {
+    elementPromiseArray.push(evaluateSingleElement(element, evaluationOptions, objects))
+  })
+  return await Promise.all<PartialEvaluatedElement>(elementPromiseArray)
+}
+
+type EvaluatElement = (
+  element: ElementForEvaluation,
+  evaluationOptions: EvaluationOptions,
+  objects: EvaluationObject
+) => Promise<PartialEvaluatedElement>
+
+const evaluateSingleElement: EvaluatElement = async (
+  element,
+  evaluationOptions,
+  { responseObject, currentUser, applicationData }
+) => {
+  const evaluationParameters = {
+    objects: {
+      responses: { ...responseObject, thisResponse: responseObject?.[element.code]?.text },
+      currentUser,
+      applicationData,
+    },
+    APIfetch: fetch,
+    graphQLConnection: { fetch: fetch.bind(window), endpoint: graphQLEndpoint },
+  }
+
+  const evaluatedElement: PartialEvaluatedElement = {}
+
+  const evaluateSingleExpression = async (
+    expressionOrValue: EvaluatorNode,
+    elementResultKey: keyof EvaluatedElement
+  ) => {
+    try {
+      evaluatedElement[elementResultKey] = isEvaluationExpression(expressionOrValue)
+        ? await evaluateExpression(expressionOrValue, evaluationParameters)
+        : expressionOrValue
+    } catch (e) {
+      console.log(e, expressionOrValue)
+    }
+  }
+
+  const evaluations = evaluationOptions.map((evaluationResultKey) => {
+    const elementExpressionKey = evaluationMapping[evaluationResultKey]
+    const evaluationExpression = element[elementExpressionKey]
+
+    return evaluateSingleExpression(evaluationExpression, evaluationResultKey)
+  })
+
+  await Promise.all(evaluations)
+
+  return evaluatedElement
+}
+
+// This method should come from evaluationExpression
+export const isEvaluationExpression = (evaluationExpression: EvaluatorNode) =>
+  evaluationExpression instanceof Object &&
+  evaluationExpression !== null &&
+  !Array.isArray(evaluationExpression) &&
+  !!evaluationExpression.operator

--- a/src/utils/helpers/structure/addEvaluatedResponsesToStructure.ts
+++ b/src/utils/helpers/structure/addEvaluatedResponsesToStructure.ts
@@ -22,14 +22,14 @@ const addEvaluatedResponsesToStructure = async ({
   const newStructure = { ...structure } // This MIGHT need to be deep-copied
 
   // Build responses by code (and only keep latest)
-  const responseObject: any = {}
+  const responses: any = {}
   const reviewResponses: { [templateElementId: string]: ReviewResponse } = {}
 
   applicationResponses?.forEach((response) => {
     const { id, isValid, value, templateElement, templateElementId, timeUpdated } = response
     const code = templateElement?.code as string
-    if (!(code in responseObject) || timeUpdated > responseObject[code].timeCreated) {
-      responseObject[code] = {
+    if (!(code in responses) || timeUpdated > responses[code].timeCreated) {
+      responses[code] = {
         id,
         isValid,
         timeUpdated,
@@ -52,7 +52,7 @@ const addEvaluatedResponsesToStructure = async ({
     flattenedElements.map((elem: PageElement) => elem.element as ElementForEvaluation),
     evaluationOptions,
     {
-      responseObject,
+      responses,
       currentUser,
       applicationData: structure.info,
     }
@@ -62,7 +62,7 @@ const addEvaluatedResponsesToStructure = async ({
     const flattenedElement = flattenedElements[index]
     const { element } = flattenedElement
     flattenedElement.element = { ...element, ...evaluatedElement }
-    flattenedElement.response = responseObject[element.code]
+    flattenedElement.response = responses[element.code]
 
     if (!flattenedElement.response) return
 
@@ -72,7 +72,7 @@ const addEvaluatedResponsesToStructure = async ({
 
     flattenedElement.response.reviewResponse = reviewResponses[flattenedElement.element.id]
   })
-  newStructure.responsesByCode = responseObject
+  newStructure.responsesByCode = responses
   return newStructure
 }
 

--- a/src/utils/hooks/useCreateApplication.tsx
+++ b/src/utils/hooks/useCreateApplication.tsx
@@ -10,7 +10,7 @@ interface CreateApplicationProps {
   orgId?: number
   sessionId: string
   templateSections: { templateSectionId: number }[]
-  templateResponses: { templateElementId: number }[]
+  templateResponses: { templateElementId: number; value: any }[]
 }
 
 interface UseCreateApplicationProps {

--- a/src/utils/hooks/useGetApplicationStructure.tsx
+++ b/src/utils/hooks/useGetApplicationStructure.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { FullStructure } from '../types'
+import { EvaluationOptions, FullStructure } from '../types'
 import {
   ApplicationResponse,
   ApplicationResponseStatus,
@@ -84,16 +84,15 @@ const useGetApplicationStructure = ({
     const applicationResponses = data?.applicationBySerial?.applicationResponses
       ?.nodes as ApplicationResponse[]
 
+    const evaluationOptions: EvaluationOptions = ['isEditable', 'isVisible', 'isRequired']
+
+    if (shouldDoValidation) evaluationOptions.push('isValid')
+
     addEvaluatedResponsesToStructure({
       structure,
       applicationResponses,
       currentUser,
-      evaluationOptions: {
-        isEditable: true,
-        isVisible: true,
-        isRequired: true,
-        isValid: shouldDoValidation,
-      },
+      evaluationOptions,
     }).then((newStructure: FullStructure) => {
       if (shouldDoValidation) {
         newStructure.lastValidationTimestamp = Date.now()

--- a/src/utils/hooks/useLoadApplication.ts
+++ b/src/utils/hooks/useLoadApplication.ts
@@ -2,9 +2,9 @@ import { useEffect, useState } from 'react'
 import {
   ApplicationDetails,
   ElementBase,
+  EvaluatedElement,
   FullStructure,
   TemplateDetails,
-  TemplateElementState,
   UseGetApplicationProps,
 } from '../types'
 import evaluate from '@openmsupply/expression-evaluator'
@@ -18,6 +18,7 @@ import {
   ApplicationStatus,
   Organisation,
   TemplateElement,
+  TemplateElementCategory,
   TemplateStage,
   useGetApplicationQuery,
   User,
@@ -124,23 +125,25 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
         if (element.elementTypePluginCode === 'pageBreak') pageCount++
         else
           baseElements.push({
-            // ...element,
-            category: element.category,
+            category: element.category || TemplateElementCategory.Information,
             id: element.id,
             code: element.code,
-            pluginCode: element.elementTypePluginCode,
-            sectionIndex: sectionNode?.templateSection?.index,
-            sectionCode: sectionNode?.templateSection?.code,
-            elementIndex: element.index,
+            pluginCode: element.elementTypePluginCode || '',
+            sectionIndex: sectionNode?.templateSection?.index || 0,
+            sectionCode: sectionNode?.templateSection?.code || '',
+            elementIndex: element.index || 0,
             page: pageCount,
             isEditableExpression: element.isEditable,
             isRequiredExpression: element.isRequired,
             isVisibleExpression: element.visibilityCondition,
             parameters: element.parameters,
             validationExpression: element.validation,
-            validationMessage: element.validationMessage,
-            helpText: element.helpText,
-          } as TemplateElementState)
+            validationMessage: element.validationMessage || '',
+            helpText: element.helpText || '',
+            title: element.title || '',
+            defaultValueExpression: element.defaultValue,
+            ...defaultEvaluatedElement,
+          })
       })
     })
 
@@ -179,6 +182,14 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
     isLoading: loading || isLoading,
     structure,
   }
+}
+
+export const defaultEvaluatedElement: EvaluatedElement = {
+  isEditable: true,
+  isRequired: true,
+  isVisible: true,
+  isValid: undefined,
+  defaultValue: null,
 }
 
 export default useLoadApplication

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -25,11 +25,16 @@ const useLoadTemplate = ({ templateCode }: UseLoadTemplateProps) => {
     userState: { currentUser },
   } = useUserState()
 
-  const { data, loading: apolloLoading, error: apolloError } = useGetTemplateQuery({
+  const {
+    data,
+    loading: apolloLoading,
+    error: apolloError,
+  } = useGetTemplateQuery({
     variables: {
       code: templateCode || '',
     },
     skip: !templateCode,
+    fetchPolicy: 'network-only',
   })
 
   useEffect(() => {
@@ -54,11 +59,15 @@ const useLoadTemplate = ({ templateCode }: UseLoadTemplateProps) => {
     const templateSections = template.templateSections.nodes as TemplateSection[]
     const sections = getTemplateSections(templateSections)
     const elementsIds: number[] = []
+    const elementsDefaults: any[] = []
 
     templateSections.forEach((section) => {
       const { templateElementsBySectionId } = section as TemplateSection
       templateElementsBySectionId.nodes.forEach((element) => {
-        if (element?.id && element.category === 'QUESTION') elementsIds.push(element.id)
+        if (element?.id && element.category === 'QUESTION') {
+          elementsIds.push(element.id)
+          elementsDefaults.push(element.defaultValue)
+        }
       })
     })
 
@@ -73,6 +82,7 @@ const useLoadTemplate = ({ templateCode }: UseLoadTemplateProps) => {
         code,
         name: name as string,
         elementsIds,
+        elementsDefaults,
         sections,
         startMessage,
       })

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import {
   GetTemplateQuery,
   Template,
+  TemplateElementCategory,
   TemplateSection,
   useGetTemplateQuery,
 } from '../generated/graphql'

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -64,7 +64,7 @@ const useLoadTemplate = ({ templateCode }: UseLoadTemplateProps) => {
     templateSections.forEach((section) => {
       const { templateElementsBySectionId } = section as TemplateSection
       templateElementsBySectionId.nodes.forEach((element) => {
-        if (element?.id && element.category === 'QUESTION') {
+        if (element?.id && element.category === TemplateElementCategory.Question) {
           elementsIds.push(element.id)
           elementsDefaults.push(element.defaultValue)
         }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -66,7 +66,6 @@ export {
   StageAndStatus,
   TemplateDetails,
   TemplateCategoryDetails,
-  TemplateElementState,
   TemplatePermissions,
   TemplateInList,
   TemplatesDetails,
@@ -173,9 +172,17 @@ interface ElementPluginParameters {
   [key: string]: ElementPluginParameterValue
 }
 
-interface ElementBase {
-  id: number
+export type ElementForEvaluation = {
+  isEditableExpression?: EvaluatorNode
+  isRequiredExpression?: EvaluatorNode
+  isVisibleExpression?: EvaluatorNode
+  validationExpression?: EvaluatorNode
+  defaultValueExpression?: EvaluatorNode
   code: string
+}
+
+interface ElementBase extends ElementForEvaluation {
+  id: number
   title: string
   pluginCode: string
   sectionIndex: number
@@ -183,17 +190,22 @@ interface ElementBase {
   elementIndex: number
   page: number
   category: TemplateElementCategory
-  validationExpression: EvaluatorNode
   validationMessage: string | null
   helpText: string | null
   parameters: any
 }
 
-interface ElementState extends ElementBase {
+export type EvaluatedElement = {
   isEditable: boolean
   isRequired: boolean
   isVisible: boolean
+  isValid: boolean | undefined
+  defaultValue: any
 }
+
+export type EvaluationOptions = (keyof EvaluatedElement)[]
+
+type ElementState = ElementBase & EvaluatedElement
 
 interface ElementsActivityState {
   elementEnteredTimestamp: number
@@ -460,14 +472,9 @@ interface TemplateDetails {
   name: string
   code: string
   elementsIds?: number[] // TODO: Change to not optional after re-structure
+  elementsDefaults?: EvaluatorNode[]
   sections?: SectionDetails[] // TODO: Change to not optional after re-structure
   startMessage?: string
-}
-
-interface TemplateElementState extends ElementBase {
-  isRequiredExpression: EvaluatorNode
-  isVisibleExpression: EvaluatorNode
-  isEditableExpression: EvaluatorNode
 }
 
 interface TemplatePermissions {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -18,7 +18,7 @@ import {
 } from './generated/graphql'
 
 import { ValidationState } from '../formElementPlugins/types'
-import { OperatorNode, ValueNode } from '@openmsupply/expression-evaluator/lib/types'
+import { EvaluatorNode } from '@openmsupply/expression-evaluator/lib/types'
 import { SemanticICONS } from 'semantic-ui-react/dist/commonjs/generic'
 import { DocumentNode } from '@apollo/client'
 
@@ -77,8 +77,6 @@ export {
   LoginPayload,
   BasicStringObject,
 }
-
-type EvaluatorNode = OperatorNode | ValueNode
 
 interface ApplicationDetails {
   id: number


### PR DESCRIPTION
Fixes: #761 

Requires back end branch in this PR: https://github.com/openmsupply/application-manager-server/pull/395

Wanted to delegate default value work to generic functionality, for it not to be plugin specific. This is needed to pre-fill default values for plugins like listBuilder.

note: Kept dropbox and radio button default parameter, however defaultValue on element will take priority

### Changes

* There is back end change to add defaultValue to element, please refer to back end PR
* Juggled types a little bit, and made useLoadApplication to be more strongly typed (previous 'as' cast ignored missing or miss typed field
* Simplified evaluation logic of element and made it usable in other context
* Create application now evaluates default values and inserts evaluated defaults on application creation
* Use types and `isEvalutorExpression` from new version of evaluator (see testing below to see how to use new version without pushing evaluator to github packages, this PR won't compile without new evaluator)

### Testing

* Use back end branch '#761F-testing` (which just adds list builder from feature showcase to user registration)
* Build evaluator (run yarn install && yarn build command within the evaluator module in back end)
* Copy path of evaluator module and run the following in front end root `yarn remove @openmsupply/expression-evaluator` then `yarn add file:{path to evaluator in back end}` then `yarn dev`
* Create a new user (make sure to add something to list builder)
* Log in with new user and edit user application, you will see list builder values as per user registration


