### PR TITLE
Parameter evaluations in structure

### DIFF
--- a/src/formElementPlugins/checkbox/pluginConfig.json
+++ b/src/formElementPlugins/checkbox/pluginConfig.json
@@ -2,11 +2,6 @@
   "isCore": true,
   "code": "checkbox",
   "displayName": "Checkbox Selectors",
-  "parameterLoadingValues": {
-    "label": "Loading...",
-    "description": "",
-    "checkboxes": ["Loading..."]
-  },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"
 }

--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -19,13 +19,13 @@ interface CheckboxSavedState {
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
-  parameters,
+  evaluatedParameters,
   onSave,
   Markdown,
   initialValue,
 }) => {
   const { isEditable } = element
-  const { label, description, checkboxes, type, layout } = parameters
+  const { label, description, checkboxes, type, layout } = evaluatedParameters
 
   const [checkboxElements, setCheckboxElements] = useState<Checkbox[]>(
     getInitialState(initialValue, checkboxes)
@@ -38,7 +38,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   useEffect(() => {
     // Don't save response if parameters are still loading
-    if (checkboxElements[0].text === config.parameterLoadingValues.label) return
+    if (checkboxElements[0].text === evaluatedParameters.label) return
     onSave({
       text: createTextString(checkboxElements),
       values: Object.fromEntries(

--- a/src/formElementPlugins/dropdownChoice/pluginConfig.json
+++ b/src/formElementPlugins/dropdownChoice/pluginConfig.json
@@ -2,11 +2,6 @@
   "isCore": true,
   "code": "dropdownChoice",
   "displayName": "Drop-down Selector",
-  "parameterLoadingValues": {
-    "label": "Loading...",
-    "description": "",
-    "options": ["Loading..."]
-  },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"
 }

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -4,11 +4,8 @@ import { ApplicationViewProps } from '../../types'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
-  parameters,
-  onUpdate,
+  evaluatedParameters,
   currentResponse,
-  // value,
-  // setValue,
   validationState,
   onSave,
   Markdown,
@@ -22,7 +19,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     options,
     optionsDisplayProperty,
     default: defaultOption,
-  } = parameters
+  } = evaluatedParameters
 
   const [selectedIndex, setSelectedIndex] = useState<number>()
   const { isEditable } = element

--- a/src/formElementPlugins/fileUpload/pluginConfig.json
+++ b/src/formElementPlugins/fileUpload/pluginConfig.json
@@ -2,10 +2,6 @@
   "isCore": true,
   "code": "fileUpload",
   "displayName": "File Upload interface",
-  "parameterLoadingValues": {
-    "label": "Loading...",
-    "description": ""
-  },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"
 }

--- a/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
+++ b/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
@@ -30,15 +30,14 @@ interface FileInfo {
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
-  parameters,
+  evaluatedParameters,
   onSave,
   Markdown,
   initialValue,
-  currentResponse,
   applicationData,
 }) => {
   const { isEditable } = element
-  const { label, description, fileCountLimit, fileExtensions, fileSizeLimit } = parameters
+  const { label, description, fileCountLimit, fileExtensions, fileSizeLimit } = evaluatedParameters
 
   const { config } = applicationData
   const host = config.serverREST

--- a/src/formElementPlugins/fileUpload/src/SummaryView.tsx
+++ b/src/formElementPlugins/fileUpload/src/SummaryView.tsx
@@ -5,13 +5,13 @@ import { SummaryViewProps } from '../../types'
 
 const host = config.serverREST
 
-const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
+const SummaryView: React.FC<SummaryViewProps> = ({ evaluatedParameters, Markdown, response }) => {
   return (
-    <Form.Field required={parameters.isRequired}>
+    <Form.Field required={evaluatedParameters.isRequired}>
       <label style={{ color: 'black' }}>
-        <Markdown text={parameters.label} semanticComponent="noParagraph" />
+        <Markdown text={evaluatedParameters.label} semanticComponent="noParagraph" />
       </label>
-      <Markdown text={parameters.description} />
+      <Markdown text={evaluatedParameters.description} />
       <List horizontal verticalAlign="top">
         {response?.files &&
           response.files.map((file) => (

--- a/src/formElementPlugins/imageDisplay/pluginConfig.json
+++ b/src/formElementPlugins/imageDisplay/pluginConfig.json
@@ -2,12 +2,6 @@
   "isCore": true,
   "code": "imageDisplay",
   "displayName": "Image Display",
-  "parameterLoadingValues": {
-    "label": "Loading...",
-    "description": "",
-    "size": "small",
-    "alignment": "center"
-  },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Informative"
 }

--- a/src/formElementPlugins/imageDisplay/src/ApplicationView.tsx
+++ b/src/formElementPlugins/imageDisplay/src/ApplicationView.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import { Image } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
 
-const ApplicationView: React.FC<ApplicationViewProps> = ({ parameters }) => {
-  const { url, size, alignment, altText } = parameters
+const ApplicationView: React.FC<ApplicationViewProps> = ({ evaluatedParameters }) => {
+  const { url, size, alignment, altText } = evaluatedParameters
 
   return (
     <Image

--- a/src/formElementPlugins/imageDisplay/src/SummaryView.tsx
+++ b/src/formElementPlugins/imageDisplay/src/SummaryView.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import { Image } from 'semantic-ui-react'
 import { SummaryViewProps } from '../../types'
 
-const SummaryView: React.FC<SummaryViewProps> = ({ parameters }) => {
-  const { url, size, alignment, altText } = parameters
+const SummaryView: React.FC<SummaryViewProps> = ({ evaluatedParameters }) => {
+  const { url, size, alignment, altText } = evaluatedParameters
 
   return (
     <Image

--- a/src/formElementPlugins/listBuilder/pluginConfig.json
+++ b/src/formElementPlugins/listBuilder/pluginConfig.json
@@ -2,10 +2,6 @@
   "isCore": true,
   "code": "listBuilder",
   "displayName": "List Builder",
-  "parameterLoadingValues": {
-    "label": "Loading...",
-    "description": ""
-  },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"
 }

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -296,7 +296,7 @@ const createTextString = (listItems: ResponsesByCode[], inputFields: TemplateEle
     (outputAcc, item) =>
       outputAcc +
       inputFields.reduce(
-        (innerAcc, field) => innerAcc + `${field.title}: ${item[field.code].text}, `,
+        (innerAcc, field) => innerAcc + `${field.title}: ${item[field.code]?.text || ''}, `,
         ''
       ) +
       '\n',
@@ -380,7 +380,9 @@ export const ListTableLayout: React.FC<ListLayoutProps> = ({
         {listItems.map((item, index) => (
           <Table.Row key={`list-row-${index}`} onClick={() => editItem(index)}>
             {codes.map((code, cellIndex) => (
-              <TableCell key={`list-cell-${index}-${cellIndex}`}>{item[code].text}</TableCell>
+              <TableCell key={`list-cell-${index}-${cellIndex}`}>
+                {item[code]?.text || ''}
+              </TableCell>
             ))}
           </Table.Row>
         ))}

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -121,7 +121,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     setInputState((currentInputState) => ({
       ...currentInputState,
       elements: newElements,
-      inputError: inputError && anyErrorItems(currentInputState.allResponses || {}, elements),
+      inputError: inputError && anyErrorItems(currentInputState.allResponses || {}, newElements),
     }))
   }
 
@@ -280,7 +280,9 @@ const anyInvalidItems = (allResponses: ResponsesByCode) =>
   Object.values(allResponses).some((response) => response.isValid === false)
 
 const anyIncompleteItems = (allResponses: ResponsesByCode, elements: ElementState[]) =>
-  elements.some((element) => element.isRequired !== false && !allResponses[element.code]?.text)
+  elements.some(
+    (element) => element.isRequired && element.isVisible && !allResponses[element.code]?.text
+  )
 
 const anyErrorItems = (allResponses: ResponsesByCode, elements: ElementState[]) => {
   return anyInvalidItems(allResponses) || anyIncompleteItems(allResponses, elements)

--- a/src/formElementPlugins/listBuilder/src/SummaryView.tsx
+++ b/src/formElementPlugins/listBuilder/src/SummaryView.tsx
@@ -3,8 +3,8 @@ import { TemplateElement } from '../../../utils/generated/graphql'
 import { SummaryViewProps } from '../../types'
 import { ListCardLayout, ListTableLayout, ListLayoutProps, DisplayType } from './ApplicationView'
 
-const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
-  const { displayType, displayFormat, inputFields } = parameters
+const SummaryView: React.FC<SummaryViewProps> = ({ evaluatedParameters, Markdown, response }) => {
+  const { displayType, displayFormat, inputFields } = evaluatedParameters
 
   const listDisplayProps: ListLayoutProps = {
     listItems: response?.list ?? [],

--- a/src/formElementPlugins/longText/pluginConfig.json
+++ b/src/formElementPlugins/longText/pluginConfig.json
@@ -2,11 +2,6 @@
   "isCore": true,
   "code": "longText",
   "displayName": "Multi-line Text Input",
-  "parameterLoadingValues": {
-    "label": "Loading...",
-    "description": "",
-    "placeholder": "Loading..."
-  },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"
 }

--- a/src/formElementPlugins/longText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/longText/src/ApplicationView.tsx
@@ -4,7 +4,7 @@ import { ApplicationViewProps } from '../../types'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
-  parameters,
+  evaluatedParameters,
   onUpdate,
   setIsActive,
   currentResponse,
@@ -14,7 +14,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 }) => {
   const [value, setValue] = useState<string | null | undefined>(currentResponse?.text)
 
-  const { label, description, placeholder, lines, maxLength } = parameters
+  const { label, description, placeholder, lines, maxLength } = evaluatedParameters
 
   const { isEditable } = element
 

--- a/src/formElementPlugins/password/pluginConfig.json
+++ b/src/formElementPlugins/password/pluginConfig.json
@@ -2,12 +2,6 @@
   "isCore": true,
   "code": "password",
   "displayName": "Secure Password Input",
-  "parameterLoadingValues": {
-    "label": "Loading...",
-    "default": "",
-    "description": ""
-  },
-  "internalParameters": ["validationInternal"],
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"
 }

--- a/src/formElementPlugins/password/src/ApplicationView.tsx
+++ b/src/formElementPlugins/password/src/ApplicationView.tsx
@@ -7,7 +7,8 @@ import strings from '../constants'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
-  parameters,
+  evaluatedParameters,
+  parametersExpressions,
   setIsActive,
   validationState,
   onSave,
@@ -26,9 +27,9 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     label,
     requireConfirmation = true,
     showPasswordToggle,
-    validationInternal,
     validationMessageInternal,
-  } = parameters
+  } = evaluatedParameters
+  const { validationInternal } = parametersExpressions
 
   const {
     userState: { currentUser },

--- a/src/formElementPlugins/radioChoice/pluginConfig.json
+++ b/src/formElementPlugins/radioChoice/pluginConfig.json
@@ -2,11 +2,6 @@
   "isCore": true,
   "code": "radioChoice",
   "displayName": "Radio Button Selector",
-  "parameterLoadingValues": {
-    "label": "Loading...",
-    "description": "",
-    "options": ["Loading..."]
-  },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"
 }

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -5,7 +5,7 @@ import strings from '../constants'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
-  parameters,
+  evaluatedParameters,
   onUpdate,
   currentResponse,
   onSave,
@@ -21,7 +21,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     hasOther,
     otherPlaceholder,
     layout,
-  } = parameters
+  } = evaluatedParameters
 
   const { code, isEditable } = element
 

--- a/src/formElementPlugins/search/pluginConfig.json
+++ b/src/formElementPlugins/search/pluginConfig.json
@@ -2,12 +2,6 @@
   "isCore": true,
   "code": "search",
   "displayName": "Search Field",
-  "parameterLoadingValues": {
-    "label": "Loading...",
-    "description": "",
-    "options": ["Loading..."]
-  },
-  "internalParameters": ["source"],
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"
 }

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -15,9 +15,9 @@ interface DisplayFormat {
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
-  parameters,
+  evaluatedParameters,
+  parametersExpressions,
   currentResponse,
-  // validationState,
   onSave,
   Markdown,
   applicationData,
@@ -26,13 +26,14 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     label,
     description,
     placeholder = strings.DEFAULT_PLACEHOLDER,
-    source,
     icon = 'search',
     multiSelect = false,
     minCharacters = 1,
     displayFormat = {},
     resultFormat = displayFormat,
-  } = parameters
+  } = evaluatedParameters
+
+  const { source } = parametersExpressions
 
   const graphQLEndpoint = applicationData.config.serverGraphQL
 

--- a/src/formElementPlugins/search/src/SummaryView.tsx
+++ b/src/formElementPlugins/search/src/SummaryView.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import { SummaryViewProps } from '../../types'
 import { DisplaySelection, DisplayProps } from './ApplicationView'
 
-const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
-  const { displayFormat } = parameters
+const SummaryView: React.FC<SummaryViewProps> = ({ evaluatedParameters, Markdown, response }) => {
+  const { displayFormat } = evaluatedParameters
 
   const displayProps: DisplayProps = {
     selection: response?.selection ?? [],

--- a/src/formElementPlugins/shortText/pluginConfig.json
+++ b/src/formElementPlugins/shortText/pluginConfig.json
@@ -2,11 +2,6 @@
   "isCore": true,
   "code": "shortText",
   "displayName": "Basic Text Input",
-  "parameterLoadingValues": {
-    "label": "Loading...",
-    "default": "",
-    "description": ""
-  },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"
 }

--- a/src/formElementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/shortText/src/ApplicationView.tsx
@@ -4,7 +4,7 @@ import { ApplicationViewProps } from '../../types'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
-  parameters,
+  evaluatedParameters,
   onUpdate,
   setIsActive,
   validationState,
@@ -21,7 +21,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     description,
     maxWidth,
     maxLength = Infinity,
-  } = parameters
+  } = evaluatedParameters
 
   function handleChange(e: any) {
     let text = e.target.value

--- a/src/formElementPlugins/textInfo/pluginConfig.json
+++ b/src/formElementPlugins/textInfo/pluginConfig.json
@@ -2,11 +2,6 @@
   "isCore": true,
   "code": "textInfo",
   "displayName": "Static Text",
-  "parameterLoadingValues": {
-    "title": "Loading...",
-    "text": "",
-    "style": "none"
-  },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Informative"
 }

--- a/src/formElementPlugins/textInfo/src/ApplicationView.tsx
+++ b/src/formElementPlugins/textInfo/src/ApplicationView.tsx
@@ -70,8 +70,8 @@ export const TextInfoElement: React.FC<TextInfoProps> = (props) => {
     )
 }
 
-const ApplicationView: React.FC<ApplicationViewProps> = ({ parameters, Markdown }) => {
-  return <TextInfoElement parameters={parameters} Markdown={Markdown} />
+const ApplicationView: React.FC<ApplicationViewProps> = ({ evaluatedParameters, Markdown }) => {
+  return <TextInfoElement parameters={evaluatedParameters} Markdown={Markdown} />
 }
 
 export default ApplicationView

--- a/src/formElementPlugins/textInfo/src/SummaryView.tsx
+++ b/src/formElementPlugins/textInfo/src/SummaryView.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import { SummaryViewProps } from '../../types'
 import { TextInfoElement } from './ApplicationView'
 
-const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown }) => {
-  return <TextInfoElement parameters={parameters} Markdown={Markdown} />
+const SummaryView: React.FC<SummaryViewProps> = ({ evaluatedParameters, Markdown }) => {
+  return <TextInfoElement parameters={evaluatedParameters} Markdown={Markdown} />
 }
 
 export default SummaryView

--- a/src/formElementPlugins/types.ts
+++ b/src/formElementPlugins/types.ts
@@ -1,5 +1,11 @@
 import { ReviewResponse, TemplateElement } from '../utils/generated/graphql'
-import { ApplicationDetails, ElementState, ResponseFull, ResponsesByCode } from '../utils/types'
+import {
+  ApplicationDetails,
+  ElementState,
+  EvaluatorNode,
+  ResponseFull,
+  ResponsesByCode,
+} from '../utils/types'
 
 interface OnUpdateApplicationView {
   (updateObject: { value?: any; isValid: boolean | undefined }): void
@@ -35,14 +41,15 @@ interface ApplicationViewProps extends ApplicationViewWrapperProps {
   initialValue: any
   setIsActive: () => void
   validationState: ValidationState
+  evaluatedParameters?: any
+  parametersExpressions?: any
   Markdown: any
   getDefaultIndex: Function
-  parameters: any // TODO: Create type for existing pre-defined types for parameters (TemplateElement)s
   validate: Function
 }
 
 interface SummaryViewProps {
-  parameters: BasicObject
+  evaluatedParameters?: any
   response: ResponseFull | null
   Markdown: any
   DefaultSummaryView: React.FC

--- a/src/utils/hooks/useGetApplicationStructure.tsx
+++ b/src/utils/hooks/useGetApplicationStructure.tsx
@@ -84,7 +84,12 @@ const useGetApplicationStructure = ({
     const applicationResponses = data?.applicationBySerial?.applicationResponses
       ?.nodes as ApplicationResponse[]
 
-    const evaluationOptions: EvaluationOptions = ['isEditable', 'isVisible', 'isRequired']
+    const evaluationOptions: EvaluationOptions = [
+      'isEditable',
+      'isVisible',
+      'isRequired',
+      'evaluatedParameters',
+    ]
 
     if (shouldDoValidation) evaluationOptions.push('isValid')
 

--- a/src/utils/hooks/useLoadApplication.ts
+++ b/src/utils/hooks/useLoadApplication.ts
@@ -136,7 +136,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
             isEditableExpression: element.isEditable,
             isRequiredExpression: element.isRequired,
             isVisibleExpression: element.visibilityCondition,
-            parameters: element.parameters,
+            parametersExpressions: element.parameters,
             validationExpression: element.validation,
             validationMessage: element.validationMessage || '',
             helpText: element.helpText || '',
@@ -189,6 +189,7 @@ export const defaultEvaluatedElement: EvaluatedElement = {
   isRequired: true,
   isVisible: true,
   isValid: undefined,
+  evaluatedParameters: undefined,
   defaultValue: null,
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -176,6 +176,7 @@ export type ElementForEvaluation = {
   isVisibleExpression?: EvaluatorNode
   validationExpression?: EvaluatorNode
   defaultValueExpression?: EvaluatorNode
+  parametersExpressions?: EvaluatorNode
   code: string
 }
 
@@ -190,7 +191,6 @@ interface ElementBase extends ElementForEvaluation {
   category: TemplateElementCategory
   validationMessage: string | null
   helpText: string | null
-  parameters: any
 }
 
 export type EvaluatedElement = {
@@ -198,6 +198,7 @@ export type EvaluatedElement = {
   isRequired: boolean
   isVisible: boolean
   isValid: boolean | undefined
+  evaluatedParameters: any
   defaultValue: any
 }
 


### PR DESCRIPTION
https://github.com/openmsupply/application-manager-web-app/pull/758#issuecomment-854186075

@CarlosNZ this is what it would be like (draft PR for now), it seems slower because for every change we re-evaluate all parameters (not just current page parameters), and since we do lots of api calls in feature showcase template, there is a delay (for example when changing from card to table view). I think that's ok though (I dont' see us using lookups to api to change evaluated parameters frequently, most api calls will use 'search' plugin.

Also we can add an optimisation to specify which questions codes evaluations for form element instance relies on.

### Changes

* Evaluate dynamic parameters in structure building
* Remove loading states
* Two parameters passed to plug in `evaluatedParameters` and `parametersExpressions`, `parmetersExpressions` is used in search and password plugin for unevaluated parameters
* Refactor list builder to account for changes (now it should work pretty much the same as general structure, with isVisible, isRequired, isEditable -> evaluatable, check out with back end branch `evaluation-in-structure-test`)

`note:` both front end and back end test branch rely on new version of evaluator, can add it from file for now as per testing in 761 pr 

