### PR TITLE
make sure validation doesn't break when plugin saves the same value

### DIFF
--- a/src/contexts/FormElementUpdateTrackerState.tsx
+++ b/src/contexts/FormElementUpdateTrackerState.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useReducer } from 'react'
 
 interface ContextFormElementUpdateTrackerState {
   elementEnteredTimestamp: number
-  elementEnteredTextValue: string
+  elementEnteredTextValue?: string
   elementUpdatedTimestamp: number
   elementUpdatedTextValue: string
   isLastElementUpdateProcessed: boolean
@@ -17,6 +17,7 @@ export type UpdateAction =
   | {
       type: 'setElementUpdated'
       textValue: string
+      previousValue: string
     }
 
 type FormElementUpdateTrackerProps = { children: React.ReactNode }
@@ -35,11 +36,17 @@ const reducer = (
         elementUpdatedTimestamp: Date.now(),
         elementUpdatedTextValue: action.textValue,
       }
+
+      const notEntryState = typeof newState.elementEnteredTextValue === 'undefined'
+      let wasElementChanged = action.textValue !== newState.elementEnteredTextValue
+      if (notEntryState) wasElementChanged = action.textValue !== action.previousValue
+
       return {
         ...newState,
         isLastElementUpdateProcessed:
           newState.elementUpdatedTimestamp >= newState.elementEnteredTimestamp,
-        wasElementChanged: newState.elementUpdatedTextValue !== newState.elementEnteredTextValue,
+        wasElementChanged,
+        elementEnteredTextValue: undefined,
       }
     }
     case 'setElementEntered': {
@@ -63,7 +70,7 @@ const initialState: ContextFormElementUpdateTrackerState = {
   isLastElementUpdateProcessed: true,
   elementEnteredTimestamp: Date.now(),
   elementUpdatedTimestamp: Date.now(),
-  elementEnteredTextValue: '',
+  elementEnteredTextValue: undefined,
   elementUpdatedTextValue: '',
   wasElementChanged: false,
 }

--- a/src/contexts/FormElementUpdateTrackerState.tsx
+++ b/src/contexts/FormElementUpdateTrackerState.tsx
@@ -37,9 +37,10 @@ const reducer = (
         elementUpdatedTextValue: action.textValue,
       }
 
-      const notEntryState = typeof newState.elementEnteredTextValue === 'undefined'
-      let wasElementChanged = action.textValue !== newState.elementEnteredTextValue
-      if (notEntryState) wasElementChanged = action.textValue !== action.previousValue
+      const wasElementChanged =
+        typeof newState.elementEnteredTextValue === 'undefined'
+          ? action.textValue !== action.previousValue
+          : action.textValue !== newState.elementEnteredTextValue
 
       return {
         ...newState,

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -127,6 +127,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
       setUpdateTrackerState({
         type: 'setElementUpdated',
         textValue: response?.text || '',
+        previousValue: currentResponse?.text || '',
       })
     } else {
       // Save response for plugins with internal validation
@@ -143,6 +144,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
       setUpdateTrackerState({
         type: 'setElementUpdated',
         textValue: response?.text || '',
+        previousValue: currentResponse?.text || '',
       })
     }
   }


### PR DESCRIPTION
Fixes: #717 

will make an issue tomorrow for this:

replication
* create org rego
* fill the fist page
* go to second page
* go back to first page
* try to go to next page

made validation a little bit more resilient (didn't realise plugins would be changing values, even if it's not change, and on subsequent loads)