### PR TITLE
#773 Option to hide "Add item" button in listBuilder

### DIFF
--- a/documentation/internal/Element-Type-Specs.md
+++ b/documentation/internal/Element-Type-Specs.md
@@ -401,6 +401,8 @@ _Allows user to build a list of items, such as an **Ingredients List**_
   - `visibility_condition` / `is_editable` -- not required, always `true` (for now, may be implemented later)
   - `parameters`, `title`, and `code` are essential
 
+- **displayOnly** `boolean` (default `false`) -- if `true` the "Add item" button will be hidden completely (as opposed to just disabled when `isEditable = true`)
+
 - **displayType** `string` (must be either `table` or `cards` (default)) -- how to present the list of items, as shown here:
 
   - **table** view:

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -53,6 +53,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     inputFields,
     displayFormat = getDefaultDisplayFormat(inputFields),
     displayType = DisplayType.CARDS,
+    displayOnly = false,
   } = parameters
 
   const [currentInputResponses, setCurrentInputResponses] = useState<ListItem>(
@@ -142,12 +143,14 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         <Markdown text={label} semanticComponent="noParagraph" />
       </label>
       <Markdown text={description} />
-      <Button
-        primary
-        content={createModalButtonText}
-        onClick={() => setOpen(true)}
-        disabled={!isEditable}
-      />
+      {!displayOnly && (
+        <Button
+          primary
+          content={createModalButtonText}
+          onClick={() => setOpen(true)}
+          disabled={!isEditable}
+        />
+      )}
       <Modal size="tiny" onClose={() => resetModalState()} onOpen={() => setOpen(true)} open={open}>
         <Segment>
           <Form>


### PR DESCRIPTION
Fixes #773.

Adds an additional (optional) parameter `displayOnly` which (if `true`) completely hides the "Add item" button for adding new ingredients (as opposed to just disabling it when `isEditable = false`). This is so a previous listBuilder response can be displayed in a form (as defaultValue) without there being any indication of editability by the user.