### PR TITLE
Demo extras

### DIFF
--- a/semantic/src/site/collections/table.overrides
+++ b/semantic/src/site/collections/table.overrides
@@ -12,7 +12,7 @@
   }
   .ui.table td {
     background: @surfacesWhite;
-    padding: 0;
+    padding: 5px;
   }
 
   .ui.table tr {

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -43,9 +43,9 @@ a:hover {
   color: @attention;
 }
 
-.information {
-  color: @information;
-}
+//.information {
+//  color: @information;
+//}
 
 .clickable {
   cursor: pointer;

--- a/src/LookupTable/hooks/useGetAllTableStructures.hook.tsx
+++ b/src/LookupTable/hooks/useGetAllTableStructures.hook.tsx
@@ -6,7 +6,7 @@ const useGetAllTableStructures = (): AllLookupTableStructuresType => {
   const [allTableStructures, setAllTableStructures] = useState<LookUpTableType[]>()
 
   const allTableStructuresLoadState = useGetAllLookupTableStructuresQuery({
-    fetchPolicy: 'no-cache',
+    fetchPolicy: 'network-only',
   })
 
   const { data, loading, error, refetch: refetchAllTableStructures } = allTableStructuresLoadState

--- a/src/LookupTable/hooks/useGetSingleTable.hook.tsx
+++ b/src/LookupTable/hooks/useGetSingleTable.hook.tsx
@@ -22,7 +22,7 @@ const useGetSingleTable = () => {
   `)
 
   const [getSingleTable, singleTableLoadState] = useLazyQuery(dynamicQuery, {
-    fetchPolicy: 'no-cache',
+    fetchPolicy: 'network-only',
   })
 
   const { called, loading, data, error } = singleTableLoadState

--- a/src/LookupTable/hooks/useGetSingleTableStructure.hook.tsx
+++ b/src/LookupTable/hooks/useGetSingleTableStructure.hook.tsx
@@ -14,13 +14,11 @@ const useGetTableStructure = (): LookupTableStructureType => {
   const [structureID, setStructureID] = useState<number>(0)
   const [structure, setStructure] = useState<LookUpTableType>()
 
-  const [execute, structureLoadState]: [
-    (options?: any) => void,
-    ApolloQueryResult<any>
-  ] = useGetLookupTableStructureByIdLazyQuery({
-    variables: { lookupTableID: structureID },
-    fetchPolicy: 'no-cache',
-  })
+  const [execute, structureLoadState]: [(options?: any) => void, ApolloQueryResult<any>] =
+    useGetLookupTableStructureByIdLazyQuery({
+      variables: { lookupTableID: structureID },
+      fetchPolicy: 'network-only',
+    })
 
   const { loading, data, error }: any = structureLoadState
 

--- a/src/components/PageElements/PageElements.tsx
+++ b/src/components/PageElements/PageElements.tsx
@@ -7,7 +7,7 @@ import {
   ResponsesByCode,
   SectionAndPage,
 } from '../../utils/types'
-import { ApplicationViewWrapper } from '../../formElementPlugins'
+import { ApplicationViewWrapper, SummaryViewWrapper } from '../../formElementPlugins'
 import { ApplicationViewWrapperProps } from '../../formElementPlugins/types'
 import { ReviewResponse, TemplateElementCategory } from '../../utils/generated/graphql'
 import Markdown from '../../utils/helpers/semanticReactMarkdown'
@@ -54,6 +54,12 @@ const PageElements: React.FC<PageElementProps> = ({
   } = useRouter()
   const visibleElements = elements.filter(({ element }) => element.isVisible)
 
+  const getSummaryViewProps = (element: ElementState) => ({
+    element,
+    response: responsesByCode?.[element.code],
+    allResponses: responsesByCode,
+    applicationData,
+  })
   // Editable Application page
   if (canEdit && !isReview && !isSummary)
     return (
@@ -78,12 +84,20 @@ const PageElements: React.FC<PageElementProps> = ({
               applicationData,
               currentResponse: responsesByCode?.[element.code],
             }
+
             // Wrapper displays response & changes requested warning for LOQ re-submission
             return (
               <div className="form-element-wrapper" key={`question_${element.code}`}>
                 <div className="form-element">
-                  <ApplicationViewWrapper {...props} />
+                  {element.category === TemplateElementCategory.Information ? (
+                    <RenderElementWrapper key={element.code}>
+                      <SummaryViewWrapper {...getSummaryViewProps(element)} />
+                    </RenderElementWrapper>
+                  ) : (
+                    <ApplicationViewWrapper {...props} />
+                  )}
                 </div>
+
                 {element.helpText && (
                   <div className="help-tips hide-on-mobile">
                     <div className="help-tips-content">
@@ -97,13 +111,6 @@ const PageElements: React.FC<PageElementProps> = ({
         )}
       </Form>
     )
-
-  const getSummaryViewProps = (element: ElementState) => ({
-    element,
-    response: responsesByCode?.[element.code],
-    allResponses: responsesByCode,
-    applicationData,
-  })
 
   // Summary Page
   if (isSummary) {

--- a/src/containers/Outcomes/ApplicationLinks.tsx
+++ b/src/containers/Outcomes/ApplicationLinks.tsx
@@ -18,7 +18,9 @@ const ApplicationLinks: React.FC<{ applicationLinkQuery: ApplicationLinkQuery; i
     fetchPolicy: 'network-only',
   })
 
-  if (error) return <Message error title={strings.ERROR_GENERIC} list={[error.message]} />
+  // if (error) return <Message error title={strings.ERROR_GENERIC} list={[error.message]} />
+  // Silently ignore errors for demo
+  if (error) return null
   if (!data) return <Loading />
 
   const applications = applicationLinkQuery.getApplications(data)

--- a/src/containers/Outcomes/Outcomes.tsx
+++ b/src/containers/Outcomes/Outcomes.tsx
@@ -17,7 +17,9 @@ const Outcomes: React.FC = () => {
 
   const { displays, error } = useGetOutcomeDisplays()
 
-  if (error) return <Message error title={strings.ERROR_GENERIC} list={[error]} />
+  // if (error) return <Message error title={strings.ERROR_GENERIC} list={[error]} />
+  // Silently ignore errors for demo
+  if (error) return null
   if (!displays) return <Loading />
 
   return (

--- a/src/containers/Outcomes/OutcomesDetail.tsx
+++ b/src/containers/Outcomes/OutcomesDetail.tsx
@@ -26,7 +26,9 @@ const OutcomeDetails: React.FC<{
     fetchPolicy: 'network-only',
   })
 
-  if (error) return <Message error title={strings.ERROR_GENERIC} list={[error.message]} />
+  // if (error) return <Message error title={strings.ERROR_GENERIC} list={[error.message]} />
+  // Silently ignore errors for demo
+  if (error) return null
   if (!data) return <Loading />
 
   const detailData = detailQuery.getNode(data)

--- a/src/containers/Outcomes/OutcomesList.tsx
+++ b/src/containers/Outcomes/OutcomesList.tsx
@@ -30,7 +30,9 @@ const Outcome: React.FC<{ code: string; title: string; outcomeCountQuery: Outcom
 }) => {
   const { data, error } = useQuery(outcomeCountQuery.query, { fetchPolicy: 'network-only' })
 
-  if (error) return <Message error title={strings.ERROR_GENERIC} list={[error.message]} />
+  // if (error) return <Message error title={strings.ERROR_GENERIC} list={[error.message]} />
+  // Silently ignore errors for demo
+  if (error) return null
   if (!data) return null
 
   const count = outcomeCountQuery.getCount(data)

--- a/src/containers/Outcomes/OutcomesTable.tsx
+++ b/src/containers/Outcomes/OutcomesTable.tsx
@@ -15,7 +15,9 @@ const OutcomeTable: React.FC<{
   const { push } = useRouter()
   const { data, error } = useQuery(tableQuery.query, { fetchPolicy: 'network-only' })
 
-  if (error) return <Message error title={strings.ERROR_GENERIC} list={[error.message]} />
+  // if (error) return <Message error title={strings.ERROR_GENERIC} list={[error.message]} />
+  // Silently ignore errors for demo
+  if (error) return null
   if (!data) return <Loading />
 
   const tableData = tableQuery.getNodes(data)

--- a/src/containers/Review/AssignmentSectionRow.tsx
+++ b/src/containers/Review/AssignmentSectionRow.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Dropdown, Grid, Label, Message } from 'semantic-ui-react'
 import strings from '../../utils/constants'
-import { ReviewAssignmentStatus } from '../../utils/generated/graphql'
+import { ReviewAssignmentStatus, TemplateElementCategory } from '../../utils/generated/graphql'
 import useUpdateReviewAssignment from '../../utils/hooks/useUpdateReviewAssignment'
 import { AssignmentDetails, FullStructure } from '../../utils/types'
 
@@ -66,7 +66,11 @@ const getOptionFromAssignment = ({ reviewer, isCurrentUserReviewer }: Assignment
     : `${reviewer.firstName || ''} ${reviewer.lastName || ''}`,
 })
 
-const getAssignmentOptions = ({ assignments, sectionCode }: AssignmentSectionRowProps) => {
+const getAssignmentOptions = ({
+  assignments,
+  sectionCode,
+  structure,
+}: AssignmentSectionRowProps) => {
   const currentSectionAssignable = assignments.filter(
     ({ assignableSectionRestrictions }) =>
       assignableSectionRestrictions.length === 0 ||
@@ -79,6 +83,14 @@ const getAssignmentOptions = ({ assignments, sectionCode }: AssignmentSectionRow
 
   // Dont' want to render assignment section row if they have no actions
   if (currentUserAssignable.length === 0) return null
+  const elements = Object.values(structure?.elementsById || {})
+  const numberOfAssignableElements = elements.filter(
+    ({ element }) =>
+      (!sectionCode || element.sectionCode === sectionCode) &&
+      element.category === TemplateElementCategory.Question
+  ).length
+
+  if (numberOfAssignableElements === 0) return null
 
   // This could differ from currentUserAssignable list because self assignable assignments don't have assigner
   const currentlyAssigned = assignments.find(

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -37,8 +37,14 @@ const MainMenuBar: React.FC = () => {
             {strings.MENU_ITEM_DASHBOARD}
           </Link>
         </List.Item>
-        <List.Item>
+        {/* <List.Item>
           <Link to="/layout">Layout helpers</Link>
+        </List.Item> */}
+        <List.Item>
+          <Link to="/lookup-tables">Lookup Tables</Link>
+        </List.Item>
+        <List.Item>
+          <Link to="/outcomes">Outcomes</Link>
         </List.Item>
         <List.Item>
           <Link to="/application/new?type=UserEdit">Edit User Account</Link>

--- a/src/formElementPlugins/SummaryViewWrapper.tsx
+++ b/src/formElementPlugins/SummaryViewWrapper.tsx
@@ -8,6 +8,7 @@ import { buildParameters } from './ApplicationViewWrapper'
 import { useUserState } from '../contexts/UserState'
 import Markdown from '../utils/helpers/semanticReactMarkdown'
 import globalConfig from '../config.json'
+import { TemplateElementCategory } from '../utils/generated/graphql'
 
 const graphQLEndpoint = globalConfig.serverGraphQL
 
@@ -56,7 +57,10 @@ const SummaryViewWrapper: React.FC<SummaryViewWrapperProps> = ({
   const DefaultSummaryView: React.FC = () => {
     const combinedParams = { ...simpleParameters, ...evaluatedParameters }
     return (
-      <Form.Field className="element-summary-view" required={isRequired}>
+      <Form.Field
+        className="element-summary-view"
+        required={isRequired && element.category !== TemplateElementCategory.Information}
+      >
         {displayTitle && (
           <>
             <label style={{ color: 'black' }}>

--- a/src/formElementPlugins/listBuilder/src/SummaryView.tsx
+++ b/src/formElementPlugins/listBuilder/src/SummaryView.tsx
@@ -13,6 +13,7 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, respons
   const {
     displayType,
     inputFields,
+    label,
     displayFormat = getDefaultDisplayFormat(inputFields),
   } = parameters
 
@@ -25,10 +26,17 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, respons
     isEditable: false,
   }
 
-  return displayType === DisplayType.TABLE ? (
-    <ListTableLayout {...listDisplayProps} />
-  ) : (
-    <ListCardLayout {...listDisplayProps} />
+  return (
+    <>
+      <label>
+        <Markdown text={label} semanticComponent="noParagraph" />
+      </label>
+      {displayType === DisplayType.TABLE ? (
+        <ListTableLayout {...listDisplayProps} />
+      ) : (
+        <ListCardLayout {...listDisplayProps} />
+      )}
+    </>
   )
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,28 +36,29 @@ const App: React.FC = () => {
       link: authLink.concat(httpLink),
       cache,
     })
+    setClient(client)
 
-    persistCache({
-      cache,
-      storage: window.localStorage,
-      /**
-       * Storage options.
-       */
-      // Maximum size of cache to persist (in bytes).
-      // Defaults to 1048576 (1 MB). For unlimited cache size, provide false.
-      // If exceeded, persistence will pause and app will start up cold on next launch.
-      maxSize: false,
+    // persistCache({
+    //   cache,
+    //   storage: window.localStorage,
+    //   /**
+    //    * Storage options.
+    //    */
+    //   // Maximum size of cache to persist (in bytes).
+    //   // Defaults to 1048576 (1 MB). For unlimited cache size, provide false.
+    //   // If exceeded, persistence will pause and app will start up cold on next launch.
+    //   maxSize: false,
 
-      /**
-       * Debugging options.
-       */
-      // Enable console logging.
-      // debug: boolean,
-    }).then(() => {
-      // TODO: Check when this would run!
-      client.onResetStore(async () => cache.reset())
-      setClient(client)
-    })
+    //   /**
+    //    * Debugging options.
+    //    */
+    //   // Enable console logging.
+    //   // debug: boolean,
+    // }).then(() => {
+    //   // TODO: Check when this would run!
+    //   client.onResetStore(async () => cache.reset())
+    //   setClient(client)
+    // })
     return () => {}
   }, [])
 

--- a/src/utils/hooks/useGetApplicationStructure.tsx
+++ b/src/utils/hooks/useGetApplicationStructure.tsx
@@ -48,8 +48,6 @@ const useGetApplicationStructure = ({
   const [lastRefetchedTimestamp, setLastRefetchedTimestamp] = useState<number>(0)
   const [lastProcessedTimestamp, setLastProcessedTimestamp] = useState<number>(0)
 
-  const networkFetch = true // To-DO: make this conditional
-
   const { data, error } = useGetAllResponsesQuery({
     variables: {
       serial,
@@ -58,7 +56,7 @@ const useGetApplicationStructure = ({
         : [ApplicationResponseStatus.Submitted],
     },
     skip: !serial,
-    fetchPolicy: networkFetch ? 'network-only' : 'cache-first',
+    fetchPolicy: 'network-only',
   })
 
   // TODO - might need a use effect if serial is changes (navigated to another application from current page)

--- a/src/utils/hooks/useLoadTemplate.tsx
+++ b/src/utils/hooks/useLoadTemplate.tsx
@@ -65,7 +65,10 @@ const useLoadTemplate = ({ templateCode }: UseLoadTemplateProps) => {
     templateSections.forEach((section) => {
       const { templateElementsBySectionId } = section as TemplateSection
       templateElementsBySectionId.nodes.forEach((element) => {
-        if (element?.id && element.category === TemplateElementCategory.Question) {
+        if (
+          element?.id &&
+          (element.category === TemplateElementCategory.Question || element?.defaultValue !== null)
+        ) {
           elementsIds.push(element.id)
           elementsDefaults.push(element.defaultValue)
         }

--- a/src/utils/hooks/useSubmitApplication.tsx
+++ b/src/utils/hooks/useSubmitApplication.tsx
@@ -15,7 +15,7 @@ const useSubmitApplication = ({ serialNumber }: UseGetApplicationProps) => {
 
   const submit = async (structure: FullStructure) => {
     const elements = Object.values(structure.elementsById || {}).filter(
-      (element) => element.element.category === TemplateElementCategory.Question
+      (element) => !!element.latestApplicationResponse.id
     )
     const responsesPatch = elements.map(({ latestApplicationResponse }) => {
       return {

--- a/src/utils/hooks/useSubmitApplication.tsx
+++ b/src/utils/hooks/useSubmitApplication.tsx
@@ -15,7 +15,7 @@ const useSubmitApplication = ({ serialNumber }: UseGetApplicationProps) => {
 
   const submit = async (structure: FullStructure) => {
     const elements = Object.values(structure.elementsById || {}).filter(
-      (element) => !!element.latestApplicationResponse.id
+      (element) => !!element.latestApplicationResponse?.id
     )
     const responsesPatch = elements.map(({ latestApplicationResponse }) => {
       return {


### PR DESCRIPTION
Small bits added to demo server:

* Spacing between tables cells (for outcome table to not be squashing things
* Add label to list build summary view
* Show summary view if template category is information
* use network only and remove cache persist for graphQL queries (saw cache errors when loading/reloading snapshots, need investigation)
* silently ignore errors in outcomes
* link in top menu to outcomes and lookup tables