### PR TITLE
#787 Update inline decision with designs (option 2)

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -863,8 +863,9 @@ a:hover {
 }
 
 .blue-border {
-  border: 1px solid @interactiveHigh;
-  border-radius: 5px !important;
+  border: 2px solid @interactiveHigh;
+  border-radius: 10px !important;
+  overflow: clip;
 }
 
 .updated-label {

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -762,7 +762,7 @@ a:hover {
   }
 
   .response-container {
-    .flex-row-center();
+    .flex-row();
     width: 100%;
     padding: 14px;
     padding-right: 20px;
@@ -860,6 +860,11 @@ a:hover {
     border-bottom-left-radius: @borderRadius;
     border-bottom-right-radius: @borderRadius;
   }
+}
+
+.blue-border {
+  border: 1px solid @interactiveHigh;
+  border-radius: 5px !important;
 }
 
 .updated-label {

--- a/src/components/PageElements/Elements/ConsolidateReviewDecision.tsx
+++ b/src/components/PageElements/Elements/ConsolidateReviewDecision.tsx
@@ -31,56 +31,66 @@ const ConsolidateReviewDecision: React.FC<ConsolidateReviewDecisionProps> = ({
   const isConsolidation = true
   const decisionExists = !!reviewResponse?.decision
 
+  const triggerTitle = isNewReviewResponse
+    ? strings.BUTTON_RE_REVIEW_RESPONSE
+    : strings.BUTTON_REVIEW_RESPONSE
+
   return (
     <>
-      {/* Application Response */}
       <ApplicantResponseElement
         applicationResponse={applicationResponse}
         summaryViewProps={summaryViewProps}
       />
-      {/* Inline Review area */}
-      {isActiveEdit && (
-        <ReviewInlineInput
-          setIsActiveEdit={setIsActiveEdit}
-          reviewResponse={reviewResponse as ReviewResponse}
-          isConsolidation={isConsolidation}
-        />
-      )}
-      {/* Consolidation Response */}
-      {decisionExists && !isActiveEdit && (
-        <ReviewResponseElement
-          isCurrentReview={true}
-          isConsolidation={isConsolidation}
-          reviewResponse={
-            reviewResponse as ReviewResponse /* Casting to ReviewResponse since decision would exist if reviewResponse is defined */
-          }
-        >
-          {isActiveReviewResponse && <UpdateIcon onClick={() => setIsActiveEdit(true)} />}
-        </ReviewResponseElement>
-      )}
-      {/* Review Response */}
-      {originalReviewResponse && (
-        <ReviewResponseElement
-          isCurrentReview={false}
-          isConsolidation={false}
-          reviewResponse={originalReviewResponse}
-        >
-          {isActiveReviewResponse && !decisionExists && (
-            <ReviewElementTrigger
-              title={strings.BUTTON_REVIEW_RESPONSE}
-              onClick={() => setIsActiveEdit(true)}
-            />
+      {isActiveEdit ? (
+        /* Inline Review area + Review response in context*/
+        <div className="blue-border">
+          <ReviewResponseElement
+            isCurrentReview={false}
+            isConsolidation={false}
+            reviewResponse={originalReviewResponse as ReviewResponse}
+          />
+          <ReviewInlineInput
+            setIsActiveEdit={setIsActiveEdit}
+            reviewResponse={reviewResponse as ReviewResponse}
+            isConsolidation={isConsolidation}
+          />
+        </div>
+      ) : (
+        <>
+          {/* Current consolidator review response */}
+          {decisionExists && (
+            <ReviewResponseElement
+              isCurrentReview={true}
+              isConsolidation={true}
+              reviewResponse={reviewResponse}
+            >
+              {isActiveReviewResponse && <UpdateIcon onClick={() => setIsActiveEdit(true)} />}
+            </ReviewResponseElement>
           )}
-        </ReviewResponseElement>
+          {/* Lower level Review Response */}
+          <ReviewResponseElement
+            isCurrentReview={false}
+            isConsolidation={false}
+            reviewResponse={originalReviewResponse as ReviewResponse}
+          >
+            {!decisionExists && (
+              <ReviewElementTrigger
+                title={triggerTitle} // Review or Re-review
+                onClick={() => setIsActiveEdit(true)}
+              />
+            )}
+          </ReviewResponseElement>
+        </>
       )}
-      {isNewReviewResponse && previousReviewResponse && (
+      {/* Previous Consolidation Response */}
+      {isNewReviewResponse && !decisionExists && (
         <ReviewResponseElement
           isCurrentReview={false}
-          isConsolidation={true}
-          shouldDim={true}
+          isConsolidation={isConsolidation}
           reviewResponse={previousReviewResponse}
         />
       )}
+      {/*TODO: Add Previous lower level Review response here - Or show history icon */}
     </>
   )
 }

--- a/src/components/PageElements/Elements/ConsolidateReviewDecision.tsx
+++ b/src/components/PageElements/Elements/ConsolidateReviewDecision.tsx
@@ -37,6 +37,7 @@ const ConsolidateReviewDecision: React.FC<ConsolidateReviewDecisionProps> = ({
 
   return (
     <>
+      {/* Applicant Response */}
       <ApplicantResponseElement
         applicationResponse={applicationResponse}
         summaryViewProps={summaryViewProps}

--- a/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
+++ b/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
@@ -176,8 +176,6 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
               {/*TODO: Add Previous Applicant response here - Or show history icon */}
             </>
           )}
-          {/* div below forced border on review response to be square */}
-          <div />
         </>
       )
     default:

--- a/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
+++ b/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
@@ -7,6 +7,12 @@ import ReviewInlineInput from './ReviewInlineInput'
 import strings from '../../../utils/constants'
 import { UpdateIcon } from '../PageElements'
 
+type ReviewType =
+  | 'NotReviewable'
+  | 'FirstReviewApplication'
+  | 'UpdateChangesRequested'
+  | 'ReReviewApplication' // 'Consolidation' is done in separated component
+
 interface ReviewApplicantResponseProps {
   applicationResponse: ApplicationResponse
   summaryViewProps: SummaryViewWrapperProps
@@ -39,114 +45,148 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
   const consolidationReviewResponse = previousReviewResponse?.reviewResponsesByReviewResponseLinkId
     .nodes[0] as ReviewResponse // There is only one reviewResponse associated per review cycle
 
-  const getConsolidationAndReview = () => (
-    <>
-      {isChangeRequest && isChanged && (
-        <ReviewResponseElement
-          isCurrentReview={true}
-          isConsolidation={false}
-          reviewResponse={reviewResponse as ReviewResponse}
-        >
-          {getReviewDecisionOption()}
-        </ReviewResponseElement>
-      )}
-      {consolidationReviewResponse && (
-        <ReviewResponseElement
-          isCurrentReview={false}
-          isConsolidation={true}
-          reviewResponse={consolidationReviewResponse}
-          shouldDim={isChangeRequest && isChanged}
-        />
-      )}
-      {previousReviewResponse && !isChanged && (
-        <ReviewResponseElement
-          isCurrentReview={true}
-          isConsolidation={false}
-          reviewResponse={previousReviewResponse as ReviewResponse}
-        >
-          {getReviewDecisionOption()}
-        </ReviewResponseElement>
-      )}
-    </>
-  )
+  const reviewType: ReviewType = isNewApplicationResponse
+    ? 'ReReviewApplication'
+    : isChangeRequest
+    ? 'UpdateChangesRequested'
+    : isActiveReviewResponse
+    ? 'FirstReviewApplication'
+    : 'NotReviewable'
 
   const getReviewDecisionOption = () => {
-    if (!isActiveReviewResponse) return null
-    if (isChangeRequest && !isChanged)
+    if (isActiveReviewResponse && isChangeRequest && !isChanged)
       return (
         <ReviewElementTrigger
           title={strings.LABEL_RESPONSE_UPDATE}
           onClick={() => setIsActiveEdit(true)}
         />
       )
-    return <UpdateIcon onClick={() => setIsActiveEdit(true)} />
+    return null
   }
 
-  return (
-    <>
-      {isActiveEdit && !consolidationReviewResponse ? (
-        /* Inline Review area + Applicant response in context*/
-        <div className="blue-border">
-          <ApplicantResponseElement
-            applicationResponse={applicationResponse}
-            summaryViewProps={summaryViewProps}
-          />
-          <ReviewInlineInput
-            setIsActiveEdit={setIsActiveEdit}
-            reviewResponse={reviewResponse as ReviewResponse}
-            isConsolidation={false}
-          />
-        </div>
-      ) : (
+  console.log(reviewType)
+
+  switch (reviewType) {
+    case 'UpdateChangesRequested':
+      return (
         <>
-          {/* Application Response */}
-          <ApplicantResponseElement
-            applicationResponse={applicationResponse}
-            summaryViewProps={summaryViewProps}
-          >
-            {isActiveReviewResponse && !decisionExists && (
-              <ReviewElementTrigger
-                title={triggerTitle}
-                // onClick={showModal}
-                onClick={() => setIsActiveEdit(true)}
+          {isActiveEdit ? (
+            /* Inline Review area + Consolidation in context*/
+            <div className="blue-border">
+              <ReviewResponseElement
+                isCurrentReview={false}
+                isConsolidation={true}
+                reviewResponse={consolidationReviewResponse}
+                shouldDim={isChangeRequest && isChanged}
               />
-            )}
-          </ApplicantResponseElement>
-          {/* Previous review */}
-          {previousReviewResponse && (
-            <ReviewResponseElement
-              isCurrentReview={false}
-              isConsolidation={false}
-              reviewResponse={previousReviewResponse}
-              shouldDim={isChangeRequest && isChanged}
-            />
+              <ReviewInlineInput
+                setIsActiveEdit={setIsActiveEdit}
+                reviewResponse={reviewResponse as ReviewResponse}
+                isConsolidation={false}
+              />
+            </div>
+          ) : (
+            /* Consolidation Response + current or previous review (in cronological order) */
+            <>
+              {isChangeRequest && isChanged && (
+                <ReviewResponseElement
+                  isCurrentReview={true}
+                  isConsolidation={false}
+                  reviewResponse={reviewResponse}
+                >
+                  {isActiveReviewResponse && <UpdateIcon onClick={() => setIsActiveEdit(true)} />}
+                </ReviewResponseElement>
+              )}
+              {consolidationReviewResponse && (
+                <ReviewResponseElement
+                  isCurrentReview={false}
+                  isConsolidation={true}
+                  reviewResponse={consolidationReviewResponse}
+                  shouldDim={isChangeRequest && isChanged}
+                />
+              )}
+              {!isChanged && (
+                <ReviewResponseElement
+                  isCurrentReview={true}
+                  isConsolidation={false}
+                  reviewResponse={previousReviewResponse}
+                >
+                  {getReviewDecisionOption()}
+                </ReviewResponseElement>
+              )}
+            </>
           )}
+          {/* div below forced border on review response to be square */}
+          <div />
         </>
-      )}
-      {decisionExists &&
-        (isActiveEdit && consolidationReviewResponse ? (
-          /* Inline Review area + Previous review and consolidation in context*/
-          <div className="blue-border">
-            <ReviewResponseElement
-              isCurrentReview={false}
-              isConsolidation={true}
-              reviewResponse={consolidationReviewResponse}
-              shouldDim={isChangeRequest && isChanged}
-            />
-            <ReviewInlineInput
-              setIsActiveEdit={setIsActiveEdit}
-              reviewResponse={reviewResponse as ReviewResponse}
-              isConsolidation={false}
-            />
-          </div>
-        ) : (
-          /* Consolidation Response + current or previous review (in cronological order) */
-          getConsolidationAndReview()
-        ))}
-      {/* div below forced border on review response to be square */}
-      <div />
-    </>
-  )
+      )
+
+    case 'ReReviewApplication':
+    case 'FirstReviewApplication':
+      return (
+        <>
+          {isActiveEdit ? (
+            /* Inline Review area + Applicant response in context*/
+            <div className="blue-border">
+              <ApplicantResponseElement
+                applicationResponse={applicationResponse}
+                summaryViewProps={summaryViewProps}
+              />
+              <ReviewInlineInput
+                setIsActiveEdit={setIsActiveEdit}
+                reviewResponse={reviewResponse as ReviewResponse}
+                isConsolidation={false}
+              />
+            </div>
+          ) : (
+            <>
+              {/* Application Response */}
+              <ApplicantResponseElement
+                applicationResponse={applicationResponse}
+                summaryViewProps={summaryViewProps}
+              >
+                {isActiveReviewResponse && !decisionExists && (
+                  <ReviewElementTrigger
+                    title={triggerTitle} // Review or Re-review
+                    // onClick={showModal}
+                    onClick={() => setIsActiveEdit(true)}
+                  />
+                )}
+              </ApplicantResponseElement>
+              {/* Current review response */}
+              {decisionExists && (
+                <ReviewResponseElement
+                  isCurrentReview={true}
+                  isConsolidation={false}
+                  reviewResponse={reviewResponse}
+                >
+                  {isActiveReviewResponse && <UpdateIcon onClick={() => setIsActiveEdit(true)} />}
+                </ReviewResponseElement>
+              )}
+              {/* Previous review response */}
+              {isNewApplicationResponse && (
+                <ReviewResponseElement
+                  isCurrentReview={false}
+                  isConsolidation={false}
+                  reviewResponse={previousReviewResponse}
+                />
+              )}
+              {/*TODO: Add Previous Applicant response here */}
+            </>
+          )}
+          {/* div below forced border on review response to be square */}
+          <div />
+        </>
+      )
+    default:
+      // 'NotReviewable'
+      return (
+        <ApplicantResponseElement
+          applicationResponse={applicationResponse}
+          summaryViewProps={summaryViewProps}
+        />
+      )
+  }
 }
 
 // TODO: Unify code with other ReviewElementTrigger

--- a/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
+++ b/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
@@ -64,8 +64,6 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
     return null
   }
 
-  console.log(reviewType)
-
   switch (reviewType) {
     case 'UpdateChangesRequested':
       return (

--- a/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
+++ b/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
@@ -68,6 +68,11 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
     case 'UpdateChangesRequested':
       return (
         <>
+          {/* Applicant Response */}
+          <ApplicantResponseElement
+            applicationResponse={applicationResponse}
+            summaryViewProps={summaryViewProps}
+          />
           {isActiveEdit ? (
             /* Inline Review area + Consolidation in context*/
             <div className="blue-border">
@@ -84,8 +89,8 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
               />
             </div>
           ) : (
-            /* Consolidation Response + current or previous review (in cronological order) */
             <>
+              {/* Consolidation Response (in cronological order) */}
               {isChangeRequest && isChanged && (
                 <ReviewResponseElement
                   isCurrentReview={true}
@@ -143,10 +148,9 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
                 applicationResponse={applicationResponse}
                 summaryViewProps={summaryViewProps}
               >
-                {isActiveReviewResponse && !decisionExists && (
+                {!decisionExists && (
                   <ReviewElementTrigger
                     title={triggerTitle} // Review or Re-review
-                    // onClick={showModal}
                     onClick={() => setIsActiveEdit(true)}
                   />
                 )}
@@ -162,14 +166,14 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
                 </ReviewResponseElement>
               )}
               {/* Previous review response */}
-              {isNewApplicationResponse && (
+              {isNewApplicationResponse && !decisionExists && (
                 <ReviewResponseElement
                   isCurrentReview={false}
                   isConsolidation={false}
                   reviewResponse={previousReviewResponse}
                 />
               )}
-              {/*TODO: Add Previous Applicant response here */}
+              {/*TODO: Add Previous Applicant response here - Or show history icon */}
             </>
           )}
           {/* div below forced border on review response to be square */}

--- a/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
+++ b/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
@@ -39,6 +39,37 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
   const consolidationReviewResponse = previousReviewResponse?.reviewResponsesByReviewResponseLinkId
     .nodes[0] as ReviewResponse // There is only one reviewResponse associated per review cycle
 
+  const getConsolidationAndReview = () => (
+    <>
+      {isChangeRequest && isChanged && (
+        <ReviewResponseElement
+          isCurrentReview={true}
+          isConsolidation={false}
+          reviewResponse={reviewResponse as ReviewResponse}
+        >
+          {getReviewDecisionOption()}
+        </ReviewResponseElement>
+      )}
+      {consolidationReviewResponse && (
+        <ReviewResponseElement
+          isCurrentReview={false}
+          isConsolidation={true}
+          reviewResponse={consolidationReviewResponse}
+          shouldDim={isChangeRequest && isChanged}
+        />
+      )}
+      {previousReviewResponse && !isChanged && (
+        <ReviewResponseElement
+          isCurrentReview={true}
+          isConsolidation={false}
+          reviewResponse={previousReviewResponse as ReviewResponse}
+        >
+          {getReviewDecisionOption()}
+        </ReviewResponseElement>
+      )}
+    </>
+  )
+
   const getReviewDecisionOption = () => {
     if (!isActiveReviewResponse) return null
     if (isChangeRequest && !isChanged)
@@ -53,52 +84,56 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
 
   return (
     <>
-      {/* Application Response */}
-      <ApplicantResponseElement
-        applicationResponse={applicationResponse}
-        summaryViewProps={summaryViewProps}
-      >
-        {isActiveReviewResponse && !decisionExists && (
-          <ReviewElementTrigger
-            title={triggerTitle}
-            // onClick={showModal}
-            onClick={() => setIsActiveEdit(true)}
+      {isActiveEdit && !consolidationReviewResponse ? (
+        /* Inline Review area + Applicant response in context*/
+        <div className="blue-border">
+          <ApplicantResponseElement
+            applicationResponse={applicationResponse}
+            summaryViewProps={summaryViewProps}
           />
-        )}
-      </ApplicantResponseElement>
-      {/* Inline Review area */}
-      {isActiveEdit && (
-        <ReviewInlineInput
-          setIsActiveEdit={setIsActiveEdit}
-          reviewResponse={reviewResponse as ReviewResponse}
-          isConsolidation={false}
-        />
-      )}
-      {/* Review Response */}
-      {decisionExists && !isActiveEdit && (
-        <>
-          <ReviewResponseElement
-            isCurrentReview={true}
+          <ReviewInlineInput
+            setIsActiveEdit={setIsActiveEdit}
+            reviewResponse={reviewResponse as ReviewResponse}
             isConsolidation={false}
-            reviewResponse={
-              reviewResponse as ReviewResponse /* Casting to ReviewResponse since decision would exist if reviewResponse is defined */
-            }
-          >
-            {getReviewDecisionOption()}
-          </ReviewResponseElement>
-          {/* div below forced border on review response to be square */}
-          <div />
-          {/* Consolidation Response */}
-          {consolidationReviewResponse && (
+          />
+        </div>
+      ) : (
+        /* Application Response */
+        <ApplicantResponseElement
+          applicationResponse={applicationResponse}
+          summaryViewProps={summaryViewProps}
+        >
+          {isActiveReviewResponse && !decisionExists && (
+            <ReviewElementTrigger
+              title={triggerTitle}
+              // onClick={showModal}
+              onClick={() => setIsActiveEdit(true)}
+            />
+          )}
+        </ApplicantResponseElement>
+      )}
+      {decisionExists &&
+        (isActiveEdit && consolidationReviewResponse ? (
+          /* Inline Review area + Previous review and consolidation in context*/
+          <div className="blue-border">
             <ReviewResponseElement
               isCurrentReview={false}
               isConsolidation={true}
               reviewResponse={consolidationReviewResponse}
               shouldDim={isChangeRequest && isChanged}
             />
-          )}
-        </>
-      )}
+            <ReviewInlineInput
+              setIsActiveEdit={setIsActiveEdit}
+              reviewResponse={reviewResponse as ReviewResponse}
+              isConsolidation={false}
+            />
+          </div>
+        ) : (
+          /* Consolidation Response + current or previous review (in cronological order) */
+          getConsolidationAndReview()
+        ))}
+      {/* div below forced border on review response to be square */}
+      <div />
     </>
   )
 }

--- a/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
+++ b/src/components/PageElements/Elements/ReviewApplicantResponse.tsx
@@ -98,19 +98,30 @@ const ReviewApplicantResponse: React.FC<ReviewApplicantResponseProps> = ({
           />
         </div>
       ) : (
-        /* Application Response */
-        <ApplicantResponseElement
-          applicationResponse={applicationResponse}
-          summaryViewProps={summaryViewProps}
-        >
-          {isActiveReviewResponse && !decisionExists && (
-            <ReviewElementTrigger
-              title={triggerTitle}
-              // onClick={showModal}
-              onClick={() => setIsActiveEdit(true)}
+        <>
+          {/* Application Response */}
+          <ApplicantResponseElement
+            applicationResponse={applicationResponse}
+            summaryViewProps={summaryViewProps}
+          >
+            {isActiveReviewResponse && !decisionExists && (
+              <ReviewElementTrigger
+                title={triggerTitle}
+                // onClick={showModal}
+                onClick={() => setIsActiveEdit(true)}
+              />
+            )}
+          </ApplicantResponseElement>
+          {/* Previous review */}
+          {previousReviewResponse && (
+            <ReviewResponseElement
+              isCurrentReview={false}
+              isConsolidation={false}
+              reviewResponse={previousReviewResponse}
+              shouldDim={isChangeRequest && isChanged}
             />
           )}
-        </ApplicantResponseElement>
+        </>
       )}
       {decisionExists &&
         (isActiveEdit && consolidationReviewResponse ? (

--- a/src/components/PageElements/Elements/ReviewResponseElement.tsx
+++ b/src/components/PageElements/Elements/ReviewResponseElement.tsx
@@ -7,7 +7,7 @@ interface ReviewResponseElementProps {
   isConsolidation: boolean
   isDecisionVisible?: boolean
   shouldDim?: boolean
-  reviewResponse: ReviewResponse
+  reviewResponse?: ReviewResponse
   originalReviewResponse?: ReviewResponse
   isActiveEdit?: boolean
   setIsActiveEdit?: Function
@@ -23,6 +23,8 @@ const ReviewResponseElement: React.FC<ReviewResponseElementProps> = ({
 }) => {
   const backgroundClass = isCurrentReview ? 'changeable-background' : ''
   const dimClass = shouldDim ? 'dim' : ''
+
+  if (!reviewResponse) return null
 
   return (
     <div className={`response-container ${backgroundClass} ${dimClass}`}>


### PR DESCRIPTION
Fixes #787

### Linked branches
based on PR #788 

### Changes

As described in the issue, there are 3 cases to update with latest designs (using Option 2):
- [x] 1.a Review applicant response (first review)
- [x] 1.b Review new applicant response
- [x] 2 Update your review (after changes-requested by Consolidator)
- [x] 3 Review lower level review (Consolidation)

#### Designs
<img width="361" alt="Screen Shot 2021-06-15 at 5 10 20 PM" src="https://user-images.githubusercontent.com/16461988/121996383-9e868200-cdfc-11eb-84fb-26a31762af37.png">

Although keep in mind that we are limiting to show only 3 maximum of response-elements (anything that was submitted by one of the applicant's reviewer or the applicant himself). Soon we will have the "Show history" option to list anything else more than the latest 3. : )

#### Current: 1.a Review applicant response (first review):
Have tried to only change things strict related to this, with help from @CarlosNZ was able to not need to change existing less files so much - only added the `blue-border` around what needs to be in context with inline-decision and that's it.
<img width="644" alt="Screen Shot 2021-06-16 at 11 12 03 AM" src="https://user-images.githubusercontent.com/16461988/122137089-f58d6500-ce97-11eb-8ff9-0f1d2fc7a20b.png">
<img width="633" alt="Screen Shot 2021-06-16 at 11 12 16 AM" src="https://user-images.githubusercontent.com/16461988/122137097-f7efbf00-ce97-11eb-9bd0-b395926bf7da.png">

#### Current: 1.b Review new applicant response
We agreed that we won't have a duplicate text version of the Applicant's response, so using straight Applicant response:
<img width="645" alt="Screen Shot 2021-06-16 at 11 13 09 AM" src="https://user-images.githubusercontent.com/16461988/122137160-1eadf580-ce98-11eb-80b9-abbe129800a8.png">
After re-review should show exactly as "first review". So any previous reviews are only available in **Review History**.

#### Current: 2 Update your review (after changes-requested by Consolidator)
<img width="651" alt="Screen Shot 2021-06-15 at 4 49 38 PM" src="https://user-images.githubusercontent.com/16461988/121996392-a21a0900-cdfc-11eb-85b1-c4c948c5f99d.png">
<img width="634" alt="Screen Shot 2021-06-15 at 4 44 55 PM" src="https://user-images.githubusercontent.com/16461988/121996393-a21a0900-cdfc-11eb-9184-4955acc09913.png">

After is **Updated**:
<img width="639" alt="Screen Shot 2021-06-16 at 11 22 00 AM" src="https://user-images.githubusercontent.com/16461988/122137724-6b460080-ce99-11eb-8941-90001ac00d62.png">

#### Current: 3 Review lower level review (Consolidation)
<img width="638" alt="Screen Shot 2021-06-16 at 11 56 42 AM" src="https://user-images.githubusercontent.com/16461988/122138267-7b121480-ce9a-11eb-8ae1-147627493384.png">
<img width="627" alt="Screen Shot 2021-06-16 at 12 00 02 PM" src="https://user-images.githubusercontent.com/16461988/122138264-79e0e780-ce9a-11eb-9045-71c614096025.png">
<img width="637" alt="Screen Shot 2021-06-16 at 12 00 17 PM" src="https://user-images.githubusercontent.com/16461988/122138259-76e5f700-ce9a-11eb-946d-f262dcfa2cb1.png">
 
### Problems
**TODO**: Tiny problem on the top of blu-border collides with what is defined in here:
https://github.com/openmsupply/application-manager-web-app/blob/df78130bfea234e9474cb1943ad2c458cb17880a/semantic/src/site/globals/site.overrides#L849-L857
not sure how to fix that... Some review's help wanted : )