### PR TITLE
#777 Fix for empty file upload responses

### DIFF
--- a/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
+++ b/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
@@ -59,6 +59,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const fileInputRef = useRef<any>(null)
 
   useEffect(() => {
+    // Set response to null if no files
+    if (uploadedFiles.length === 0) {
+      onSave(null)
+      return
+    }
     // Only store files that aren't error or loading
     const fileDataToSave = uploadedFiles
       .filter(({ loading, error, fileData }) => !(loading || error) && fileData)


### PR DESCRIPTION
Fixes #777 

In the `useEffect` watching the "uploadedFiles" array, we now check if the length is 0, in which case we (re)set the saved response to `null`.