### PR TITLE
#818 Parameters not updating in Summary View

### DIFF
--- a/src/formElementPlugins/SummaryViewWrapper.tsx
+++ b/src/formElementPlugins/SummaryViewWrapper.tsx
@@ -36,7 +36,7 @@ const SummaryViewWrapper: React.FC<SummaryViewWrapperProps> = ({
   )
 
   useEffect(() => {
-    // Runs once on component mount
+    // Update dynamic parameters when responses change
     Object.entries(parameterExpressions).forEach(([field, expression]) => {
       evaluateExpression(expression as EvaluatorNode, {
         objects: {

--- a/src/formElementPlugins/SummaryViewWrapper.tsx
+++ b/src/formElementPlugins/SummaryViewWrapper.tsx
@@ -50,7 +50,7 @@ const SummaryViewWrapper: React.FC<SummaryViewWrapperProps> = ({
         setEvaluatedParameters((prevState) => ({ ...prevState, [field]: result }))
       )
     })
-  }, [])
+  }, [allResponses])
 
   if (!pluginCode || !isVisible) return null
 


### PR DESCRIPTION
Fixes #818 

Very simple fix -- the SummaryViewWrapper useEffect was not watching the "allResponses" object like the ApplicationViewWrapper was.

It didn't used to matter for the Summary page, as the parameters never changed after loading, but now that we're displaying SummaryView in application forms (for INFORMATION types), the parameters can change in response to other responses.