### PR TITLE
#816 Nested Listbuilder -- WIP

### DIFF
--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -159,10 +159,6 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
 
   if (!pluginCode || !isVisible) return null
 
-  console.log('element', element.code)
-  console.log('response', currentResponse)
-  console.log('validationState', validationState)
-
   const PluginComponent = (
     <ApplicationView
       onUpdate={onUpdate}

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -159,6 +159,10 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
 
   if (!pluginCode || !isVisible) return null
 
+  console.log('element', element.code)
+  console.log('response', currentResponse)
+  console.log('validationState', validationState)
+
   const PluginComponent = (
     <ApplicationView
       onUpdate={onUpdate}

--- a/src/formElementPlugins/listBuilder/constants.ts
+++ b/src/formElementPlugins/listBuilder/constants.ts
@@ -3,6 +3,7 @@ export default {
   BUTTON_ADD: 'Add',
   BUTTON_UPDATE: 'Update',
   BUTTON_DELETE: 'Delete item',
+  BUTTON_CANCEL: 'Cancel',
   ERROR_LIST_ITEMS_NOT_VALID:
     "Can't add item to list. There are invalid entries or incomplete required fields",
 }

--- a/src/formElementPlugins/listBuilder/constants.ts
+++ b/src/formElementPlugins/listBuilder/constants.ts
@@ -2,6 +2,7 @@ export default {
   BUTTON_LAUNCH_MODAL: 'Add item',
   BUTTON_ADD: 'Add',
   BUTTON_UPDATE: 'Update',
+  BUTTON_EDIT: 'Edit',
   BUTTON_DELETE: 'Delete item',
   BUTTON_CANCEL: 'Cancel',
   ERROR_LIST_ITEMS_NOT_VALID:

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -75,7 +75,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   // console.log('currentResponseElementsState', currentResponseElementsState)
 
   useEffect(() => {
-    console.log('Building elemens')
+    console.log('Building elements')
     buildElements(
       inputFields,
       allResponses,
@@ -193,6 +193,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       {inputState.currentElementsState &&
         inputFields.map((field: TemplateElement, index: number) => {
           const element = inputState.currentElementsState?.[field.code]
+          console.log('current Response', field.code, inputState.currentResponses[element.code])
           return (
             <ApplicationViewWrapper
               key={`list-${element.code}`}

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -60,19 +60,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   }
 
   const [inputState, setInputState] = useState<InputState>(defaultInputState)
-
-  // const [currentInputResponses, setCurrentInputResponses] = useState<ListItem>(
-  //   resetCurrentResponses(inputFields)
-  // )
-
   const [listItems, setListItems] = useState<ListItem[]>(initialValue?.list ?? [])
-  // const [selectedListItem, setSelectedListItem] = useState<number | null>(null)
-  // const [open, setOpen] = useState(false)
-  // const [inputError, setInputError] = useState(false)
-
-  // const [currentResponseElementsState, setCurrentResponseElementsState] = useState<any>()
-
-  // console.log('currentResponseElementsState', currentResponseElementsState)
 
   useEffect(() => {
     console.log('Building elements')
@@ -102,21 +90,14 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       // need to get most recent state of currentInputResponse, thus using callback
       setInputState((currentInputState) => {
         const newResponses = { ...currentInputState.currentResponses, [code]: response }
-        const error = anyErrorItems(newResponses, inputFields)
-        console.log('ERROR', error)
+        const error = !anyErrorItems(newResponses, inputFields) ? false : inputState.error
         return { ...currentInputState, currentResponses: newResponses, error }
       })
-      // setCurrentInputResponses((currentInputResponses) => {
-      //   const newResponses = { ...currentInputResponses, [code]: response }
-      //   if (!anyErrorItems(newResponses, inputFields)) setInputError(false)
-      //   return newResponses
-      // })
     }
 
   const updateList = async () => {
     if (anyErrorItems(inputState.currentResponses, inputFields)) {
       setInputState({ ...inputState, error: true })
-      // setInputError(true)
       return
     }
     // Add item
@@ -128,7 +109,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       newList[inputState.selectedListItemIndex] = inputState.currentResponses
       setListItems(newList)
     }
-    resetFormState()
+    setInputState(defaultInputState)
   }
 
   const editItem = async (index: number) => {
@@ -139,21 +120,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       selectedListItemIndex: index,
       isOpen: true,
     })
-    // setCurrentInputResponses(listItems[index])
-    // setOpen(true)
   }
 
   const deleteItem = async (index: number) => {
     setListItems(listItems.filter((_, i) => i !== index))
-    resetFormState()
-  }
-
-  const resetFormState = () => {
     setInputState(defaultInputState)
-    // setCurrentInputResponses(resetCurrentResponses(inputFields))
-    // setOpen(false)
-    // setSelectedListItem(null)
-    // setInputError(false)
   }
 
   const listDisplayProps: ListLayoutProps = {
@@ -235,7 +206,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     </>
   )
 
-  console.log('InputState', inputState)
   return (
     <>
       <label>
@@ -251,7 +221,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       {displayType !== DisplayType.INLINE && (
         <Modal
           size="tiny"
-          onClose={() => resetFormState()}
+          onClose={() => setInputState(defaultInputState)}
           onOpen={() => setInputState({ ...inputState, isOpen: true })}
           open={inputState.isOpen}
         >
@@ -260,7 +230,9 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
           </Segment>
         </Modal>
       )}
-      {displayType === DisplayType.INLINE && open && <Segment>{ListInputForm}</Segment>}
+      {displayType === DisplayType.INLINE && inputState.isOpen && (
+        <Segment>{ListInputForm}</Segment>
+      )}
       {DisplayComponent}
     </>
   )

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -157,7 +157,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       {currentResponseElementsState &&
         inputFields.map((field: TemplateElement, index: number) => {
           const element = currentResponseElementsState?.[field.code]
-          // console.log('Element', element)
           return (
             <ApplicationViewWrapper
               key={`list-${element.code}`}

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -61,11 +61,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   const [inputState, setInputState] = useState<InputState>(defaultInputState)
   const [listItems, setListItems] = useState<ListItem[]>(initialValue?.list ?? [])
-  const [DisplayComponent, setDisplayComponent] = useState(getDisplayComponent(displayType))
-
-  useEffect(() => {
-    setDisplayComponent(getDisplayComponent(displayType))
-  }, [displayType])
 
   useEffect(() => {
     console.log('Building elements')
@@ -113,9 +108,9 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       // Or update existing item
       const newList = [...listItems]
       console.log('UPdating', inputState.currentResponses)
-      newList[inputState.selectedListItemIndex] = inputState.currentResponses
+      newList[inputState.selectedListItemIndex] = { ...inputState.currentResponses }
       console.log('Updated', newList)
-      setListItems([...newList])
+      setListItems(newList)
       console.log('List items', listItems)
     }
     setInputState(defaultInputState)
@@ -135,37 +130,33 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     setInputState((prev) => defaultInputState)
   }
 
-  function getDisplayComponent(displayType: DisplayType) {
-    const listDisplayProps: ListLayoutProps = {
-      listItems,
-      displayFormat,
-      editItem: isEditable ? editItem : () => {},
-      deleteItem: isEditable ? deleteItem : () => {},
-      fieldTitles: inputFields.map((e: TemplateElement) => e.title),
-      codes: inputFields.map((e: TemplateElement) => e.code),
-      Markdown,
-      isEditable,
-    }
-    switch (displayType) {
-      case DisplayType.TABLE:
-        return <ListTableLayout {...listDisplayProps} />
-      case DisplayType.INLINE:
-        console.log('Checking Display')
-        return (
-          <ListInlineLayout
-            {...listDisplayProps}
-            inputFields={inputFields}
-            responses={allResponses}
-            currentUser={currentUser as User}
-            applicationData={applicationData}
-            editItemText={strings.BUTTON_EDIT}
-            deleteItemText={deleteItemText}
-          />
-        )
-      default:
-        return <ListCardLayout {...listDisplayProps} />
-    }
+  const listDisplayProps: ListLayoutProps = {
+    listItems,
+    displayFormat,
+    editItem: isEditable ? editItem : () => {},
+    deleteItem: isEditable ? deleteItem : () => {},
+    fieldTitles: inputFields.map((e: TemplateElement) => e.title),
+    codes: inputFields.map((e: TemplateElement) => e.code),
+    Markdown,
+    isEditable,
   }
+
+  const DisplayComponent =
+    displayType === DisplayType.TABLE ? (
+      <ListTableLayout {...listDisplayProps} />
+    ) : displayType === DisplayType.INLINE ? (
+      <ListInlineLayout
+        {...listDisplayProps}
+        inputFields={inputFields}
+        responses={allResponses}
+        currentUser={currentUser as User}
+        applicationData={applicationData}
+        editItemText={strings.BUTTON_EDIT}
+        deleteItemText={deleteItemText}
+      />
+    ) : (
+      <ListCardLayout {...listDisplayProps} />
+    )
 
   const ListInputForm = (
     <>

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -430,7 +430,7 @@ export const ListInlineLayout: React.FC<ListLayoutProps> = ({
   codes = [],
   Markdown,
   editItem = () => {},
-  // deleteItem = () => {},
+  deleteItem = () => {},
   isEditable = true,
   inputFields,
   responses,
@@ -438,7 +438,7 @@ export const ListInlineLayout: React.FC<ListLayoutProps> = ({
   applicationData,
 }) => {
   // Inner component -- one for each Item in list
-  const ItemAccordion: React.FC<any> = ({ item, header }) => {
+  const ItemAccordion: React.FC<any> = ({ item, header, index }) => {
     const [open, setOpen] = useState(false)
     const [currentItemElementsState, setItemResponseElementsState] = useState<any>()
     useEffect(() => {
@@ -460,11 +460,14 @@ export const ListInlineLayout: React.FC<ListLayoutProps> = ({
         <Accordion.Content active={open}>
           {codes.map((code, cellIndex) => (
             <SummaryViewWrapper
+              key={`item_${cellIndex}`}
               element={currentItemElementsState[code]}
               response={item[code].value}
               allResponses={responses}
             />
           ))}
+          <Button primary content={'EDIT'} onClick={() => editItem(index)} />
+          <Button secondary content={'DELETE'} onClick={() => deleteItem(index)} />
         </Accordion.Content>
       </Accordion>
     )
@@ -473,7 +476,7 @@ export const ListInlineLayout: React.FC<ListLayoutProps> = ({
   return (
     <>
       {listItems.map((item, index) => (
-        <ItemAccordion item={item} header={displayFormat.title} key={index} />
+        <ItemAccordion item={item} header={displayFormat.title} key={index} index={index} />
       ))}
     </>
   )

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -30,6 +30,7 @@ import { useUserState } from '../../../contexts/UserState'
 export enum DisplayType {
   CARDS = 'cards',
   TABLE = 'table',
+  INLINE = 'inline',
 }
 
 interface InputResponseField {

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -102,7 +102,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       setInputState((currentInputState) => {
         const newResponses = { ...currentInputState.currentResponses, [code]: response }
         const error = anyErrorItems(newResponses, inputFields)
-        return { ...currentInputState, currentResponses: newResponses, error: error }
+        return { ...currentInputState, currentResponses: newResponses, error }
       })
       // setCurrentInputResponses((currentInputResponses) => {
       //   const newResponses = { ...currentInputResponses, [code]: response }
@@ -193,6 +193,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       {inputState.currentElementsState &&
         inputFields.map((field: TemplateElement, index: number) => {
           const element = inputState.currentElementsState?.[field.code]
+          console.log(element.code, inputState.error)
           return (
             <ApplicationViewWrapper
               key={`list-${element.code}`}

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -98,10 +98,12 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const innerElementUpdate =
     (code: string) =>
     async ({ variables: response }: { variables: InputResponseField }) => {
+      console.log('UPDATING')
       // need to get most recent state of currentInputResponse, thus using callback
       setInputState((currentInputState) => {
         const newResponses = { ...currentInputState.currentResponses, [code]: response }
         const error = anyErrorItems(newResponses, inputFields)
+        console.log('ERROR', error)
         return { ...currentInputState, currentResponses: newResponses, error }
       })
       // setCurrentInputResponses((currentInputResponses) => {
@@ -193,7 +195,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       {inputState.currentElementsState &&
         inputFields.map((field: TemplateElement, index: number) => {
           const element = inputState.currentElementsState?.[field.code]
-          console.log(element.code, inputState.error)
           return (
             <ApplicationViewWrapper
               key={`list-${element.code}`}
@@ -234,6 +235,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     </>
   )
 
+  console.log('InputState', inputState)
   return (
     <>
       <label>

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -193,7 +193,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       {inputState.currentElementsState &&
         inputFields.map((field: TemplateElement, index: number) => {
           const element = inputState.currentElementsState?.[field.code]
-          console.log('current Response', field.code, inputState.currentResponses[element.code])
           return (
             <ApplicationViewWrapper
               key={`list-${element.code}`}

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -1,46 +1,20 @@
 import React, { useEffect, useState } from 'react'
-import {
-  Button,
-  Modal,
-  Form,
-  Segment,
-  Table,
-  TableHeaderCell,
-  TableCell,
-  Card,
-  Icon,
-  Label,
-  Accordion,
-} from 'semantic-ui-react'
+import { Button, Modal, Form, Segment, Icon } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
-import {
-  ApplicationDetails,
-  ElementState,
-  EvaluationOptions,
-  ResponseFull,
-  ResponsesByCode,
-  User,
-} from '../../../utils/types'
-import { TemplateElement, TemplateElementCategory } from '../../../utils/generated/graphql'
+import { User } from '../../../utils/types'
+import { DisplayType, InputResponseField, ListItem, ListLayoutProps } from './types'
+import { TemplateElement } from '../../../utils/generated/graphql'
 import ApplicationViewWrapper from '../../ApplicationViewWrapper'
-import SummaryViewWrapper from '../../SummaryViewWrapper'
+import {
+  buildElements,
+  getDefaultDisplayFormat,
+  resetCurrentResponses,
+  anyErrorItems,
+  createTextString,
+} from './helpers'
+import { ListCardLayout, ListTableLayout, ListInlineLayout } from './displayComponents'
 import strings from '../constants'
-import { evaluateElements } from '../../../utils/helpers/evaluateElements'
-import { defaultEvaluatedElement } from '../../../utils/hooks/useLoadApplication'
 import { useUserState } from '../../../contexts/UserState'
-
-export enum DisplayType {
-  CARDS = 'cards',
-  TABLE = 'table',
-  INLINE = 'inline',
-}
-
-interface InputResponseField {
-  isValid?: boolean
-  value: ResponseFull
-}
-
-type ListItem = { [code: string]: InputResponseField }
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
   element,
@@ -161,11 +135,17 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       DisplayComponent = <ListTableLayout {...listDisplayProps} />
       break
     case DisplayType.INLINE:
-      listDisplayProps.inputFields = inputFields
-      listDisplayProps.responses = allResponses
-      listDisplayProps.currentUser = currentUser as User
-      listDisplayProps.applicationData = applicationData
-      DisplayComponent = <ListInlineLayout {...listDisplayProps} />
+      DisplayComponent = (
+        <ListInlineLayout
+          {...listDisplayProps}
+          inputFields={inputFields}
+          responses={allResponses}
+          currentUser={currentUser as User}
+          applicationData={applicationData}
+          editItemText={strings.BUTTON_EDIT}
+          deleteItemText={deleteItemText}
+        />
+      )
       break
     default:
       DisplayComponent = <ListCardLayout {...listDisplayProps} />
@@ -241,243 +221,3 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 }
 
 export default ApplicationView
-
-const combineResponses = (allResponses: ResponsesByCode, currentInputResponses: ListItem) => {
-  const currentResponses = Object.entries(currentInputResponses).reduce(
-    (responses, [code, value]) => ({ ...responses, [code]: value?.value }),
-    {}
-  )
-  return { ...allResponses, ...currentResponses }
-}
-
-const buildElements = async (
-  fields: TemplateElement[],
-  allResponses: ResponsesByCode,
-  currentInputResponses: ListItem,
-  currentUser: User,
-  applicationData: ApplicationDetails
-) => {
-  const elements = fields.map((field, index) => ({
-    ...defaultEvaluatedElement,
-    id: index,
-    code: field.code,
-    pluginCode: field.elementTypePluginCode as string,
-    category: field.category as TemplateElementCategory,
-    title: field.title as string,
-    parameters: field.parameters,
-    validationExpression: field?.validation || true,
-    validationMessage: field?.validationMessage || '',
-    isVisibleExpression: field?.visibilityCondition || true,
-    isEditableExpression: field?.isEditable || true,
-    isRequiredExpression: field?.isRequired || false,
-    // "Dummy" values, but required for element props:
-    elementIndex: 0,
-    isValid: undefined,
-    page: 0,
-    sectionIndex: 0,
-    helpText: null,
-    sectionCode: '0',
-  }))
-  const evaluationOptions: EvaluationOptions = ['isEditable', 'isVisible', 'isRequired']
-  const evaluationObjects = {
-    responses: combineResponses(allResponses, currentInputResponses),
-    currentUser,
-    applicationData,
-  }
-  const evaluatedElements = await evaluateElements(elements, evaluationOptions, evaluationObjects)
-  const outputElements: { [key: string]: ElementState } = {}
-  for (let i = 0; i < elements.length; i++) {
-    outputElements[elements[i].code] = { ...elements[i], ...evaluatedElements[i] }
-  }
-  return outputElements
-}
-
-export const getDefaultDisplayFormat = (inputFields: TemplateElement[]) => {
-  const displayString = inputFields.reduce(
-    (acc: string, { code, title }) => acc + `**${title}**: \${${code}}  \n`,
-    ''
-  )
-  return { title: '', subtitle: '', description: displayString }
-}
-
-const resetCurrentResponses = (inputFields: TemplateElement[]) =>
-  inputFields.reduce((acc, { code }) => ({ ...acc, [code]: { value: { text: undefined } } }), {})
-
-const anyInvalidItems = (currentInput: ListItem) =>
-  Object.values(currentInput).some((response) => response.isValid === false)
-
-const anyIncompleteItems = (currentInput: ListItem, inputFields: TemplateElement[]) =>
-  Object.values(currentInput).some(
-    (response, index) => inputFields[index]?.isRequired !== false && !response.value?.text
-  )
-
-const anyErrorItems = (currentInput: ListItem, inputFields: TemplateElement[]) =>
-  anyInvalidItems(currentInput) || anyIncompleteItems(currentInput, inputFields)
-
-const substituteValues = (parameterisedString: string, item: ListItem) => {
-  const getValueFromCode = (_: string, $: string, code: string) => item[code]?.value?.text || ''
-  return parameterisedString.replace(/(\${)(.*?)(})/gm, getValueFromCode)
-}
-
-const createTextString = (listItems: ListItem[], inputFields: TemplateElement[]) =>
-  listItems.reduce(
-    (outputAcc, item) =>
-      outputAcc +
-      inputFields.reduce(
-        (innerAcc, field) => innerAcc + `${field.title}: ${item[field.code]?.value?.text}, `,
-        ''
-      ) +
-      '\n',
-    ''
-  )
-
-// Separate components, so can be shared with SummaryView
-export interface ListLayoutProps {
-  listItems: ListItem[]
-  displayFormat: { title?: string; subtitle?: string; description: string }
-  Markdown: any
-  fieldTitles?: string[]
-  codes?: string[]
-  editItem?: (index: number) => void
-  deleteItem?: (index: number) => void
-  isEditable?: boolean
-  // These values required for SummaryView in Inline layout
-  elements?: any
-  inputFields?: any
-  responses?: any
-  currentUser?: User
-  applicationData?: ApplicationDetails
-}
-
-export const ListCardLayout: React.FC<ListLayoutProps> = ({
-  listItems,
-  displayFormat,
-  editItem = () => {},
-  deleteItem = () => {},
-  Markdown,
-  isEditable = true,
-}) => {
-  const { title, subtitle, description } = displayFormat
-  return (
-    <>
-      {listItems.map((item, index) => (
-        <Card key={`list-item-${index}`}>
-          <Card.Content>
-            {isEditable && (
-              <Label floating onClick={() => deleteItem(index)}>
-                <Icon name="delete" />
-              </Label>
-            )}
-            {title && (
-              <Card.Header onClick={() => editItem(index)}>
-                <Markdown text={substituteValues(title, item)} semanticComponent="noParagraph" />
-              </Card.Header>
-            )}
-            {subtitle && (
-              <Card.Meta onClick={() => editItem(index)}>
-                <Markdown text={substituteValues(subtitle, item)} semanticComponent="noParagraph" />
-              </Card.Meta>
-            )}
-            {description && (
-              <Card.Description onClick={() => editItem(index)}>
-                <Markdown
-                  text={substituteValues(description, item)}
-                  semanticComponent="noParagraph"
-                />
-              </Card.Description>
-            )}
-          </Card.Content>
-        </Card>
-      ))}
-    </>
-  )
-}
-
-export const ListTableLayout: React.FC<ListLayoutProps> = ({
-  listItems,
-  fieldTitles = [],
-  codes = [],
-  editItem = () => {},
-  // deleteItem = () => {},
-  isEditable = true,
-}) => {
-  return (
-    <Table celled selectable={isEditable}>
-      <Table.Header>
-        <Table.Row>
-          {fieldTitles.map((title) => (
-            <TableHeaderCell key={`list-header-field-${title}`}>{title}</TableHeaderCell>
-          ))}
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        {listItems.map((item, index) => (
-          <Table.Row key={`list-row-${index}`} onClick={() => editItem(index)}>
-            {codes.map((code, cellIndex) => (
-              <TableCell key={`list-cell-${index}-${cellIndex}`}>{item[code].value.text}</TableCell>
-            ))}
-          </Table.Row>
-        ))}
-      </Table.Body>
-    </Table>
-  )
-}
-
-export const ListInlineLayout: React.FC<ListLayoutProps> = ({
-  listItems,
-  displayFormat,
-  fieldTitles = [],
-  codes = [],
-  Markdown,
-  editItem = () => {},
-  deleteItem = () => {},
-  isEditable = true,
-  inputFields,
-  responses,
-  currentUser,
-  applicationData,
-}) => {
-  // Inner component -- one for each Item in list
-  const ItemAccordion: React.FC<any> = ({ item, header, index }) => {
-    const [open, setOpen] = useState(false)
-    const [currentItemElementsState, setItemResponseElementsState] = useState<any>()
-    useEffect(() => {
-      buildElements(
-        inputFields,
-        responses,
-        item,
-        currentUser as User,
-        applicationData as ApplicationDetails
-      ).then((elements) => setItemResponseElementsState(elements))
-    }, [])
-    if (!currentItemElementsState) return null
-    return (
-      <Accordion styled style={{ marginBottom: 5, marginTop: 10 }}>
-        <Accordion.Title active={open} onClick={() => setOpen(!open)}>
-          <Icon name="dropdown" />
-          <Markdown text={substituteValues(header, item)} semanticComponent="noParagraph" />
-        </Accordion.Title>
-        <Accordion.Content active={open}>
-          {codes.map((code, cellIndex) => (
-            <SummaryViewWrapper
-              key={`item_${cellIndex}`}
-              element={currentItemElementsState[code]}
-              response={item[code].value}
-              allResponses={responses}
-            />
-          ))}
-          <Button primary content={'EDIT'} onClick={() => editItem(index)} />
-          <Button secondary content={'DELETE'} onClick={() => deleteItem(index)} />
-        </Accordion.Content>
-      </Accordion>
-    )
-  }
-
-  return (
-    <>
-      {listItems.map((item, index) => (
-        <ItemAccordion item={item} header={displayFormat.title} key={index} index={index} />
-      ))}
-    </>
-  )
-}

--- a/src/formElementPlugins/listBuilder/src/SummaryView.tsx
+++ b/src/formElementPlugins/listBuilder/src/SummaryView.tsx
@@ -1,13 +1,9 @@
 import React from 'react'
 import { TemplateElement } from '../../../utils/generated/graphql'
 import { SummaryViewProps } from '../../types'
-import {
-  ListCardLayout,
-  ListTableLayout,
-  ListLayoutProps,
-  DisplayType,
-  getDefaultDisplayFormat,
-} from './ApplicationView'
+import { ListCardLayout, ListTableLayout, ListInlineLayout } from './displayComponents'
+import { getDefaultDisplayFormat } from './helpers'
+import { DisplayType, ListLayoutProps } from './types'
 
 const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
   const {

--- a/src/formElementPlugins/listBuilder/src/displayComponents/ListCardLayout.tsx
+++ b/src/formElementPlugins/listBuilder/src/displayComponents/ListCardLayout.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Card, Icon, Label } from 'semantic-ui-react'
+import { ListLayoutProps } from '../types'
+import { substituteValues } from '../helpers'
+
+const ListCardLayout: React.FC<ListLayoutProps> = ({
+  listItems,
+  displayFormat,
+  editItem = () => {},
+  deleteItem = () => {},
+  Markdown,
+  isEditable = true,
+}) => {
+  const { title, subtitle, description } = displayFormat
+  return (
+    <>
+      {listItems.map((item, index) => (
+        <Card key={`list-item-${index}`}>
+          <Card.Content>
+            {isEditable && (
+              <Label floating onClick={() => deleteItem(index)}>
+                <Icon name="delete" />
+              </Label>
+            )}
+            {title && (
+              <Card.Header onClick={() => editItem(index)}>
+                <Markdown text={substituteValues(title, item)} semanticComponent="noParagraph" />
+              </Card.Header>
+            )}
+            {subtitle && (
+              <Card.Meta onClick={() => editItem(index)}>
+                <Markdown text={substituteValues(subtitle, item)} semanticComponent="noParagraph" />
+              </Card.Meta>
+            )}
+            {description && (
+              <Card.Description onClick={() => editItem(index)}>
+                <Markdown
+                  text={substituteValues(description, item)}
+                  semanticComponent="noParagraph"
+                />
+              </Card.Description>
+            )}
+          </Card.Content>
+        </Card>
+      ))}
+    </>
+  )
+}
+
+export default ListCardLayout

--- a/src/formElementPlugins/listBuilder/src/displayComponents/ListInlineLayout.tsx
+++ b/src/formElementPlugins/listBuilder/src/displayComponents/ListInlineLayout.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react'
 import { Button, Icon, Accordion } from 'semantic-ui-react'
 import { ApplicationDetails, User } from '../../../../utils/types'
 import { ListLayoutProps } from '../types'
-
 import ApplicationViewWrapper from '../../../ApplicationViewWrapper'
 import SummaryViewWrapper from '../../../SummaryViewWrapper'
 import { buildElements, substituteValues } from '../helpers'
+import '../styles.css'
 
 const ListInlineLayout: React.FC<ListLayoutProps> = ({
   listItems,
@@ -36,7 +36,11 @@ const ListInlineLayout: React.FC<ListLayoutProps> = ({
     }, [])
     if (!currentItemElementsState) return null
     return (
-      <Accordion styled style={{ marginBottom: 5, marginTop: 10 }}>
+      <Accordion
+        styled
+        className="accordion-container"
+        style={{ maxWidth: open ? 'none' : '100%' }}
+      >
         <Accordion.Title active={open} onClick={() => setOpen(!open)}>
           <Icon name="dropdown" />
           <Markdown text={substituteValues(header, item)} semanticComponent="noParagraph" />

--- a/src/formElementPlugins/listBuilder/src/displayComponents/ListInlineLayout.tsx
+++ b/src/formElementPlugins/listBuilder/src/displayComponents/ListInlineLayout.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react'
+import { Button, Icon, Accordion } from 'semantic-ui-react'
+import { ApplicationDetails, User } from '../../../../utils/types'
+import { ListLayoutProps } from '../types'
+
+import ApplicationViewWrapper from '../../../ApplicationViewWrapper'
+import SummaryViewWrapper from '../../../SummaryViewWrapper'
+import { buildElements, substituteValues } from '../helpers'
+
+const ListInlineLayout: React.FC<ListLayoutProps> = ({
+  listItems,
+  displayFormat,
+  fieldTitles = [],
+  codes = [],
+  Markdown,
+  editItem = () => {},
+  deleteItem = () => {},
+  isEditable = true,
+  inputFields,
+  responses,
+  currentUser,
+  applicationData,
+}) => {
+  // Inner component -- one for each Item in list
+  const ItemAccordion: React.FC<any> = ({ item, header, index }) => {
+    const [open, setOpen] = useState(false)
+    const [currentItemElementsState, setItemResponseElementsState] = useState<any>()
+    useEffect(() => {
+      buildElements(
+        inputFields,
+        responses,
+        item,
+        currentUser as User,
+        applicationData as ApplicationDetails
+      ).then((elements) => setItemResponseElementsState(elements))
+    }, [])
+    if (!currentItemElementsState) return null
+    return (
+      <Accordion styled style={{ marginBottom: 5, marginTop: 10 }}>
+        <Accordion.Title active={open} onClick={() => setOpen(!open)}>
+          <Icon name="dropdown" />
+          <Markdown text={substituteValues(header, item)} semanticComponent="noParagraph" />
+        </Accordion.Title>
+        <Accordion.Content active={open}>
+          {codes.map((code, cellIndex) => (
+            <SummaryViewWrapper
+              key={`item_${cellIndex}`}
+              element={currentItemElementsState[code]}
+              response={item[code].value}
+              allResponses={responses}
+            />
+          ))}
+          <Button primary content={'EDIT'} onClick={() => editItem(index)} />
+          <Button secondary content={'DELETE'} onClick={() => deleteItem(index)} />
+        </Accordion.Content>
+      </Accordion>
+    )
+  }
+
+  return (
+    <>
+      {listItems.map((item, index) => (
+        <ItemAccordion item={item} header={displayFormat.title} key={index} index={index} />
+      ))}
+    </>
+  )
+}
+
+export default ListInlineLayout

--- a/src/formElementPlugins/listBuilder/src/displayComponents/ListInlineLayout.tsx
+++ b/src/formElementPlugins/listBuilder/src/displayComponents/ListInlineLayout.tsx
@@ -48,7 +48,7 @@ const ListInlineLayout: React.FC<ListLayoutProps> = ({
         <Accordion.Content active={open}>
           {codes.map((code, cellIndex) => (
             <SummaryViewWrapper
-              key={`item_${cellIndex}`}
+              key={`item_accordion_${cellIndex}`}
               element={currentItemElementsState[code]}
               response={item[code].value}
               allResponses={responses}

--- a/src/formElementPlugins/listBuilder/src/displayComponents/ListTableLayout.tsx
+++ b/src/formElementPlugins/listBuilder/src/displayComponents/ListTableLayout.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Table, TableHeaderCell, TableCell } from 'semantic-ui-react'
+import { ListLayoutProps } from '../types'
+
+const ListTableLayout: React.FC<ListLayoutProps> = ({
+  listItems,
+  fieldTitles = [],
+  codes = [],
+  editItem = () => {},
+  // deleteItem = () => {},
+  isEditable = true,
+}) => {
+  return (
+    <Table celled selectable={isEditable}>
+      <Table.Header>
+        <Table.Row>
+          {fieldTitles.map((title) => (
+            <TableHeaderCell key={`list-header-field-${title}`}>{title}</TableHeaderCell>
+          ))}
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {listItems.map((item, index) => (
+          <Table.Row key={`list-row-${index}`} onClick={() => editItem(index)}>
+            {codes.map((code, cellIndex) => (
+              <TableCell key={`list-cell-${index}-${cellIndex}`}>{item[code].value.text}</TableCell>
+            ))}
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  )
+}
+
+export default ListTableLayout

--- a/src/formElementPlugins/listBuilder/src/displayComponents/ListTableLayout.tsx
+++ b/src/formElementPlugins/listBuilder/src/displayComponents/ListTableLayout.tsx
@@ -23,7 +23,9 @@ const ListTableLayout: React.FC<ListLayoutProps> = ({
         {listItems.map((item, index) => (
           <Table.Row key={`list-row-${index}`} onClick={() => editItem(index)}>
             {codes.map((code, cellIndex) => (
-              <TableCell key={`list-cell-${index}-${cellIndex}`}>{item[code].value.text}</TableCell>
+              <TableCell key={`list-cell-${index}-${cellIndex}`}>
+                {item[code]?.value?.text}
+              </TableCell>
             ))}
           </Table.Row>
         ))}

--- a/src/formElementPlugins/listBuilder/src/displayComponents/index.tsx
+++ b/src/formElementPlugins/listBuilder/src/displayComponents/index.tsx
@@ -1,0 +1,5 @@
+import ListCardLayout from './ListCardLayout'
+import ListTableLayout from './ListTableLayout'
+import ListInlineLayout from './ListInlineLayout'
+
+export { ListCardLayout, ListTableLayout, ListInlineLayout }

--- a/src/formElementPlugins/listBuilder/src/helpers.ts
+++ b/src/formElementPlugins/listBuilder/src/helpers.ts
@@ -1,0 +1,112 @@
+import { ApplicationViewProps } from '../../types'
+import {
+  ApplicationDetails,
+  ElementState,
+  EvaluationOptions,
+  ResponseFull,
+  ResponsesByCode,
+  User,
+} from '../../../utils/types'
+import { TemplateElement, TemplateElementCategory } from '../../../utils/generated/graphql'
+import ApplicationViewWrapper from '../../ApplicationViewWrapper'
+import SummaryViewWrapper from '../../SummaryViewWrapper'
+import strings from '../constants'
+import { evaluateElements } from '../../../utils/helpers/evaluateElements'
+import { defaultEvaluatedElement } from '../../../utils/hooks/useLoadApplication'
+import { useUserState } from '../../../contexts/UserState'
+import { DisplayType, InputResponseField, ListItem, ListLayoutProps } from './types'
+
+// Formatting and Text manipulation
+export const getDefaultDisplayFormat = (inputFields: TemplateElement[]) => {
+  const displayString = inputFields.reduce(
+    (acc: string, { code, title }) => acc + `**${title}**: \${${code}}  \n`,
+    ''
+  )
+  return { title: '', subtitle: '', description: displayString }
+}
+
+export const substituteValues = (parameterisedString: string, item: ListItem) => {
+  const getValueFromCode = (_: string, $: string, code: string) => item[code]?.value?.text || ''
+  return parameterisedString.replace(/(\${)(.*?)(})/gm, getValueFromCode)
+}
+
+export const createTextString = (listItems: ListItem[], inputFields: TemplateElement[]) =>
+  listItems.reduce(
+    (outputAcc, item) =>
+      outputAcc +
+      inputFields.reduce(
+        (innerAcc, field) => innerAcc + `${field.title}: ${item[field.code]?.value?.text}, `,
+        ''
+      ) +
+      '\n',
+    ''
+  )
+
+// Data validation and state reset
+export const resetCurrentResponses = (inputFields: TemplateElement[]) =>
+  inputFields.reduce((acc, { code }) => ({ ...acc, [code]: { value: { text: undefined } } }), {})
+
+export const anyInvalidItems = (currentInput: ListItem) =>
+  Object.values(currentInput).some((response) => response.isValid === false)
+
+export const anyIncompleteItems = (currentInput: ListItem, inputFields: TemplateElement[]) =>
+  Object.values(currentInput).some(
+    (response, index) => inputFields[index]?.isRequired !== false && !response.value?.text
+  )
+
+export const anyErrorItems = (currentInput: ListItem, inputFields: TemplateElement[]) =>
+  anyInvalidItems(currentInput) || anyIncompleteItems(currentInput, inputFields)
+
+// Building elements
+export const combineResponses = (
+  allResponses: ResponsesByCode,
+  currentInputResponses: ListItem
+) => {
+  const currentResponses = Object.entries(currentInputResponses).reduce(
+    (responses, [code, value]) => ({ ...responses, [code]: value?.value }),
+    {}
+  )
+  return { ...allResponses, ...currentResponses }
+}
+
+export const buildElements = async (
+  fields: TemplateElement[],
+  allResponses: ResponsesByCode,
+  currentInputResponses: ListItem,
+  currentUser: User,
+  applicationData: ApplicationDetails
+) => {
+  const elements = fields.map((field, index) => ({
+    ...defaultEvaluatedElement,
+    id: index,
+    code: field.code,
+    pluginCode: field.elementTypePluginCode as string,
+    category: field.category as TemplateElementCategory,
+    title: field.title as string,
+    parameters: field.parameters,
+    validationExpression: field?.validation || true,
+    validationMessage: field?.validationMessage || '',
+    isVisibleExpression: field?.visibilityCondition || true,
+    isEditableExpression: field?.isEditable || true,
+    isRequiredExpression: field?.isRequired || false,
+    // "Dummy" values, but required for element props:
+    elementIndex: 0,
+    isValid: undefined,
+    page: 0,
+    sectionIndex: 0,
+    helpText: null,
+    sectionCode: '0',
+  }))
+  const evaluationOptions: EvaluationOptions = ['isEditable', 'isVisible', 'isRequired']
+  const evaluationObjects = {
+    responses: combineResponses(allResponses, currentInputResponses),
+    currentUser,
+    applicationData,
+  }
+  const evaluatedElements = await evaluateElements(elements, evaluationOptions, evaluationObjects)
+  const outputElements: { [key: string]: ElementState } = {}
+  for (let i = 0; i < elements.length; i++) {
+    outputElements[elements[i].code] = { ...elements[i], ...evaluatedElements[i] }
+  }
+  return outputElements
+}

--- a/src/formElementPlugins/listBuilder/src/styles.css
+++ b/src/formElementPlugins/listBuilder/src/styles.css
@@ -1,0 +1,4 @@
+.accordion-container {
+  margin-bottom: 5px;
+  margin-top: 10px;
+}

--- a/src/formElementPlugins/listBuilder/src/types.ts
+++ b/src/formElementPlugins/listBuilder/src/types.ts
@@ -1,19 +1,5 @@
 import { ApplicationViewProps } from '../../types'
-import {
-  ApplicationDetails,
-  ElementState,
-  EvaluationOptions,
-  ResponseFull,
-  ResponsesByCode,
-  User,
-} from '../../../utils/types'
-import { TemplateElement, TemplateElementCategory } from '../../../utils/generated/graphql'
-import ApplicationViewWrapper from '../../ApplicationViewWrapper'
-import SummaryViewWrapper from '../../SummaryViewWrapper'
-import strings from '../constants'
-import { evaluateElements } from '../../../utils/helpers/evaluateElements'
-import { defaultEvaluatedElement } from '../../../utils/hooks/useLoadApplication'
-import { useUserState } from '../../../contexts/UserState'
+import { ApplicationDetails, ResponseFull, User } from '../../../utils/types'
 
 export enum DisplayType {
   CARDS = 'cards',

--- a/src/formElementPlugins/listBuilder/src/types.ts
+++ b/src/formElementPlugins/listBuilder/src/types.ts
@@ -1,0 +1,48 @@
+import { ApplicationViewProps } from '../../types'
+import {
+  ApplicationDetails,
+  ElementState,
+  EvaluationOptions,
+  ResponseFull,
+  ResponsesByCode,
+  User,
+} from '../../../utils/types'
+import { TemplateElement, TemplateElementCategory } from '../../../utils/generated/graphql'
+import ApplicationViewWrapper from '../../ApplicationViewWrapper'
+import SummaryViewWrapper from '../../SummaryViewWrapper'
+import strings from '../constants'
+import { evaluateElements } from '../../../utils/helpers/evaluateElements'
+import { defaultEvaluatedElement } from '../../../utils/hooks/useLoadApplication'
+import { useUserState } from '../../../contexts/UserState'
+
+export enum DisplayType {
+  CARDS = 'cards',
+  TABLE = 'table',
+  INLINE = 'inline',
+}
+
+export interface InputResponseField {
+  isValid?: boolean
+  value: ResponseFull
+}
+
+export type ListItem = { [code: string]: InputResponseField }
+
+export interface ListLayoutProps {
+  listItems: ListItem[]
+  displayFormat: { title?: string; subtitle?: string; description: string }
+  Markdown: any
+  fieldTitles?: string[]
+  codes?: string[]
+  editItem?: (index: number) => void
+  deleteItem?: (index: number) => void
+  isEditable?: boolean
+  // These values required for SummaryView in Inline layout
+  elements?: any
+  inputFields?: any
+  responses?: any
+  currentUser?: User
+  applicationData?: ApplicationDetails
+  editItemText?: string
+  deleteItemText?: string
+}


### PR DESCRIPTION
Just putting this here so @andreievg can have a look if you want. 

Back-end branch is `#816F-nested-list-builders` (Inline listbuilder is in "Drug Registration - General Medicines Procedure", Ingredients Page 1)

I've significantly tidied up the plugin, separating into different files for easier structure.

I haven't managed to get the Edit working for the Inline version of the plugin, as we're still getting the re-renders of the child components, not sure how to fix.

For some reason, the "outer" component (ApplicationView) is running multiple times when it loads, each time which causes its children (the DisplayComponent and its children) to be re-instantiated with initial values.

Same when the response changes -- it causes a "save" which causes "allResponses" all the way up in the structure to update, so all children get re-run -- so the list ApplicationVIew re-loads and its children get reset. You can see this most clearly when you open one of the list Accordions, and click "edit" -- we see the inline form appear, but the accordion itself is closed even though there was never any `setOpen(false)` called on it -- it's been re-initialised. 

We need to figure out how to deal with this problem before I can embed an editable form inside the Accordions (it should be straightforward after that)