### PR TITLE
Search plugin fix - use currentUser and applicationData for search query evaluation

### DIFF
--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -3,6 +3,7 @@ const DEBOUNCE_TIMEOUT = 350 //milliseconds
 import React, { useEffect, useState } from 'react'
 import { Search, Label, Card, Icon } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
+import { useUserState } from '../../../contexts/UserState'
 import strings from '../constants'
 import evaluateExpression from '@openmsupply/expression-evaluator'
 import useDebounce from './useDebounce'
@@ -35,6 +36,10 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     textFormat,
   } = parameters
 
+  const {
+    userState: { currentUser },
+  } = useUserState()
+
   const graphQLEndpoint = applicationData.config.serverGraphQL
 
   const [searchText, setSearchText] = useState('')
@@ -52,7 +57,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         : selection.length > 0
         ? JSON.stringify(selection)
         : undefined,
-      // text: selection.length > 0 ? JSON.stringify(selection) : undefined,
       selection: selection,
     })
   }, [selection])
@@ -65,7 +69,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const evaluateSearchQuery = (text: string) => {
     const search = { text }
     evaluateExpression(source, {
-      objects: { search },
+      objects: { search, currentUser, applicationData },
       APIfetch: fetch,
       graphQLConnection: { fetch: fetch.bind(window), endpoint: graphQLEndpoint },
     })

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -22,6 +22,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   onSave,
   Markdown,
   applicationData,
+  allResponses,
 }) => {
   const {
     label,
@@ -69,7 +70,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const evaluateSearchQuery = (text: string) => {
     const search = { text }
     evaluateExpression(source, {
-      objects: { search, currentUser, applicationData },
+      objects: { search, currentUser, applicationData, responses: allResponses },
       APIfetch: fetch,
       graphQLConnection: { fetch: fetch.bind(window), endpoint: graphQLEndpoint },
     })


### PR DESCRIPTION
Quick fix for the problem @nmadruga describes [here](https://github.com/openmsupply/application-manager-server/pull/451#issue-687480490)

Have added `currentUser`, `applicationData` and `responses` as part of "objects" in the search query evaluation.