### PR TITLE
#846 Fix problem with draft reviews not changed showing on history

### DIFF
--- a/src/utils/hooks/useGetReviewStructureForSection/helpers.tsx
+++ b/src/utils/hooks/useGetReviewStructureForSection/helpers.tsx
@@ -217,6 +217,16 @@ const addAllReviewResponses = (structure: FullStructure, data: GetReviewResponse
     (element, response) => (element.previousOriginalReviewResponse = response)
   )
 
+  const isUpdatedDecision = (
+    latestReviewResponse?: ReviewResponse,
+    previousReviewResponse?: ReviewResponse
+  ) => {
+    if (!latestReviewResponse || !previousReviewResponse) return false
+    const { decision: latestDecision, comment: lastestComment } = latestReviewResponse
+    const { decision: previousDecision, comment: previousComment } = previousReviewResponse
+    return latestDecision !== previousDecision || lastestComment !== previousComment
+  }
+
   Object.entries(structure?.elementsById || {}).forEach(([id, element]) => {
     const elementThisReviewResponses = thisReviewResponses.filter(
       ({ templateElementId }) => templateElementId && String(templateElementId) === id
@@ -227,17 +237,14 @@ const addAllReviewResponses = (structure: FullStructure, data: GetReviewResponse
 
     const hasThisReviewResponsesHistory =
       elementThisReviewResponses.length > 2 ||
-      (element.thisReviewLatestResponse && element.thisReviewPreviousResponse
-        ? element.thisReviewLatestResponse?.decision !==
-          element.thisReviewPreviousResponse?.decision
-        : false)
+      isUpdatedDecision(element.thisReviewLatestResponse, element.thisReviewPreviousResponse)
 
     const hasLowerLevelReviewResponsesHistory =
       elementLowerLevelReviewResponses.length > 2 ||
-      (element.lowerLevelReviewLatestResponse && element.lowerLevelReviewPreviousResponse
-        ? element.lowerLevelReviewLatestResponse?.decision !==
-          element.lowerLevelReviewPreviousResponse?.decision
-        : false)
+      isUpdatedDecision(
+        element.lowerLevelReviewLatestResponse,
+        element.lowerLevelReviewPreviousResponse
+      )
 
     // Check if enableViewHistory already set to true (when there is more than 2 ApplicantResponseElements)
     // Or more than 2 thisReview or lowerLevelReview (that aren't duplications)


### PR DESCRIPTION
Fixes #846 

### Changes
- When `reviewResponse` is DRAFT and not different to previous ReviewResponse, then it doesn't show on the history.
- Also simplify a little how it's checking when to show "View history" clickable label 