### PR TITLE
#857 Fix weird top-border on Summary elements

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -900,6 +900,14 @@ a:hover {
   border-top: none;
 }
 
+.history-block {
+  margin-bottom: 20px;
+}
+
+.stage-label-spacing {
+  margin-bottom: 10px;
+}
+
 .blue-border {
   border: 2px solid @interactiveHigh;
   border-radius: 10px !important;

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -912,6 +912,10 @@ a:hover {
   border: 2px solid @interactiveHigh;
   border-radius: 10px !important;
   overflow: clip;
+
+  > :nth-child(n) {
+    border: none !important;
+  }
 }
 
 .updated-label {

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -872,8 +872,11 @@ a:hover {
     }
   }
 
-  > :first-child {
+  .response-container:first-of-type {
     border-top: 2px solid @surfacesMed;
+  }
+
+  > :first-child {
     border-top-left-radius: @borderRadius;
     border-top-right-radius: @borderRadius;
   }
@@ -961,7 +964,6 @@ a:hover {
 // Layouts
 #dashboard {
   .flex-column();
-
 
   .template-category {
     .flex-column();
@@ -1105,7 +1107,7 @@ a:hover {
   padding-left: 10px;
   padding-right: 10px;
   background-color: @surfacesWhite;
-  margin:5px;
+  margin: 5px;
   color: @darkGrey;
   border: solid 1px @fullyTransperant;
 
@@ -1116,7 +1118,6 @@ a:hover {
   .dropdown.icon {
     margin-left: 6px;
   }
-
 }
 
 // Layouts
@@ -1149,10 +1150,10 @@ a:hover {
   }
 
   // Add filter selector
-  >.ui.dropdown {
+  > .ui.dropdown {
     color: @blue !important;
   }
-  
+
   .active-filter {
     // Needed for relative position of floating label
     position: relative;
@@ -1170,13 +1171,12 @@ a:hover {
       margin-right: 7px;
     }
   }
-
 }
 
 /*--------------------------------
       Date Picker
 ---------------------------------*/
-@weekDayRowBorder: 1px solid rgba(0,0,0, 0.05);
+@weekDayRowBorder: 1px solid rgba(0, 0, 0, 0.05);
 
 .not-clickable {
   cursor: default;
@@ -1196,11 +1196,11 @@ a:hover {
   .flex-row();
   align-items: center;
 
-  >div {
+  > div {
     .flex-column();
     margin-left: 5px;
     align-items: center;
-    
+
     &.title-and-criteria {
       :first-child {
         align-self: flex-start;
@@ -1215,17 +1215,15 @@ a:hover {
 .date-filter {
   .flex-row();
   padding: 5px;
-  padding-top:15px;
+  padding-top: 15px;
   padding-bottom: 5px;
-
-
 
   .named-dates {
     .flex-column();
     padding-left: 10px;
     padding-right: 10px;
     align-items: stretch;
-    margin-right:5px;
+    margin-right: 5px;
     overflow-y: auto;
     max-height: 300px;
 
@@ -1282,19 +1280,18 @@ a:hover {
         border-top: @weekDayRowBorder;
 
         :first-child.day-in-range {
-          .in-range-left-border
-        } 
+          .in-range-left-border;
+        }
 
         :last-child.day-in-range {
-          .in-range-right-border
-          
-        }         
+          .in-range-right-border;
+        }
 
         .first-in-range {
           border-top-left-radius: 5px;
           border-bottom-left-radius: 5px;
         }
-    
+
         .last-in-range {
           border-top-right-radius: 5px;
           border-bottom-right-radius: 5px;
@@ -1311,7 +1308,7 @@ a:hover {
             background-color: @dateFilterLightBlue;
           }
 
-          >div {
+          > div {
             border-radius: 200px;
             width: 32px;
             height: 32px;
@@ -1320,7 +1317,6 @@ a:hover {
               background-color: @selectedDayColor;
             }
           }
-          
         }
       }
     }

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -913,6 +913,7 @@ a:hover {
   border-radius: 10px !important;
   overflow: clip;
 
+  // Turns off border of inner elements
   > :nth-child(n) {
     border: none !important;
   }

--- a/src/components/Review/HistoryPanel.tsx
+++ b/src/components/Review/HistoryPanel.tsx
@@ -53,8 +53,10 @@ const HistoryPanel: React.FC<HistoryPanelProps> = ({
             const stageName = stageDetails?.name || strings.STAGE_NOT_FOUND
             const stageColour = stageDetails?.colour || ''
             return (
-              <div key={`history_stage_${stageName}`}>
-                <Stage name={stageName} colour={stageColour} />
+              <div key={`history_stage_${stageName}`} className="history-block">
+                <div className="stage-label-spacing">
+                  <Stage name={stageName} colour={stageColour} />
+                </div>
                 {historyElements.map((historyElement, index) => (
                   <Segment basic className="summary-page-element-container" key={index}>
                     <div className="response-container">


### PR DESCRIPTION
Fixes #857 (and #825).

The "first-child" top-border was necessary for response-container, but not regular Summary element, so ensured it only gets applied to response-container by using "first-of-type" selector.

Couple of additional tweaks I did here:

- Improve spacing of Stage labels on History Panel:
![Screen Shot 2021-07-27 at 10 51 17 AM](https://user-images.githubusercontent.com/5456533/127071592-eca87f1a-5aaa-49a6-8c99-3a94523acd10.png)

- Hide inner (grey) border when "blue-border" is active:
![Screen Shot 2021-07-27 at 10 51 03 AM](https://user-images.githubusercontent.com/5456533/127071637-080cd689-6cc0-45d6-a394-107bf5c0e641.png)
