### PR TITLE
Fix to stop edit option showing for submitted application - when not updating

### DIFF
--- a/src/components/PageElements/PageElements.tsx
+++ b/src/components/PageElements/PageElements.tsx
@@ -136,7 +136,8 @@ const PageElements: React.FC<PageElementProps> = ({
             // Applicant can edit the summary page when is first submission and a response has been added
             // Or when changes required for any question that have been updated (isUpdating true)
             const canApplicantEdit =
-              canEdit && isUpdating ? isResponseUpdated : !!latestApplicationResponse?.value
+              canEdit && (isUpdating ? isResponseUpdated : !!latestApplicationResponse?.value)
+
             const reviewResponse = previousApplicationResponse?.reviewResponses.nodes[0]
             const summaryViewProps = getSummaryViewProps(element)
 


### PR DESCRIPTION
No linked issues.

### Briefing
Quick fix - for another quick fix (not well done - by me)
Before the application submitted was showing the **Edit** icon on all elements - allowing you to change responses after the application was submitted. So, now that's fixed.