### PR TITLE
#866 improve revalidation element state tracking

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -666,6 +666,9 @@ a:hover {
     .flex-row();
     flex-grow: 1;
     justify-content: flex-end;
+    .loader {
+      margin-left: 10px;
+    }
   }
 }
 

--- a/src/components/Application/Navigation.tsx
+++ b/src/components/Application/Navigation.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Container, Icon } from 'semantic-ui-react'
+import { Button, Container, Icon, Loader } from 'semantic-ui-react'
 import {
   MethodRevalidate,
   MethodToCallProps,
@@ -16,6 +16,7 @@ interface NavigationProps {
   sections: SectionsStructure
   serialNumber: string
   requestRevalidation: MethodRevalidate
+  isValidating: boolean
 }
 
 const Navigation: React.FC<NavigationProps> = ({
@@ -24,6 +25,7 @@ const Navigation: React.FC<NavigationProps> = ({
   sections,
   serialNumber,
   requestRevalidation,
+  isValidating,
 }) => {
   const { push } = useRouter()
 
@@ -120,7 +122,15 @@ const Navigation: React.FC<NavigationProps> = ({
           </p>
         </div>
         <div className="button-container">
-          <Button primary onClick={summaryButtonHandler} content={strings.BUTTON_SUMMARY} />
+          <Button
+            primary
+            inverted={isValidating}
+            disabled={isValidating}
+            onClick={summaryButtonHandler}
+          >
+            {isValidating ? strings.BUTTON_VALIDATING : strings.BUTTON_SUMMARY}
+            {isValidating && <Loader active inline size="tiny" />}
+          </Button>
         </div>
       </div>
     </Container>

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -12,11 +12,13 @@ import { checkPageIsAccessible } from '../../utils/helpers/structure'
 import { useRouter } from '../../utils/hooks/useRouter'
 import usePageTitle from '../../utils/hooks/usePageTitle'
 import strings from '../../utils/constants'
+import { useFormElementUpdateTracker } from '../../contexts/FormElementUpdateTrackerState'
 
 const ApplicationPage: React.FC<ApplicationProps> = ({
   structure: fullStructure,
   requestRevalidation,
   strictSectionPage,
+  isValidating,
 }) => {
   const {
     query: { serialNumber, sectionCode, page },
@@ -24,6 +26,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({
     replace,
   } = useRouter()
 
+  const { setState: setUpdateTrackerState } = useFormElementUpdateTracker()
   usePageTitle(strings.PAGE_TITLE_APPLICATION.replace('%1', serialNumber))
 
   const pageNumber = Number(page)
@@ -44,6 +47,11 @@ const ApplicationPage: React.FC<ApplicationProps> = ({
       push(`/application/${fullStructure.info.serial}/${sectionCode}/Page${pageNumber}`)
     }
   }, [fullStructure, sectionCode, page])
+
+  // update tracker state when page or section changes
+  useEffect(() => {
+    setUpdateTrackerState({ type: 'resetElementsTracker' })
+  }, [sectionCode, page])
 
   if (!fullStructure || !fullStructure.responsesByCode) return <Loading />
 
@@ -84,6 +92,7 @@ const ApplicationPage: React.FC<ApplicationProps> = ({
           <Navigation
             current={{ sectionCode, pageNumber }}
             isLinear={isLinear}
+            isValidating={!!isValidating}
             sections={fullStructure.sections}
             serialNumber={serialNumber}
             requestRevalidation={requestRevalidation as MethodRevalidate}

--- a/src/contexts/FormElementUpdateTrackerState.tsx
+++ b/src/contexts/FormElementUpdateTrackerState.tsx
@@ -1,80 +1,146 @@
 import React, { createContext, useContext, useReducer } from 'react'
 
-interface ContextFormElementUpdateTrackerState {
-  elementEnteredTimestamp: number
-  elementEnteredTextValue?: string
-  elementUpdatedTimestamp: number
-  elementUpdatedTextValue: string
-  isLastElementUpdateProcessed: boolean
-  wasElementChanged: boolean
+interface SingleFormElementUpdateState {
+  enteredTimestamp: number
+  enteredSequence: number // See calculateLatestChangedTimestamp timestamps for explanation
+  previousEnteredTextValue?: string
+  enteredTextValue?: string
+  updatedSequence: number
+  changedTimestamp: number
 }
 
+const elementStateDefault: SingleFormElementUpdateState = {
+  enteredTimestamp: 0,
+  enteredSequence: 0,
+  updatedSequence: 0,
+  changedTimestamp: 0,
+}
+
+interface ContextFormElementUpdateTrackerState {
+  elementsUpdateState: { [elementCode: string]: SingleFormElementUpdateState }
+  // if still waiting for element to update (i.e. it's still in focus, then it will be set to 'infinity')
+  // if no elements were updated, it will be set to 0
+  latestChangedElementUpdateTimestamp: number
+}
+
+const contextStateDefault: ContextFormElementUpdateTrackerState = {
+  elementsUpdateState: {},
+  latestChangedElementUpdateTimestamp: 0,
+}
+
+const calculateLatestChangedTimestamp = (elementsUpdateState: {
+  [elementCode: string]: SingleFormElementUpdateState
+}) =>
+  Object.values(elementsUpdateState).reduce((latestUpdateTimestamp, singleElementState) => {
+    if (latestUpdateTimestamp === Infinity) return Infinity
+    const { enteredSequence, updatedSequence, changedTimestamp } = singleElementState
+    // Element is in focus still when entered sequence is higher then updated seqeunce, using sequence to accomodate plugins like password
+    // which have two fields for the same element, and there is a race condition when second field entered
+    // occurs before first field exit (because exit is triggered after mutation)
+    if (enteredSequence > updatedSequence) return Infinity
+
+    return Math.max(latestUpdateTimestamp, changedTimestamp)
+  }, 0)
+
 export type UpdateAction =
+  // this action should be called whenever an application page is refreshed on navigated
+  | {
+      type: 'resetElementsTracker'
+    }
   | {
       type: 'setElementEntered'
+      elementCode: string
       textValue: string
     }
   | {
       type: 'setElementUpdated'
+      elementCode: string
       textValue: string
       previousValue: string
     }
 
 type FormElementUpdateTrackerProps = { children: React.ReactNode }
 
-// TODO will have to think about storing elementEnteredTimestamp and elementUpdatedTimestamp by element code/application
-// think of a use case where API query take a long time, and focus is changed to another field and submit is pressed
-// straight away
-const reducer = (
+type Reducer = (
   state: ContextFormElementUpdateTrackerState,
   action: UpdateAction
-): ContextFormElementUpdateTrackerState => {
+) => ContextFormElementUpdateTrackerState
+
+const reducer: Reducer = (state, action) => {
   switch (action.type) {
-    case 'setElementUpdated': {
-      const newState = {
-        ...state,
-        elementUpdatedTimestamp: Date.now(),
-        elementUpdatedTextValue: action.textValue,
+    case 'resetElementsTracker':
+      return contextStateDefault
+    case 'setElementEntered': {
+      const { elementCode } = action
+      const previousElementState = state.elementsUpdateState[elementCode] || elementStateDefault
+
+      const newState: ContextFormElementUpdateTrackerState = {
+        latestChangedElementUpdateTimestamp: Infinity, // signaling that at least one elements is awaiting update
+        elementsUpdateState: {
+          ...state.elementsUpdateState,
+          [elementCode]: {
+            ...previousElementState,
+            enteredSequence: previousElementState.enteredSequence + 1,
+            enteredTimestamp: Date.now(),
+            previousEnteredTextValue: previousElementState.enteredTextValue,
+            enteredTextValue: action.textValue,
+          },
+        },
       }
+
+      return newState
+    }
+    case 'setElementUpdated': {
+      const { elementCode } = action
+      const previousElementState = state.elementsUpdateState[elementCode] || elementStateDefault
+      const { updatedSequence, enteredSequence } = previousElementState
+      // It's possible for element update sequence to get ahead of element entered sequence, want to restrict this
+      // btw this could happen when element is updated when it's created or when 'entered' activity is not recorded
+      const newUpdateSequence =
+        updatedSequence >= enteredSequence ? enteredSequence : updatedSequence + 1
+
+      const previousTextValue =
+        newUpdateSequence === enteredSequence
+          ? previousElementState.enteredTextValue
+          : previousElementState.previousEnteredTextValue
 
       const wasElementChanged =
-        typeof newState.elementEnteredTextValue === 'undefined'
+        typeof previousTextValue === 'undefined'
           ? action.textValue !== action.previousValue
-          : action.textValue !== newState.elementEnteredTextValue
+          : action.textValue !== previousTextValue
 
-      return {
-        ...newState,
-        isLastElementUpdateProcessed:
-          newState.elementUpdatedTimestamp >= newState.elementEnteredTimestamp,
-        wasElementChanged,
-        elementEnteredTextValue: undefined,
-      }
-    }
-    case 'setElementEntered': {
-      const newState = {
-        ...state,
-        elementEnteredTimestamp: Date.now(),
-        elementEnteredTextValue: action.textValue,
+      const changedTimestamp = wasElementChanged
+        ? Date.now()
+        : previousElementState.changedTimestamp
+
+      const newElementState: SingleFormElementUpdateState = {
+        ...previousElementState,
+        updatedSequence: newUpdateSequence,
+        enteredTextValue: action.textValue,
+        changedTimestamp,
       }
 
-      return {
-        ...newState,
-        isLastElementUpdateProcessed: false,
+      const newElementsUpdateState = {
+        ...state.elementsUpdateState,
+        [elementCode]: newElementState,
       }
+
+      const latestChangedElementUpdateTimestamp =
+        calculateLatestChangedTimestamp(newElementsUpdateState)
+
+      const newState: ContextFormElementUpdateTrackerState = {
+        latestChangedElementUpdateTimestamp,
+        elementsUpdateState: newElementsUpdateState,
+      }
+
+      return newState
     }
     default:
       return state
   }
 }
 
-const initialState: ContextFormElementUpdateTrackerState = {
-  isLastElementUpdateProcessed: true,
-  elementEnteredTimestamp: Date.now(),
-  elementUpdatedTimestamp: Date.now(),
-  elementEnteredTextValue: undefined,
-  elementUpdatedTextValue: '',
-  wasElementChanged: false,
-}
+const initialState: ContextFormElementUpdateTrackerState = contextStateDefault
 
 // By setting the typings here, we ensure we get intellisense in VS Code
 const initialContext: {

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -39,7 +39,6 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
     pluginCode,
     parameters,
     isVisible,
-    isEditable,
     isRequired,
     validationExpression,
     validationMessage,
@@ -129,6 +128,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
         })
       setUpdateTrackerState({
         type: 'setElementUpdated',
+        elementCode: code,
         textValue: response?.text || '',
         previousValue: currentResponse?.text || '',
       })
@@ -147,6 +147,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
       })
       setUpdateTrackerState({
         type: 'setElementUpdated',
+        elementCode: code,
         textValue: response?.text || '',
         previousValue: currentResponse?.text || '',
       })
@@ -157,6 +158,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
     // Tells application state that a plugin field is in focus
     setUpdateTrackerState({
       type: 'setElementEntered',
+      elementCode: code,
       textValue: currentResponse?.text || '',
     })
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -39,6 +39,7 @@ export default {
   BUTTON_SELF_ASSIGN: 'Self Assign',
   BUTTON_SUMMARY: 'Review & Summary',
   BUTTON_SUBMIT: 'Submit',
+  BUTTON_VALIDATING: 'Validating',
   BUTTON_CANCEL: 'Cancel',
   BUTTON_SUBMIT_APPLICATION: 'Submit application',
   BUTTON_SUMMARY_EDIT: 'Edit',

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -111,6 +111,7 @@ interface ApplicationProps {
   structure: FullStructure
   requestRevalidation?: MethodRevalidate
   strictSectionPage?: SectionAndPage | null
+  isValidating?: boolean
 }
 
 interface AssignmentDetails {


### PR DESCRIPTION
Fixes: #866 

Ended up changing element tracker to track changes for individual elements, and only supplying `latestChangedElementUpdateTimestamp` to ApplicationPageWrapper and in turn to useGetApplicationStructure as minRefetchTimestampForRevalidation.

Also introduced `sequence` to tracked elements, to make sure overlapping exit event in password plugin doesn't undermine enter event it overlaps.

### Changes

Basic flow is as follows:

Each element can indicate when it's 'entered' via `setIsActive` function prop, ApplicationViewWrapper (AVW) will call setUpdateTracker `setElementEntered` with that element code. Then when element is saved AVW will call setUpdateTracker with `setElementUpdated` with that code. Entered and exited (including start and end value) events for all element are tracked, and if element is active (in focus), latestChangedElementUpdateTimestamp will be Infinity, otherwise, if element looses focus and was changed, then latestChangedElementUpdateTimestamp will be set to Date.now() (more precisely to the latest  changedTimestamp of all updated elements since page was opened). 

When revalidation is requested, ApplicationPageWrapper will pass along `latestChangedElementUpdateTimestamp` to `useGetApplicationStructure` which will re evaluate isValid field when responses are updated (refetched) after `latestChangedElementUpdateTimestamp`

Refer to this behemoth of a diagram: https://github.com/openmsupply/application-manager-web-app/wiki/Application-and-Review-Flow#revalidation-diagram

Also took the liberty of showing a loading indicator (replaces review and summary button content when isValidating)

`NOTE`: I tried to be careful not to break existing functionality, and did some minor test, seems to be all good 🤞 


### Testing

This backend branch  `#866F-testing` has user registration form with just first name and password field, can check out the following with and without this front end branch:

* Create new user registration
* Change to slow or fast 3g
* Enter things in the application and tab through inputs
* When doing confirmation of password, don't tab out but press the review and submit button

After summary page is reached go back to application and try changing password so it's not matching confirmed password anymore, without loosing focus from password input try review and submit button.

### Thoughts

Not happy about the complexity of the thing, but should be safe now for use cases like:
* Long validation on text input (say some slow endpoint)
* Making changes in that long validation input then quickly tabbing out into another field and tabbing out of that one and quickly pressing review and summary

### TODO

Need to update docs and diagram 
