### PR TITLE
#899 template export correctly filters permission names and filter linked …

### DIFF
--- a/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
+++ b/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
@@ -249,7 +249,15 @@ export const importTemplate: ImportTemplateHelper =
   }
 
 const getFitlerBody = (id: number) => {
-  const filters = { filters: { template: { id: { equalTo: id } } } }
+  const equalToTemplateId = { equalTo: id }
+  const allElementsMatchTemplateId = { some: { templateId: equalToTemplateId } }
+  const filters = {
+    filters: {
+      template: { id: equalToTemplateId },
+      filter: { templateFilterJoins: allElementsMatchTemplateId },
+      permissionName: { templatePermissions: allElementsMatchTemplateId },
+    },
+  }
   return JSON.stringify(filters)
 }
 const safeFetch = async (


### PR DESCRIPTION
Fixes: #899 

Tables that are hierarchical reference depended to template would automatically inherit template (or their reference) filter. You can check this by adding `console.log(gql)` to:
https://github.com/openmsupply/application-manager-server/blob/136612028b7be0e8e2c1cbfc3aaaf96703a2e188/src/components/exportAndImport/exportToJson.ts#L83-L85

But other tables like permissionName and filter are not filtered accordingly, this is fixed in this PR:

### Changes

* Added further filter criteria  to getFilterBody (which is used in export and duplicate functionality).

### Testing

* Adding a log as per described above, and without this commit run an export on template, see console out put and snapshot.json
* Run export with this commit and note the difference in console output and resulting snapshot.json