### PR TITLE
#911 What is your emergency?

### DIFF
--- a/src/containers/User/Login.tsx
+++ b/src/containers/User/Login.tsx
@@ -105,7 +105,7 @@ const Login: React.FC = () => {
           </Header>
         </div>
         <Header as="h2" className="centered header-space-around-medium">
-          {loginPayload
+          {loginPayload && selectedOrgId === NO_ORG_SELECTED
             ? messages.LOGIN_WELCOME.replace('%1', loginPayload.user.firstName)
             : strings.TITLE_LOGIN}
         </Header>
@@ -154,7 +154,7 @@ const Login: React.FC = () => {
               </p>
             </>
           )}
-          {loginPayload && loginPayload?.orgList && (
+          {loginPayload?.orgList && loginPayload?.orgList?.length > 1 && (
             <>
               <p>
                 <strong>{messages.LOGIN_ORG_SELECT}</strong>

--- a/src/containers/User/Login.tsx
+++ b/src/containers/User/Login.tsx
@@ -27,6 +27,7 @@ const Login: React.FC = () => {
     orgId: LOGIN_AS_NO_ORG,
     orgName: strings.LABEL_NO_ORG_OPTION,
     userRole: null,
+    isSystemOrg: false,
   }
 
   // useEffect ensures isLoggedIn only runs on first mount, not re-renders

--- a/src/containers/User/Login.tsx
+++ b/src/containers/User/Login.tsx
@@ -63,10 +63,14 @@ const Login: React.FC = () => {
   }
 
   useEffect(() => {
-    if (loginPayload?.orgList?.length === LOGIN_AS_NO_ORG) {
+    if (loginPayload?.orgList?.length === 0) {
       // No orgs, so skip org login
       finishLogin(loginPayload)
       return
+    }
+    if (loginPayload?.orgList?.length === 1) {
+      // Only one org, so select it by default
+      setSelectedOrgId(loginPayload.orgList[0].orgId)
     }
   }, [loginPayload])
 

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -191,11 +191,13 @@ const OrgSelector: React.FC<{ user: User; orgs: OrganisationSimple[]; onLogin: F
     text: orgName,
     value: orgId,
   }))
-  dropdownOptions.push({
-    key: LOGIN_AS_NO_ORG,
-    text: strings.LABEL_NO_ORG,
-    value: LOGIN_AS_NO_ORG,
-  })
+  // Only add "No Org" option if user not part of "Admin" org (e.g. FDA)
+  if (!orgs.some(({ isSystemOrg }) => isSystemOrg))
+    dropdownOptions.push({
+      key: LOGIN_AS_NO_ORG,
+      text: `> ${strings.LABEL_NO_ORG_SELECT}`,
+      value: LOGIN_AS_NO_ORG,
+    })
   return (
     <div id="org-selector">
       {user?.organisation?.logoUrl && (

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -204,11 +204,15 @@ const OrgSelector: React.FC<{ user: User; orgs: OrganisationSimple[]; onLogin: F
         <Image src={getFullUrl(user?.organisation?.logoUrl, config.serverREST)} />
       )}
       <div>
-        <Dropdown
-          text={user?.organisation?.orgName || strings.LABEL_NO_ORG}
-          options={dropdownOptions}
-          onChange={handleChange}
-        ></Dropdown>
+        {dropdownOptions.length === 1 ? (
+          user?.organisation?.orgName || strings.LABEL_NO_ORG
+        ) : (
+          <Dropdown
+            text={user?.organisation?.orgName || strings.LABEL_NO_ORG}
+            options={dropdownOptions}
+            onChange={handleChange}
+          ></Dropdown>
+        )}
       </div>
     </div>
   )

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent } from 'react'
+import React, { SyntheticEvent, useEffect, useState } from 'react'
 import { Button, Container, Image, List, Dropdown } from 'semantic-ui-react'
 import { useUserState } from '../../contexts/UserState'
 import { attemptLoginOrg } from '../../utils/helpers/attemptLogin'
@@ -49,11 +49,30 @@ interface MainMenuBarProps {
   templates: TemplateInList[]
   outcomes: OutcomeDisplay[]
 }
+interface DropdownsState {
+  dashboard: { active: boolean }
+  templates: { active: boolean; selection: string }
+  outcomes: { active: boolean; selection: string }
+  admin: { active: boolean; selection: string }
+}
 const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
+  const [dropdownsState, setDropDownsState] = useState<DropdownsState>({
+    dashboard: { active: false },
+    templates: { active: false, selection: '' },
+    outcomes: { active: false, selection: '' },
+    admin: { active: false, selection: '' },
+  })
   const { push, pathname } = useRouter()
   const {
     userState: { isAdmin },
   } = useUserState()
+
+  // Ensures the "selected" state of other dropdowns gets disabled
+  useEffect(() => {
+    const basepath = pathname.split('/')?.[1]
+    setDropDownsState((currState) => getNewDropdownsState(basepath, currState))
+  }, [pathname])
+
   const outcomeOptions = outcomes.map(({ code, title, tableName }): any => ({
     key: code,
     text: title,
@@ -97,30 +116,28 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
   )
 
   const handleOutcomeChange = (_: SyntheticEvent, { value }: any) => {
+    setDropDownsState({ ...dropdownsState, outcomes: { active: true, selection: value } })
     push(`/outcomes/${value}`)
   }
 
   const handleTemplateChange = (_: SyntheticEvent, { value }: any) => {
+    setDropDownsState({ ...dropdownsState, templates: { active: true, selection: value } })
     push(`/applications?type=${value}`)
   }
 
   const handleAdminChange = (_: SyntheticEvent, { value }: any) => {
+    setDropDownsState({ ...dropdownsState, admin: { active: true, selection: value } })
     push(value)
-  }
-
-  const getSelectedLinkClass = (link: string) => {
-    const basepath = pathname.split('/')?.[1]
-    return link === basepath ? 'selected-link' : ''
   }
 
   return (
     <div id="menu-bar">
       <List horizontal>
-        <List.Item className={getSelectedLinkClass('')}>
+        <List.Item className={dropdownsState.dashboard.active ? 'selected-link' : ''}>
           <Link to="/">{strings.MENU_ITEM_DASHBOARD}</Link>
         </List.Item>
         {templateOptions.length > 0 && (
-          <List.Item className={getSelectedLinkClass('applications')}>
+          <List.Item className={dropdownsState.templates.active ? 'selected-link' : ''}>
             <Dropdown
               text={strings.MENU_ITEM_APPLICATION_LIST}
               options={templateOptions}
@@ -129,7 +146,7 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
           </List.Item>
         )}
         {outcomeOptions.length > 1 && (
-          <List.Item className={getSelectedLinkClass('outcomes')}>
+          <List.Item className={dropdownsState.outcomes.active ? 'selected-link' : ''}>
             <Dropdown
               text={strings.MENU_ITEM_OUTCOMES}
               options={outcomeOptions}
@@ -138,7 +155,7 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
           </List.Item>
         )}
         {isAdmin && (
-          <List.Item className={getSelectedLinkClass('admin')}>
+          <List.Item className={dropdownsState.admin.active ? 'selected-link' : ''}>
             <Dropdown
               text={strings.MENU_ITEM_ADMIN_CONFIG}
               options={adminOptions}
@@ -245,3 +262,42 @@ const UserMenu: React.FC<{ user: User; templates: TemplateInList[] }> = ({ user,
 }
 
 export default UserArea
+
+const getNewDropdownsState = (basepath: string, dropdownsState: DropdownsState): DropdownsState => {
+  switch (basepath) {
+    case '':
+      return {
+        dashboard: { active: true },
+        templates: { active: false, selection: '' },
+        outcomes: { active: false, selection: '' },
+        admin: { active: false, selection: '' },
+      }
+    case 'applications':
+      return {
+        dashboard: { active: false },
+        templates: { active: true, selection: dropdownsState.templates.selection },
+        outcomes: { active: false, selection: '' },
+        admin: { active: false, selection: '' },
+      }
+    case 'outcomes':
+      return {
+        dashboard: { active: false },
+        templates: { active: false, selection: '' },
+        outcomes: { active: true, selection: dropdownsState.outcomes.selection },
+        admin: { active: false, selection: '' },
+      }
+    case 'admin':
+      return {
+        dashboard: { active: false },
+        templates: { active: false, selection: '' },
+        outcomes: { active: false, selection: '' },
+        admin: { active: true, selection: dropdownsState.admin.selection },
+      }
+  }
+  return {
+    dashboard: { active: false },
+    templates: { active: false, selection: '' },
+    outcomes: { active: false, selection: '' },
+    admin: { active: false, selection: '' },
+  }
+}

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent, useEffect, useState } from 'react'
+import React, { SyntheticEvent } from 'react'
 import { Button, Container, Image, List, Dropdown } from 'semantic-ui-react'
 import { useUserState } from '../../contexts/UserState'
 import { attemptLoginOrg } from '../../utils/helpers/attemptLogin'
@@ -49,30 +49,11 @@ interface MainMenuBarProps {
   templates: TemplateInList[]
   outcomes: OutcomeDisplay[]
 }
-interface DropdownsState {
-  dashboard: { active: boolean }
-  templates: { active: boolean; selection: string }
-  outcomes: { active: boolean; selection: string }
-  admin: { active: boolean; selection: string }
-}
 const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
-  const [dropdownsState, setDropDownsState] = useState<DropdownsState>({
-    dashboard: { active: false },
-    templates: { active: false, selection: '' },
-    outcomes: { active: false, selection: '' },
-    admin: { active: false, selection: '' },
-  })
   const { push, pathname } = useRouter()
   const {
     userState: { isAdmin },
   } = useUserState()
-
-  // Ensures the "selected" state of other dropdowns gets disabled
-  useEffect(() => {
-    const basepath = pathname.split('/')?.[1]
-    setDropDownsState((currState) => getNewDropdownsState(basepath, currState))
-  }, [pathname])
-
   const outcomeOptions = outcomes.map(({ code, title, tableName }): any => ({
     key: code,
     text: title,
@@ -116,28 +97,30 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
   )
 
   const handleOutcomeChange = (_: SyntheticEvent, { value }: any) => {
-    setDropDownsState({ ...dropdownsState, outcomes: { active: true, selection: value } })
     push(`/outcomes/${value}`)
   }
 
   const handleTemplateChange = (_: SyntheticEvent, { value }: any) => {
-    setDropDownsState({ ...dropdownsState, templates: { active: true, selection: value } })
     push(`/applications?type=${value}`)
   }
 
   const handleAdminChange = (_: SyntheticEvent, { value }: any) => {
-    setDropDownsState({ ...dropdownsState, admin: { active: true, selection: value } })
     push(value)
+  }
+
+  const getSelectedLinkClass = (link: string) => {
+    const basepath = pathname.split('/')?.[1]
+    return link === basepath ? 'selected-link' : ''
   }
 
   return (
     <div id="menu-bar">
       <List horizontal>
-        <List.Item className={dropdownsState.dashboard.active ? 'selected-link' : ''}>
+        <List.Item className={getSelectedLinkClass('')}>
           <Link to="/">{strings.MENU_ITEM_DASHBOARD}</Link>
         </List.Item>
         {templateOptions.length > 0 && (
-          <List.Item className={dropdownsState.templates.active ? 'selected-link' : ''}>
+          <List.Item className={getSelectedLinkClass('applications')}>
             <Dropdown
               text={strings.MENU_ITEM_APPLICATION_LIST}
               options={templateOptions}
@@ -146,7 +129,7 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
           </List.Item>
         )}
         {outcomeOptions.length > 1 && (
-          <List.Item className={dropdownsState.outcomes.active ? 'selected-link' : ''}>
+          <List.Item className={getSelectedLinkClass('outcomes')}>
             <Dropdown
               text={strings.MENU_ITEM_OUTCOMES}
               options={outcomeOptions}
@@ -155,7 +138,7 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
           </List.Item>
         )}
         {isAdmin && (
-          <List.Item className={dropdownsState.admin.active ? 'selected-link' : ''}>
+          <List.Item className={getSelectedLinkClass('admin')}>
             <Dropdown
               text={strings.MENU_ITEM_ADMIN_CONFIG}
               options={adminOptions}
@@ -262,42 +245,3 @@ const UserMenu: React.FC<{ user: User; templates: TemplateInList[] }> = ({ user,
 }
 
 export default UserArea
-
-const getNewDropdownsState = (basepath: string, dropdownsState: DropdownsState): DropdownsState => {
-  switch (basepath) {
-    case '':
-      return {
-        dashboard: { active: true },
-        templates: { active: false, selection: '' },
-        outcomes: { active: false, selection: '' },
-        admin: { active: false, selection: '' },
-      }
-    case 'applications':
-      return {
-        dashboard: { active: false },
-        templates: { active: true, selection: dropdownsState.templates.selection },
-        outcomes: { active: false, selection: '' },
-        admin: { active: false, selection: '' },
-      }
-    case 'outcomes':
-      return {
-        dashboard: { active: false },
-        templates: { active: false, selection: '' },
-        outcomes: { active: true, selection: dropdownsState.outcomes.selection },
-        admin: { active: false, selection: '' },
-      }
-    case 'admin':
-      return {
-        dashboard: { active: false },
-        templates: { active: false, selection: '' },
-        outcomes: { active: false, selection: '' },
-        admin: { active: true, selection: dropdownsState.admin.selection },
-      }
-  }
-  return {
-    dashboard: { active: false },
-    templates: { active: false, selection: '' },
-    outcomes: { active: false, selection: '' },
-    admin: { active: false, selection: '' },
-  }
-}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -104,6 +104,7 @@ export default {
   LABEL_LOGIN_USERNAME: 'Username',
   LABEL_LOG_IN: 'Log in',
   LABEL_NO_ORG: 'No organisation',
+  LABEL_NO_ORG_SELECT: 'No organisation (act as user only)',
   LABEL_NO_ORG_OPTION: 'Log in without organisation',
   LABEL_PROCESSING: 'Processing...',
   LABEL_PREVIOUS_REVIEW: 'Previous review',

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -555,6 +555,7 @@ interface OrganisationSimple {
   orgId: number
   userRole: string | null
   orgName: string
+  isSystemOrg: boolean
 }
 
 interface Organisation extends OrganisationSimple {


### PR DESCRIPTION
Fixes #911 

Requires [back-end PR #524](https://github.com/openmsupply/application-manager-server/pull/524)

This is kind of an interim solution, we can come up with something else later on if it's a problem. For now, the FDA org never see the "No Org" selection, which is what Craig wants.

- Also tweaked the logic on the login screen, so if a user only has one org (i.e. most people), they'll skip the org selection and automatically be logged in as their only org (so won't see the "No Org" option initially). So only people who go poking around in the Org dropdown will see the "No Org" option

To test, just set the "isSystemOrg" flag on any org to "true" and note that users who are part of this org can no longer see the "No Org" option

Edit: improved it further so there is not even a Dropdown at all when there is only one choice (i.e one company, FDA), it's just a fixed banner)