### PR TITLE
#917 Fix menu items state

### DIFF
--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent } from 'react'
+import React, { SyntheticEvent, useEffect, useState } from 'react'
 import { Button, Container, Image, List, Dropdown } from 'semantic-ui-react'
 import { useUserState } from '../../contexts/UserState'
 import { attemptLoginOrg } from '../../utils/helpers/attemptLogin'
@@ -49,11 +49,30 @@ interface MainMenuBarProps {
   templates: TemplateInList[]
   outcomes: OutcomeDisplay[]
 }
+interface DropdownsState {
+  dashboard: { active: boolean }
+  templates: { active: boolean; selection: string }
+  outcomes: { active: boolean; selection: string }
+  admin: { active: boolean; selection: string }
+}
 const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
+  const [dropdownsState, setDropDownsState] = useState<DropdownsState>({
+    dashboard: { active: false },
+    templates: { active: false, selection: '' },
+    outcomes: { active: false, selection: '' },
+    admin: { active: false, selection: '' },
+  })
   const { push, pathname } = useRouter()
   const {
     userState: { isAdmin },
   } = useUserState()
+
+  // Ensures the "selected" state of other dropdowns gets disabled
+  useEffect(() => {
+    const basepath = pathname.split('/')?.[1]
+    setDropDownsState((currState) => getNewDropdownsState(basepath, currState))
+  }, [pathname])
+
   const outcomeOptions = outcomes.map(({ code, title, tableName }): any => ({
     key: code,
     text: title,
@@ -97,30 +116,28 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
   )
 
   const handleOutcomeChange = (_: SyntheticEvent, { value }: any) => {
+    setDropDownsState({ ...dropdownsState, outcomes: { active: true, selection: value } })
     push(`/outcomes/${value}`)
   }
 
   const handleTemplateChange = (_: SyntheticEvent, { value }: any) => {
+    setDropDownsState({ ...dropdownsState, templates: { active: true, selection: value } })
     push(`/applications?type=${value}`)
   }
 
   const handleAdminChange = (_: SyntheticEvent, { value }: any) => {
+    setDropDownsState({ ...dropdownsState, admin: { active: true, selection: value } })
     push(value)
-  }
-
-  const getSelectedLinkClass = (link: string) => {
-    const basepath = pathname.split('/')?.[1]
-    return link === basepath ? 'selected-link' : ''
   }
 
   return (
     <div id="menu-bar">
       <List horizontal>
-        <List.Item className={getSelectedLinkClass('')}>
+        <List.Item className={dropdownsState.dashboard.active ? 'selected-link' : ''}>
           <Link to="/">{strings.MENU_ITEM_DASHBOARD}</Link>
         </List.Item>
         {templateOptions.length > 0 && (
-          <List.Item className={getSelectedLinkClass('applications')}>
+          <List.Item className={dropdownsState.templates.active ? 'selected-link' : ''}>
             <Dropdown
               text={strings.MENU_ITEM_APPLICATION_LIST}
               options={templateOptions}
@@ -129,7 +146,7 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
           </List.Item>
         )}
         {outcomeOptions.length > 1 && (
-          <List.Item className={getSelectedLinkClass('outcomes')}>
+          <List.Item className={dropdownsState.outcomes.active ? 'selected-link' : ''}>
             <Dropdown
               text={strings.MENU_ITEM_OUTCOMES}
               options={outcomeOptions}
@@ -138,7 +155,7 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({ outcomes, templates }) => {
           </List.Item>
         )}
         {isAdmin && (
-          <List.Item className={getSelectedLinkClass('admin')}>
+          <List.Item className={dropdownsState.admin.active ? 'selected-link' : ''}>
             <Dropdown
               text={strings.MENU_ITEM_ADMIN_CONFIG}
               options={adminOptions}
@@ -245,3 +262,42 @@ const UserMenu: React.FC<{ user: User; templates: TemplateInList[] }> = ({ user,
 }
 
 export default UserArea
+
+const getNewDropdownsState = (basepath: string, dropdownsState: DropdownsState): DropdownsState => {
+  switch (basepath) {
+    case '':
+      return {
+        dashboard: { active: true },
+        templates: { active: false, selection: '' },
+        outcomes: { active: false, selection: '' },
+        admin: { active: false, selection: '' },
+      }
+    case 'applications':
+      return {
+        dashboard: { active: false },
+        templates: { active: true, selection: dropdownsState.templates.selection },
+        outcomes: { active: false, selection: '' },
+        admin: { active: false, selection: '' },
+      }
+    case 'outcomes':
+      return {
+        dashboard: { active: false },
+        templates: { active: false, selection: '' },
+        outcomes: { active: true, selection: dropdownsState.outcomes.selection },
+        admin: { active: false, selection: '' },
+      }
+    case 'admin':
+      return {
+        dashboard: { active: false },
+        templates: { active: false, selection: '' },
+        outcomes: { active: false, selection: '' },
+        admin: { active: true, selection: dropdownsState.admin.selection },
+      }
+  }
+  return {
+    dashboard: { active: false },
+    templates: { active: false, selection: '' },
+    outcomes: { active: false, selection: '' },
+    admin: { active: false, selection: '' },
+  }
+}


### PR DESCRIPTION
Fixes #917 

Have combined the state of the Dropdowns into a single stateful object that stores which Dropdown is active (i.e. one of its pages is selected) and what its current value is.

This is not an optimal solution, but the logic to fully update the state of the Menu item dropdowns based completely on the URL would be unncessarily complicated for minimal gain. The only thing it doesn't do is correctly show (i.e. in **bold**) the current active menu item on page reload. But that doesn't seem completely necessary right now.