### PR TITLE
Add error-handling for radioChoice and fix dropdown error color

### DIFF
--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -84,13 +84,10 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         options={dropdownOptions}
         onChange={handleChange}
         value={selectedIndex}
-        disabled={!isEditable}
         error={!validationState.isValid ? true : undefined}
       />
       {validationState.isValid ? null : (
-        <Label basic color="red" pointing>
-          {validationState?.validationMessage}
-        </Label>
+        <Label pointing prompt content={validationState?.validationMessage} />
       )}
     </>
   )

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -38,7 +38,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   )
 
   useEffect(() => {
-    onUpdate(currentResponse)
     // This ensures that, if a default is specified, it gets saved on first load
     if (!currentResponse?.text && defaultOption !== undefined) {
       const optionIndex = getDefaultIndex(defaultOption, options)

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Radio, Form, Input } from 'semantic-ui-react'
+import { Radio, Form, Input, Label } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
 import strings from '../constants'
 
@@ -8,6 +8,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   parameters,
   onUpdate,
   currentResponse,
+  validationState,
   onSave,
   Markdown,
   getDefaultIndex,
@@ -110,7 +111,13 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       {radioButtonOptions.map((option: any, index: number) => {
         const showOther = hasOther && index === allOptions.length - 1
         return (
-          <Form.Field key={option.key} disabled={!isEditable} style={styles} inline={showOther}>
+          <Form.Field
+            key={option.key}
+            disabled={!isEditable}
+            style={styles}
+            inline={showOther}
+            error={!validationState.isValid}
+          >
             <Radio
               label={option.text}
               name={`${code}_radio_${index}`} // This is GROUP name
@@ -132,6 +139,9 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
           </Form.Field>
         )
       })}
+      {validationState.isValid ? null : (
+        <Label pointing prompt content={validationState?.validationMessage} />
+      )}
     </>
   )
 }


### PR DESCRIPTION
Fixes #784 and fixes #813 

## Linked PR
- Based in #820 

## Changes

Just adding some error-handling to radio-button to show something is wrong (using validationMessage) when trying to submit with one selected. As mentioned in "Demo server templates/configs": Radio selection on Page 3 (and maybe other radios) need a validation message to show when trying to navigate to next page without one selected - Adam's feedback

![Screen Shot 2021-08-24 at 11 57 09 PM](https://user-images.githubusercontent.com/16461988/130612390-2347e067-d46d-4927-a123-ecf48bdd4df4.png)
![Screen Shot 2021-08-24 at 11 57 26 PM](https://user-images.githubusercontent.com/16461988/130612394-4c3c0a79-d405-409c-8785-0d86503b7feb.png)


TODO:
- Add something similar to List-builder once decided