### PR TITLE
#692 Auto-assign sections to same assignee + Fix problem with review self-assignment for consolidation

### DIFF
--- a/src/components/Review/ReviewSectionRowAction.tsx
+++ b/src/components/Review/ReviewSectionRowAction.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Grid, Icon, Label, Message } from 'semantic-ui-react'
 import { useRouter } from '../../utils/hooks/useRouter'
 import {
@@ -184,8 +184,20 @@ const GenerateActionButton: React.FC<ReviewSectionComponentProps> = ({
 const SelfAssignButton: React.FC<ReviewSectionComponentProps> = ({
   assignment,
   fullStructure: structure,
+  shouldAssignState: [shouldAssign, setShouldAssign],
 }) => {
   const [assignmentError, setAssignmentError] = useState(false)
+
+  // Do auto-assign for other sections when one is selected
+  // for auto-assignment in another row when shouldAssign == true
+  // Note: This is required to be passed on as props to be processed
+  // in each row since the fullStructure is related to each section
+  useEffect(() => {
+    if (shouldAssign == true) {
+      selfAssignReview()
+    }
+  }, [shouldAssign])
+
   const { assignSectionToUser } = useUpdateReviewAssignment(structure)
 
   const selfAssignReview = async () => {
@@ -202,7 +214,13 @@ const SelfAssignButton: React.FC<ReviewSectionComponentProps> = ({
   if (assignmentError) return <Message error title={strings.ERROR_GENERIC} />
 
   return (
-    <a className="user-action clickable" onClick={selfAssignReview}>
+    <a
+      className="user-action clickable"
+      onClick={() => {
+        selfAssignReview()
+        setShouldAssign(true)
+      }}
+    >
       {strings.BUTTON_SELF_ASSIGN}
     </a>
   )

--- a/src/containers/Review/AssignmentSectionRow.tsx
+++ b/src/containers/Review/AssignmentSectionRow.tsx
@@ -34,12 +34,11 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = (props) => {
 
   const { assignSectionToUser } = useUpdateReviewAssignment(structure)
 
-  const onAssignment = async (newValue: number) => {
-    if (newValue === AssignmentOption.NOT_ASSIGNED || newValue === value) return
-    if (newValue === AssignmentOption.UNASSIGN) return console.log('un assignment not implemented')
-    const assignment = assignments.find((assignment) => assignment.reviewer.id === newValue)
+  const onAssignment = async (value: number) => {
+    if (value === AssignmentOption.NOT_ASSIGNED || value === selected) return
+    if (value === AssignmentOption.UNASSIGN) return console.log('un assignment not implemented')
+    const assignment = assignments.find((assignment) => assignment.reviewer.id === value)
     if (!assignment) return
-
     try {
       await assignSectionToUser({ assignment, sectionCode })
     } catch (e) {
@@ -48,11 +47,18 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = (props) => {
     }
   }
 
+  const onAssigneeSelection = async (_: any, { value }: any) => {
+    const assignment = assignments.find((assignment) => assignment.reviewer.id === value)
+    onAssignment(value as number)
+    // When review isLastLevel then all sections are assigned to same user (similar to consolidation)
+    if (assignment?.isLastLevel) setShouldAssign(value as number)
+  }
+
   const assignmentOptions = getAssignmentOptions(props)
 
   if (!assignmentOptions) return null
 
-  const { options, selected: value } = assignmentOptions
+  const { options, selected } = assignmentOptions
 
   if (assignmentError) return <Message error title={strings.ERROR_GENERIC} />
   return (
@@ -63,11 +69,8 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = (props) => {
           <Dropdown
             className="reviewer-dropdown"
             options={options}
-            value={value}
-            onChange={(_, { value }) => {
-              onAssignment(value as number)
-              setShouldAssign(value as number)
-            }}
+            value={selected}
+            onChange={onAssigneeSelection}
           />
         </Grid.Column>
       </Grid.Row>

--- a/src/containers/Review/AssignmentSectionRow.tsx
+++ b/src/containers/Review/AssignmentSectionRow.tsx
@@ -27,7 +27,8 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = (props) => {
   // Note: This is required to be passed on as props to be processed
   // in each row since the fullStructure is related to each section
   useEffect(() => {
-    if (shouldAssign as boolean) return
+    // Option -1 (UNASSIGNED) or 0 (Re-assign) shouldn't change others
+    if ((shouldAssign as number) < 1) return
     onAssignment(shouldAssign as number)
   }, [shouldAssign])
 

--- a/src/containers/Review/ReviewHome.tsx
+++ b/src/containers/Review/ReviewHome.tsx
@@ -17,8 +17,6 @@ const ReviewHome: React.FC<ReviewHomeProps> = ({
   assignmentInPreviousStage,
   fullApplicationStructure,
 }) => {
-  console.log('Render')
-
   const [shouldAssign, setShouldAssign] = useState<number | boolean>(false)
   return (
     <>

--- a/src/containers/Review/ReviewHome.tsx
+++ b/src/containers/Review/ReviewHome.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Segment, Header } from 'semantic-ui-react'
 import { AssignmentDetails, FullStructure } from '../../utils/types'
 import AssignmentSectionRow from './AssignmentSectionRow'
@@ -16,32 +16,37 @@ const ReviewHome: React.FC<ReviewHomeProps> = ({
   assignmentsByUserAndStage,
   assignmentInPreviousStage,
   fullApplicationStructure,
-}) => (
-  <>
-    {Object.values(fullApplicationStructure.sections).map(({ details: { id, title, code } }) => (
-      <Segment className="stripes" key={id}>
-        <Header className="section-title" as="h5" content={title} />
-        <AssignmentSectionRow
-          {...{
-            assignments: assignmentsByStage,
-            structure: fullApplicationStructure,
-            sectionCode: code,
-          }}
-        />
-        {assignmentsByUserAndStage.map((assignment) => (
-          <ReviewSectionRow
+}) => {
+  const [shouldAssign, setShouldAssign] = useState<number | boolean>(false)
+  return (
+    <>
+      {Object.values(fullApplicationStructure.sections).map(({ details: { id, title, code } }) => (
+        <Segment className="stripes" key={id}>
+          <Header className="section-title" as="h5" content={title} />
+          <AssignmentSectionRow
             {...{
-              key: assignment.id,
-              sectionId: id,
-              assignment,
-              fullApplicationStructure,
-              previousAssignment: assignmentInPreviousStage,
+              assignments: assignmentsByStage,
+              structure: fullApplicationStructure,
+              sectionCode: code,
+              shouldAssignState: [shouldAssign, setShouldAssign],
             }}
           />
-        ))}
-      </Segment>
-    ))}
-  </>
-)
+          {assignmentsByUserAndStage.map((assignment) => (
+            <ReviewSectionRow
+              {...{
+                key: assignment.id,
+                sectionId: id,
+                assignment,
+                fullApplicationStructure,
+                previousAssignment: assignmentInPreviousStage,
+                shouldAssignState: [shouldAssign, setShouldAssign],
+              }}
+            />
+          ))}
+        </Segment>
+      ))}
+    </>
+  )
+}
 
 export default ReviewHome

--- a/src/containers/Review/ReviewHome.tsx
+++ b/src/containers/Review/ReviewHome.tsx
@@ -17,6 +17,8 @@ const ReviewHome: React.FC<ReviewHomeProps> = ({
   assignmentInPreviousStage,
   fullApplicationStructure,
 }) => {
+  console.log('Render')
+
   const [shouldAssign, setShouldAssign] = useState<number | boolean>(false)
   return (
     <>

--- a/src/containers/Review/ReviewSectionRow.tsx
+++ b/src/containers/Review/ReviewSectionRow.tsx
@@ -23,6 +23,7 @@ type ReviewSectionRowProps = {
   assignment: AssignmentDetails
   previousAssignment: AssignmentDetails
   fullApplicationStructure: FullStructure
+  shouldAssignState: [number | boolean, React.Dispatch<React.SetStateAction<number | boolean>>]
 }
 
 const ReviewSectionRow: React.FC<ReviewSectionRowProps> = ({
@@ -30,6 +31,7 @@ const ReviewSectionRow: React.FC<ReviewSectionRowProps> = ({
   assignment,
   previousAssignment,
   fullApplicationStructure,
+  shouldAssignState,
 }) => {
   const { fullReviewStructure, error } = useGetReviewStructureForSections({
     reviewAssignment: assignment,
@@ -58,6 +60,7 @@ const ReviewSectionRow: React.FC<ReviewSectionRowProps> = ({
     action: section?.assignment?.action || ReviewAction.unknown,
     isConsolidation: section.assignment?.isConsolidation || false,
     isAssignedToCurrentUser,
+    shouldAssignState,
   }
 
   const canRenderRow =

--- a/src/utils/data/assignmentOptions.ts
+++ b/src/utils/data/assignmentOptions.ts
@@ -1,0 +1,4 @@
+export enum AssignmentOption {
+  UNASSIGN = -1,
+  NOT_ASSIGNED = 0,
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -355,6 +355,7 @@ type ReviewSectionComponentProps = {
   action: ReviewAction
   isAssignedToCurrentUser: boolean
   isConsolidation: boolean
+  shouldAssignState: [number | boolean, React.Dispatch<React.SetStateAction<number | boolean>>]
 }
 
 interface ReviewDetails {


### PR DESCRIPTION
1 - fixes #692  auto-assign sections to same assigner selected in one row
2 - No issue - [from Demo server config doc](https://docs.google.com/document/d/19CYbrFv2NyV69ggqWRVmbAxktPIwyNRe0W9c9xUikHM/edit#heading=h.wp1x7v9odz8) "Getting an error when trying to submit consolidation -- says “Not all sections have been reviewed” even when they are. Is this a bug?"
Fix self-assignment of consolidation not considering reviews not existing when generating questionAssignments.

## Brief
The problem was related to questions with different configurations, the code logic to give reviewQuestionAssignments was different to the one from `useGetReviewStructureForSection/helpers` and therefor was considering questions with empty responses/review when generating the reviewAssignment for consolidator on Self-assignment. Fix is in `useUpdateReviewAssignment.tsx`

Another problem that started to happen with fix was that only the first sections was being correctly assigned when using self-assignment. Now with this change the assignment will run per Section where the structure is up-to-date.

## Changes
- Uses new state `shouldAssignState` to pass from one section to other with `true` to self-assign another section to the same reviewer, or with the assignee index (on the dropdown) to select the same reviewer selected in one section to others.
- Check if `isLastLevel` to do the auto-assignment otherwise should not auto-assign other sections.
- Move assignment and check for error to inner component so it doesn't re-render each row each time it auto-assign other sections (self-assignment of lastLevel assignment)