### PR TITLE
Show field "Can Make Decision" in template builder UI

### DIFF
--- a/src/containers/TemplateBuilder/template/Permissions/PermissionNameList.tsx
+++ b/src/containers/TemplateBuilder/template/Permissions/PermissionNameList.tsx
@@ -60,6 +60,7 @@ const PermissionNameList: React.FC<PermissionNameListProps> = ({
             {type === PermissionPolicyType.Review && levelNumber && (
               <ReviewTemplatePermission
                 templatePermission={templatePermission}
+                stageNumber={stageNumber}
                 levelNumber={levelNumber}
               />
             )}

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -29035,7 +29035,7 @@ export type FullTemplateFragment = (
     { __typename?: 'TemplatePermissionsConnection' }
     & { nodes: Array<Maybe<(
       { __typename?: 'TemplatePermission' }
-      & Pick<TemplatePermission, 'allowedSections' | 'canSelfAssign' | 'id' | 'levelNumber' | 'restrictions' | 'stageNumber' | 'permissionNameId'>
+      & Pick<TemplatePermission, 'allowedSections' | 'canMakeFinalDecision' | 'canSelfAssign' | 'id' | 'levelNumber' | 'restrictions' | 'stageNumber' | 'permissionNameId'>
       & { permissionName?: Maybe<(
         { __typename?: 'PermissionName' }
         & Pick<PermissionName, 'id' | 'name' | 'permissionPolicyId'>
@@ -30398,6 +30398,7 @@ export const FullTemplateFragmentDoc = gql`
   templatePermissions {
     nodes {
       allowedSections
+      canMakeFinalDecision
       canSelfAssign
       id
       levelNumber

--- a/src/utils/graphql/fragments/fullTemplate.fragment.ts
+++ b/src/utils/graphql/fragments/fullTemplate.fragment.ts
@@ -38,6 +38,7 @@ export default gql`
     templatePermissions {
       nodes {
         allowedSections
+        canMakeFinalDecision
         canSelfAssign
         id
         levelNumber


### PR DESCRIPTION
Partial fix issue https://github.com/openmsupply/application-manager-server/issues/506

- Visible in Permisisons: on each level of a stage
- Rules: Can only be associated to level 1 review and for stage higher than 1.
- Required to get ProdRegistration template working - last stage should be final decision
- set true when selected