### PR TITLE
#947 search plugin showing changes when it hasn't

### DIFF
--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -53,11 +53,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   useEffect(() => {
     onSave({
-      text: textFormat
-        ? getTextFormat(textFormat, selection)
-        : selection.length > 0
-        ? JSON.stringify(selection)
-        : undefined,
+      text: getTextFormat(textFormat, selection),
       selection: selection,
     })
   }, [selection])
@@ -183,8 +179,20 @@ const getDefaultString = (result: any, fieldType: ResultsField = 'title') => {
   }
 }
 
-const getTextFormat = (textFormat: string, selection: any[]) => {
-  const strings = selection.map((item) => substituteValues(textFormat, item))
+const getTextFormat = (textFormat: string, selection: any[]): string | undefined => {
+  if (selection.length === 0) return undefined
+  if (textFormat) {
+    const strings = selection.map((item) => substituteValues(textFormat, item))
+    return strings.join(', ')
+  }
+  // Default "text" field -- needs to return consistent string regardless of
+  // object field order
+  const strings = selection.map((item) => {
+    const itemFields = Object.entries(item)
+      .sort()
+      .map(([key, value]) => `${key}: ${value}`)
+    return `{${itemFields.join(', ')}}`
+  })
   return strings.join(', ')
 }
 


### PR DESCRIPTION
Fixes #947 

Just updates the default "text" value saved in the response. Previously was just using `JSON.stringify()`, but the output might change as the retrieved response would change the order of the fields in the selection objects.

Added a custom string processor (when "textFormat" is not defined) -- bonus is that the output string is _slightly_ nicer to look at.

