### PR TITLE
Fix start message as null when empty string

### DIFF
--- a/src/containers/TemplateBuilder/template/General/MessagesConfig.tsx
+++ b/src/containers/TemplateBuilder/template/General/MessagesConfig.tsx
@@ -48,7 +48,7 @@ const MessagesConfig: React.FC<MessagesConfigProps> = ({ isOpen, onClose }) => {
   const updateMessage = async () => {
     const { startMessage, submissionMessage } = state
     const result = await updateTemplate(templateId, {
-      startMessage: startMessage && startMessage !== '' ? startMessage : null,
+      startMessage: startMessage ? startMessage : null,
       submissionMessage,
     })
     if (!result) return

--- a/src/containers/TemplateBuilder/template/General/MessagesConfig.tsx
+++ b/src/containers/TemplateBuilder/template/General/MessagesConfig.tsx
@@ -48,7 +48,7 @@ const MessagesConfig: React.FC<MessagesConfigProps> = ({ isOpen, onClose }) => {
   const updateMessage = async () => {
     const { startMessage, submissionMessage } = state
     const result = await updateTemplate(templateId, {
-      startMessage,
+      startMessage: startMessage && startMessage !== '' ? startMessage : null,
       submissionMessage,
     })
     if (!result) return


### PR DESCRIPTION
Another partial fix for https://github.com/openmsupply/application-manager-server/issues/506

### Linked PRs
- Based on PR #948 

### Changes
Just enforce starMessage to `null` in case it is set to empty string