### PR TITLE
outcome column header and application list to show correctly

### DIFF
--- a/src/containers/Outcomes/ApplicationLinks.tsx
+++ b/src/containers/Outcomes/ApplicationLinks.tsx
@@ -6,6 +6,7 @@ import { Loading } from '../../components'
 import strings from '../../utils/constants'
 import { useRouter } from '../../utils/hooks/useRouter'
 import { ApplicationLinkQuery } from '../../utils/types'
+import { Link } from 'react-router-dom'
 
 const ApplicationLinks: React.FC<{ applicationLinkQuery: ApplicationLinkQuery; id: number }> = ({
   applicationLinkQuery,
@@ -24,7 +25,6 @@ const ApplicationLinks: React.FC<{ applicationLinkQuery: ApplicationLinkQuery; i
   if (!data) return <Loading />
 
   const applications = applicationLinkQuery.getApplications(data)
-  const navigateToApplication = (serial: string) => push(`/application/${serial}`)
   if (applications.length === 0) return null
 
   return (
@@ -43,13 +43,13 @@ const ApplicationLinks: React.FC<{ applicationLinkQuery: ApplicationLinkQuery; i
           </Table.Header>
           <Table.Body>
             {applications.map((row, index) => (
-              <Table.Row
-                key={index}
-                className="clickable"
-                onClick={() => navigateToApplication(row.serial)}
-              >
+              <Table.Row key={index}>
                 {Object.values(row).map((value, index) => (
-                  <Table.Cell key={index}>{value}</Table.Cell>
+                  <Table.Cell key={index}>
+                    <Link to={`/application/${row.serial}`} target="_blank">
+                      {value}
+                    </Link>
+                  </Table.Cell>
                 ))}
               </Table.Row>
             ))}

--- a/src/containers/Outcomes/contexts/helpers.ts
+++ b/src/containers/Outcomes/contexts/helpers.ts
@@ -14,6 +14,8 @@ import {
   ApplicationLinkQueryResult,
   SchemaColumn,
   SchemaInfo,
+  GetApplicationJoinLinkTableName,
+  CaseType,
 } from '../../../utils/types'
 
 import { camelCase, snakeCase } from 'lodash'
@@ -57,7 +59,7 @@ export const getTableDisplaysForTableName = (
   return displayTableRowsWithExistingColumns.map((displayTable) => ({
     columnName: String(displayTable?.columnName),
     isTextColumn: !!displayTable?.isTextColumn,
-    title: String(displayTable?.columnName),
+    title: String(displayTable?.title),
   }))
 }
 
@@ -130,13 +132,20 @@ export const buildCountQuery = ({ pluralTableName }: OutcomeDisplay) => {
   return { query, getCount }
 }
 
-export const getDBApplicationJoinLinkTableName = (tableName: string) =>
-  snakeCase(`${tableName}ApplicationJoins`)
+export const getApplicationJoinLinkTableName: GetApplicationJoinLinkTableName = ({
+  tableName,
+  caseType,
+}) => {
+  const linkTableName = `${tableName} Application Join`
+  if (caseType === CaseType.Camel) return camelCase(linkTableName)
+  else return snakeCase(linkTableName)
+}
 
-export const getApplicationJoinLinkTableName = (tableName: string) => `${tableName}ApplicationJoins`
+export const getApplicationJoinLinkQueryName = (tableName: string) =>
+  `${getApplicationJoinLinkTableName({ tableName, caseType: CaseType.Camel })}s`
 
 export const buildApplicationLinkQuery = ({ tableName }: OutcomeDisplay) => {
-  const applicationJoin = getApplicationJoinLinkTableName(tableName)
+  const applicationJoin = getApplicationJoinLinkQueryName(tableName)
 
   const query = gql`
       query get${tableName}Applications ($id: Int!) {

--- a/src/containers/Outcomes/contexts/outcomesState.tsx
+++ b/src/containers/Outcomes/contexts/outcomesState.tsx
@@ -17,6 +17,7 @@ import {
   ApplicationLinkQueryByCode,
   OutcomeCountQueryByCode,
   SchemaInfo,
+  CaseType,
 } from '../../../utils/types'
 import {
   buildTableQuery,
@@ -26,7 +27,6 @@ import {
   getTableDisplaysForTableName,
   getDetailDisplaysForTableName,
   getApplicationJoinLinkTableName,
-  getDBApplicationJoinLinkTableName,
   getSchemaInfo,
 } from './helpers'
 
@@ -109,7 +109,11 @@ const OutcomeDisplayInner: React.FC<OutcomeDisplayInnerProps> = ({
         detailDisplaysByCode[displayCode]
       )
 
-      if (schemaTablesAsCamelcase.includes(getApplicationJoinLinkTableName(tableName)))
+      if (
+        schemaTablesAsCamelcase.includes(
+          getApplicationJoinLinkTableName({ tableName, caseType: CaseType.Camel })
+        )
+      )
         applicationLinkQueryByCode[displayCode] = buildApplicationLinkQuery(outcomeDisplay)
 
       outcomeCountQueryByCode[displayCode] = buildCountQuery(outcomeDisplay)
@@ -156,13 +160,16 @@ const useGetSchemaColumns = ({
 
   const displayNodes = outcomeDisplaysData?.outcomeDisplays?.nodes || []
   const outcomeTables = displayNodes.map((display) => snakeCase(display?.tableName || ''))
-  const outcomeApplicationLinkTabeles = displayNodes.map((display) =>
-    getDBApplicationJoinLinkTableName(display?.tableName || '')
+  const outcomeApplicationLinkTables = displayNodes.map((display) =>
+    getApplicationJoinLinkTableName({
+      tableName: display?.tableName || '',
+      caseType: CaseType.Snake,
+    })
   )
   const shouldFetchColumns = !outcomeDisplaysError && outcomeTables.length > 1
 
   const { data, error } = useGetSchemaColumnsQuery({
-    variables: { tableNames: [...outcomeTables, ...outcomeApplicationLinkTabeles] },
+    variables: { tableNames: [...outcomeTables, ...outcomeApplicationLinkTables] },
     fetchPolicy: 'network-only',
     skip: !shouldFetchColumns,
   })

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -706,6 +706,16 @@ export type OutcomeDisplaysStructure = {
   applicationLinkQueryByCode: ApplicationLinkQueryByCode
 }
 
+export enum CaseType {
+  Snake,
+  Camel,
+}
+
+export type GetApplicationJoinLinkTableName = (props: {
+  tableName: string
+  caseType: CaseType
+}) => string
+
 // *****************
 // LIST FILTERS
 // *****************


### PR DESCRIPTION
Fixes: #959 
Fixes: #958 

Column title was easy, just made sure it mapped properly.

As for application link, issue was in confirming that table existed, the tried to simplify logic, still not 100% happy with it.

Basically the schema query, is using snake case for tables names, so as a query parameter table name should be singular and snake. useGetSchemaColumns then converts all table names to camel case, and then in OutcomeDisplayInner we check if the table exists (now singular but in camel case). 

### Changes

* Changed `getDBApplicationJoinLinkTableName` to `getApplicationJoinLinkTableName` with extra case parameter
* Use `getApplicationJoinLinkTableName` correctly to provide variable to graphql query (`useGetSchemaColumns`) and to deduce if table name exists in schema (`OutcomeDisplayInner`)

