### PR TITLE
Quick fix - only prevents app from crashing

### DIFF
--- a/src/containers/Outcomes/contexts/helpers.ts
+++ b/src/containers/Outcomes/contexts/helpers.ts
@@ -166,8 +166,10 @@ export const buildApplicationLinkQuery = ({ tableName }: OutcomeDisplay) => {
 
   const getApplications = (queryResult: ApplicationLinkQueryResult) => {
     const applicationJoins = queryResult?.[tableName]?.[applicationJoin]?.nodes || []
-    if (applicationJoins.length === 0) return []
-    return applicationJoins.map(({ application }) => ({
+    // Remove null joins which is breaking the app
+    const cleanApplicationJoins = applicationJoins.filter((join) => !!join)
+    if (cleanApplicationJoins.length === 0) return []
+    return cleanApplicationJoins.map(({ application }) => ({
       name: String(application.name),
       serial: String(application.serial),
       templateName: String(application?.template?.name),


### PR DESCRIPTION
Partial fix for issue https://github.com/openmsupply/application-manager-server/issues/559

Not a fully fix, but it at least stops from breaking the app in case there is no applicationJoin returned, or the one returned is null for some reason. We will need to work a little more to get this outcomes page is better shape when working in https://github.com/openmsupply/application-manager-server/issues/556