### PR TITLE
#964 Number input fix

### DIFF
--- a/src/components/Application/ApplicationHomeWrapper.tsx
+++ b/src/components/Application/ApplicationHomeWrapper.tsx
@@ -24,7 +24,7 @@ const ApplicationHomeWrapper: React.FC<ApplicationHomeWrapperProps> = ({
       <Container id="application-home-content">
         <Header as="h2" textAlign="center">
           {`${name} ${strings.TITLE_APPLICATION_FORM}`}
-          <Header.Subheader as="h3" content={title} />
+          <Header.Subheader content={title} />
         </Header>
         {subtitle && <p>{subtitle}</p>}
         <Header as="h4" className="steps-header" content={strings.TITLE_STEPS} />

--- a/src/formElementPlugins/number/src/ApplicationView.tsx
+++ b/src/formElementPlugins/number/src/ApplicationView.tsx
@@ -108,6 +108,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         placeholder={placeholder}
         onChange={handleChange}
         onBlur={handleLoseFocus}
+        onClick={handleLoseFocus} // To capture changes via stepper
         onFocus={setIsActive}
         value={textValue ? textValue : ''}
         disabled={!isEditable}


### PR DESCRIPTION
Fix #964 

Quick little fix. Turns out clicking the stepper was only triggering the "onChange" event (which doesn't save), not the "onBlur" event (which does). Added additional "onClick" listener which calls the same function as "onBlur", so we can save input from the stepper alone.

(Also -- fixed the annoying React error about incorrectly nested DOM elements which has been low-key bugging me for ages)