### PR TITLE
#964 Number plugin fix (2)

### DIFF
--- a/src/formElementPlugins/number/src/ApplicationView.tsx
+++ b/src/formElementPlugins/number/src/ApplicationView.tsx
@@ -79,6 +79,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   }
 
   function handleLoseFocus() {
+    if (!textValue) return
     const [number, text] = parseInput(textValue, numberFormatter, simple, prefix, suffix)
     const validation = customValidate(number, type, minValue, maxValue)
     setInternalValidation(validation)


### PR DESCRIPTION
Fix #964 (again)

Sorry, was a little hasty with yesterday's fix, the "onClick" handler was running validation checks even before any text was entered (the handler is supposed to be just for onLoseFocus, so shouldn't have happened).

Anyway, added tiny extra check to not going any further if the response is still NULL (so it behaves like the other text input plugins again)