### PR TITLE
Quick fix to allow viewing lookup tables inserted with plural names

### DIFF
--- a/src/LookupTable/graphql/getDynamicSingleTable.query.ts
+++ b/src/LookupTable/graphql/getDynamicSingleTable.query.ts
@@ -3,7 +3,7 @@ import { buildFieldList, capitalizeFirstLetter, toCamelCase } from '../utils'
 
 const getDynamicSingleTable = (structure: any) => gql`
     query getDynamicSingleTable {
-      lookupTable${capitalizeFirstLetter(toCamelCase(structure.name))}s {
+      lookupTable${capitalizeFirstLetter(toCamelCase(structure.name))} {
         nodes {
           ${buildFieldList(structure.fieldMap)}
         }

--- a/src/LookupTable/hooks/useGetSingleTable.hook.tsx
+++ b/src/LookupTable/hooks/useGetSingleTable.hook.tsx
@@ -45,7 +45,7 @@ const useGetSingleTable = () => {
     if (structure?.name) {
       const tableName = `${GQL_TABLE_NAME_PREFIX}${capitalizeFirstLetter(
         toCamelCase(structure.name)
-      )}s`
+      )}`
 
       if (!loading && called && !error && data[tableName]) {
         setLookupTable(data[tableName].nodes)


### PR DESCRIPTION
Fixes back-end issue https://github.com/openmsupply/application-manager-server/issues/587

### Changes
- Just remove added `s` to table names, which are usually a plural name, and fails when trying to query with extra `s`