### PR TITLE
#993 Hide "Dev" switcher in production

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link, Route, Switch } from 'react-router-dom'
 import { Header } from 'semantic-ui-react'
 import { NoMatch } from '.'
+import Snapshots from '../containers/Dev/Snapshots'
 import TemplateWrapper from '../containers/TemplateBuilder/template/TemplateWrapper'
 import Templates from '../containers/TemplateBuilder/Templates'
 import { useUserState } from '../contexts/UserState'
@@ -49,6 +50,11 @@ const Admin: React.FC = () => {
       route: 'localisations',
       header: 'Localisations',
       Element: () => <AdminLocalisations />,
+    },
+    {
+      route: 'snapshots',
+      header: 'Snapshots',
+      Element: () => <Snapshots />,
     },
   ]
 

--- a/src/containers/Dev/DevOptions.tsx
+++ b/src/containers/Dev/DevOptions.tsx
@@ -4,15 +4,15 @@ import Snapshots from './Snapshots'
 import UserSelection from './UserSelection'
 
 const DevOptions: React.FC = () => {
-  return (
+  return process.env.NODE_ENV === 'production' ? null : (
     <div id="dev-options" style={menuStyle}>
       <Dropdown item icon="user">
         <UserSelection />
       </Dropdown>
 
-      <Dropdown item icon="file video outline">
+      {/* <Dropdown item icon="file video outline">
         <Snapshots />
-      </Dropdown>
+      </Dropdown> */}
     </div>
   )
 }

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -1,15 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import {
-  Button,
-  Grid,
-  GridColumn,
-  Icon,
-  Input,
-  Label,
-  Loader,
-  Modal,
-  Popup,
-} from 'semantic-ui-react'
+import { Button, Grid, Icon, Input, Label, Loader, Modal } from 'semantic-ui-react'
 import config from '../../config'
 
 const snapshotsBaseUrl = `${config.serverREST}/snapshot`
@@ -21,22 +11,20 @@ const uploadSnapshotUrl = `${snapshotsBaseUrl}/upload`
 // const diffSnapshotUrl = `${snapshotsBaseUrl}/diff`
 
 const Snapshots: React.FC = () => {
-  const [isOpen, setIsOpen] = useState(false)
   const [compareFrom, setCompareFrom] = useState('')
   const [isLoading, setIsLoading] = useState(false)
-  const [snapshotError, setSnapshotError] =
-    useState<{ message: string; error: string } | null>(null)
+  const [snapshotError, setSnapshotError] = useState<{ message: string; error: string } | null>(
+    null
+  )
 
   const [data, setData] = useState<string[] | null>(null)
 
   useEffect(() => {
-    if (isOpen) {
-      setData(null)
-      setCompareFrom('')
-      setSnapshotError(null)
-      getList()
-    }
-  }, [isOpen])
+    setData(null)
+    setCompareFrom('')
+    setSnapshotError(null)
+    getList()
+  }, [])
 
   const getList = async () => {
     try {
@@ -53,7 +41,6 @@ const Snapshots: React.FC = () => {
 
   const takeSnapshot = async (name: string) => {
     if (!name) return
-    setIsOpen(false)
     setIsLoading(true)
     try {
       const resultRaw = await fetch(`${takeSnapshotUrl}?name=${normaliseSnapshotName(name)}`, {
@@ -70,7 +57,6 @@ const Snapshots: React.FC = () => {
   }
 
   const useSnapshot = async (name: string) => {
-    setIsOpen(false)
     setIsLoading(true)
     try {
       const resultRaw = await fetch(`${useSnapshotUrl}?name=${name}`, {
@@ -92,7 +78,6 @@ const Snapshots: React.FC = () => {
     const file = event.target.files[0]
     const snapshotName = normaliseSnapshotName(file.name.replace('.zip', ''))
 
-    setIsOpen(false)
     setIsLoading(true)
     try {
       const data = new FormData()
@@ -117,33 +102,43 @@ const Snapshots: React.FC = () => {
     return (
       <>
         {data.map((snapshotName) => (
-          <Grid.Row key={`app_menu_${snapshotName}`}>
-            <div>
+          <Grid.Row key={`app_menu_${snapshotName}`} style={{ paddingBottom: 0 }}>
+            <Grid.Column width={3} textAlign="right">
               <Label>{snapshotName}</Label>
+            </Grid.Column>
 
-              {compareFrom === '' && (
-                <>
+            {compareFrom === '' && (
+              <>
+                <Grid.Column>
                   <Icon
+                    size="large"
                     className="clickable"
                     name="play circle"
                     onClick={() => useSnapshot(snapshotName)}
                   />
+                </Grid.Column>
+                <Grid.Column>
                   <Icon
+                    size="large"
                     className="clickable"
                     name="record"
                     onClick={() => takeSnapshot(snapshotName)}
                   />
+                </Grid.Column>
+                <Grid.Column>
                   <a href={`${snapshotFilesUrl}/${snapshotName}.zip`} target="_blank">
-                    <Icon name="download" />
+                    <Icon name="download" size="large" />
                   </a>
-                  {/* <Icon
+                </Grid.Column>
+                {/* <Icon
                     className="clickable"
+                    size="big"
                     name="random"
                     onClick={() => setCompareFrom(snapshotName)}
                   /> */}
-                </>
-              )}
-              {/* {compareFrom !== snapshotName && compareFrom !== '' ? (
+              </>
+            )}
+            {/* {compareFrom !== snapshotName && compareFrom !== '' ? (
                 <>
                   <a
                     ref={compareLinkRef}
@@ -161,7 +156,6 @@ const Snapshots: React.FC = () => {
                   />
                 </>
               ) : null} */}
-            </div>
           </Grid.Row>
         ))}
       </>
@@ -193,15 +187,22 @@ const Snapshots: React.FC = () => {
     const [value, setValue] = useState('')
     if (compareFrom !== '') return null
     return (
-      <Grid.Row key={`app_menu_new-snapshot`}>
-        <div>
+      <Grid.Row>
+        <Grid.Column width={3}>
           <Input
             size="mini"
             onChange={(_, { value }) => setValue(value)}
             placeholder="New Snapshot"
           />
-          <Icon className="clickable" name="record" onClick={() => takeSnapshot(value)} />
-        </div>
+        </Grid.Column>
+        <Grid.Column textAlign="left">
+          <Icon
+            size="large"
+            className="clickable"
+            name="record"
+            onClick={() => takeSnapshot(value)}
+          />
+        </Grid.Column>
       </Grid.Row>
     )
   }
@@ -211,45 +212,35 @@ const Snapshots: React.FC = () => {
     if (compareFrom !== '') return null
     // />
     return (
-      <Grid.Row key={`app_menu_upload-snapshot`}>
-        <Button size="mini" onClick={() => fileInputRef?.current?.click()}>
-          Upload Snapshot {''}
-          <Icon name="upload" />
-        </Button>
-        <input
-          type="file"
-          ref={fileInputRef}
-          accept=".zip"
-          hidden
-          name="file"
-          multiple={false}
-          onChange={(e) => uploadSnapshot(e)}
-        />
+      <Grid.Row>
+        <Grid.Column width={3}>
+          <Button size="mini" onClick={() => fileInputRef?.current?.click()}>
+            Upload Snapshot {''}
+            <Icon name="upload" />
+          </Button>
+          <input
+            type="file"
+            ref={fileInputRef}
+            accept=".zip"
+            hidden
+            name="file"
+            multiple={false}
+            onChange={(e) => uploadSnapshot(e)}
+          />
+        </Grid.Column>
       </Grid.Row>
     )
   }
 
   return (
-    <>
-      <Popup
-        position="bottom right"
-        trigger={<Icon name="angle down" style={{ paddingLeft: 10 }} />}
-        on="click"
-        onOpen={() => setIsOpen(true)}
-        onClose={() => setIsOpen(false)}
-        open={isOpen}
-        style={{ zIndex: 20 }}
-      >
-        <Grid textAlign="center" divided columns="equal">
-          <GridColumn>
-            {newSnapshot()}
-            {renderSnapshotList()}
-            {renderUploadSnapshot()}
-          </GridColumn>
-        </Grid>
-      </Popup>
+    <div id="list-container" style={{ backgroundColor: 'white' }}>
+      <Grid textAlign="center">
+        {newSnapshot()}
+        {renderUploadSnapshot()}
+        {renderSnapshotList()}
+      </Grid>
       {renderLoadingAndError()}
-    </>
+    </div>
   )
 }
 

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react'
-import { Button, Grid, Icon, Input, Label, Loader, Modal } from 'semantic-ui-react'
+import { Button, Grid, Header, Icon, Input, Label, Loader, Modal, Table } from 'semantic-ui-react'
 import config from '../../config'
 
 const snapshotsBaseUrl = `${config.serverREST}/snapshot`
@@ -102,34 +102,33 @@ const Snapshots: React.FC = () => {
     return (
       <>
         {data.map((snapshotName) => (
-          <Grid.Row key={`app_menu_${snapshotName}`} style={{ paddingBottom: 0 }}>
-            <Grid.Column width={3} textAlign="right">
-              <Label>{snapshotName}</Label>
-            </Grid.Column>
-
+          <Table.Row key={`app_menu_${snapshotName}`} style={{ paddingBottom: 0 }}>
+            <Table.Cell textAlign="right">
+              <p>{snapshotName}</p>
+            </Table.Cell>
             {compareFrom === '' && (
               <>
-                <Grid.Column>
+                <Table.Cell>
                   <Icon
                     size="large"
                     className="clickable"
                     name="play circle"
                     onClick={() => useSnapshot(snapshotName)}
                   />
-                </Grid.Column>
-                <Grid.Column>
+                </Table.Cell>
+                <Table.Cell width={1}>
                   <Icon
                     size="large"
                     className="clickable"
                     name="record"
                     onClick={() => takeSnapshot(snapshotName)}
                   />
-                </Grid.Column>
-                <Grid.Column>
+                </Table.Cell>
+                <Table.Cell textAlign="left">
                   <a href={`${snapshotFilesUrl}/${snapshotName}.zip`} target="_blank">
                     <Icon name="download" size="large" />
                   </a>
-                </Grid.Column>
+                </Table.Cell>
                 {/* <Icon
                     className="clickable"
                     size="big"
@@ -156,7 +155,7 @@ const Snapshots: React.FC = () => {
                   />
                 </>
               ) : null} */}
-          </Grid.Row>
+          </Table.Row>
         ))}
       </>
     )
@@ -187,23 +186,24 @@ const Snapshots: React.FC = () => {
     const [value, setValue] = useState('')
     if (compareFrom !== '') return null
     return (
-      <Grid.Row>
-        <Grid.Column width={3}>
-          <Input
-            size="mini"
-            onChange={(_, { value }) => setValue(value)}
-            placeholder="New Snapshot"
-          />
-        </Grid.Column>
-        <Grid.Column textAlign="left">
-          <Icon
-            size="large"
-            className="clickable"
-            name="record"
-            onClick={() => takeSnapshot(value)}
-          />
-        </Grid.Column>
-      </Grid.Row>
+      <>
+        <Table.Cell>
+          <div className="flex-row-start" style={{ alignItems: 'center' }}>
+            <Input
+              size="mini"
+              onChange={(_, { value }) => setValue(value)}
+              placeholder="New Snapshot"
+              style={{ paddingRight: 10 }}
+            />
+            <Icon
+              size="large"
+              className="clickable"
+              name="record"
+              onClick={() => takeSnapshot(value)}
+            />
+          </div>
+        </Table.Cell>
+      </>
     )
   }
 
@@ -212,11 +212,16 @@ const Snapshots: React.FC = () => {
     if (compareFrom !== '') return null
     // />
     return (
-      <Grid.Row>
-        <Grid.Column width={3}>
-          <Button size="mini" onClick={() => fileInputRef?.current?.click()}>
-            Upload Snapshot {''}
-            <Icon name="upload" />
+      <>
+        <Table.Cell colSpan={3} textAlign="right">
+          <Button
+            primary
+            // color="blue"
+            // size="mini"
+            onClick={() => fileInputRef?.current?.click()}
+            // labelPosition="right"
+          >
+            Upload <Icon name="upload" />
           </Button>
           <input
             type="file"
@@ -227,18 +232,23 @@ const Snapshots: React.FC = () => {
             multiple={false}
             onChange={(e) => uploadSnapshot(e)}
           />
-        </Grid.Column>
-      </Grid.Row>
+        </Table.Cell>
+      </>
     )
   }
 
   return (
-    <div id="list-container" style={{ backgroundColor: 'white' }}>
-      <Grid textAlign="center">
-        {newSnapshot()}
-        {renderUploadSnapshot()}
-        {renderSnapshotList()}
-      </Grid>
+    <div id="list-container" style={{ width: 400 }}>
+      <Header>Snapshots</Header>
+      <Table stackable>
+        <Table.Body>
+          <Table.Row>
+            {newSnapshot()}
+            {renderUploadSnapshot()}
+          </Table.Row>
+          {renderSnapshotList()}
+        </Table.Body>
+      </Table>
       {renderLoadingAndError()}
     </div>
   )

--- a/src/containers/Main/SiteLayout.tsx
+++ b/src/containers/Main/SiteLayout.tsx
@@ -11,7 +11,6 @@ import { Container } from 'semantic-ui-react'
 import DevOptions from '../Dev/DevOptions'
 import LayoutHelpers from '../../components/LayoutHelpers'
 import Outcomes from '../Outcomes/Outcomes'
-import OutcomeDisplaysContext from '../Outcomes/contexts/outcomesState'
 
 const SiteLayout: React.FC = () => {
   return (


### PR DESCRIPTION
Fix #993 

Implemented as stated in issue.

- Hide `DevOptions` completely
- Move (and modify layout to fit) the "Snapshots" list component into a page, which is only accessible with Admin JWT
- accessed at `/admin/snapshots` -- note: intentionally omitted from "Admin" menu, we don't really want this accessible to anyone other than devs