### PR TITLE
TB - Added segment at the start of each action line combining all action tools

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -1762,6 +1762,10 @@ a:hover {
 .config-container-alternate {
   .config-container();
   background-color: rgba(0, 0, 0, 0.03);
+
+  .ui.segment {
+    .padding-zero();
+  }
 }
 
 /*******************************

--- a/src/containers/TemplateBuilder/shared/CheckboxIO.tsx
+++ b/src/containers/TemplateBuilder/shared/CheckboxIO.tsx
@@ -3,8 +3,9 @@ import { Checkbox, Popup } from 'semantic-ui-react'
 
 type CheckboxIOprops = {
   value: boolean
-  title: string
   setValue: (value: boolean) => boolean | undefined | void
+  title?: string
+  basic?: boolean
   disabled?: boolean
   disabledMessage?: string
   isPropUpdated?: boolean
@@ -13,6 +14,7 @@ type CheckboxIOprops = {
 const CheckboxIO: React.FC<CheckboxIOprops> = ({
   value,
   setValue,
+  basic = false,
   disabled = false,
   title,
   disabledMessage,
@@ -34,7 +36,8 @@ const CheckboxIO: React.FC<CheckboxIOprops> = ({
           <div className="io-component value">
             <Checkbox
               checked={innerValue}
-              toggle
+              toggle={!basic}
+              slider={basic}
               disabled={disabled}
               size="small"
               onChange={() => {

--- a/src/containers/TemplateBuilder/template/Actions/TriggerDisplay.tsx
+++ b/src/containers/TemplateBuilder/template/Actions/TriggerDisplay.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Checkbox, Header } from 'semantic-ui-react'
+import { Checkbox, Header, Segment } from 'semantic-ui-react'
 import strings from '../../../../utils/constants'
 import { TemplateAction, Trigger } from '../../../../utils/generated/graphql'
 import CheckboxIO from '../../shared/CheckboxIO'
@@ -127,26 +127,37 @@ const TriggerDisplay: React.FC<TriggerDisplayProps> = ({ trigger, allTemplateAct
           {templateActions.map((templateAction, index) => (
             <div key={templateAction.id} className="config-container-alternate">
               <div className="flex-row-start-center">
-                {!isAsynchronous(templateAction) && templateAction?.sequence !== firstSequence && (
+                <Segment basic className="flex-column-center-center">
+                  {!isAsynchronous(templateAction) && templateAction?.sequence !== firstSequence && (
+                    <IconButton
+                      name="angle up"
+                      onClick={() => {
+                        swapSequences(templateAction, templateActions[index - 1])
+                      }}
+                    />
+                  )}
+                  {!isAsynchronous(templateAction) && templateAction?.sequence !== lastSequence && (
+                    <IconButton
+                      name="angle down"
+                      onClick={() => {
+                        swapSequences(templateAction, templateActions[index + 1])
+                      }}
+                    />
+                  )}
                   <IconButton
-                    name="angle up"
-                    onClick={() => {
-                      swapSequences(templateAction, templateActions[index - 1])
-                    }}
+                    name="setting"
+                    onClick={() => setCurrentTemplateAction(templateAction)}
                   />
-                )}
-                {!isAsynchronous(templateAction) && templateAction?.sequence !== lastSequence && (
-                  <IconButton
-                    name="angle down"
-                    onClick={() => {
-                      swapSequences(templateAction, templateActions[index + 1])
-                    }}
+                  <CheckboxIO
+                    basic={true}
+                    disabled={!isDraft}
+                    disabledMessage={disabledMessage}
+                    value={!isAsynchronous(templateAction)}
+                    setValue={(isSequential) =>
+                      setIsSequential(templateAction?.id || 0, isSequential)
+                    }
                   />
-                )}
-                <IconButton
-                  name="setting"
-                  onClick={() => setCurrentTemplateAction(templateAction)}
-                />
+                </Segment>
                 <div className="flex-row-start-center-wrap">
                   <TextIO
                     title={strings.TEMPLATE_LABEL_ACTION}
@@ -168,15 +179,6 @@ const TriggerDisplay: React.FC<TriggerDisplayProps> = ({ trigger, allTemplateAct
                     </div>
                   </div>
                 </div>
-                <CheckboxIO
-                  disabled={!isDraft}
-                  disabledMessage={disabledMessage}
-                  title={strings.TEMPLATE_LABEL_SEQUENTIAL}
-                  value={!isAsynchronous(templateAction)}
-                  setValue={(isSequential) =>
-                    setIsSequential(templateAction?.id || 0, isSequential)
-                  }
-                />
                 <IconButton
                   disabled={!isDraft}
                   disabledMessage={disabledMessage}


### PR DESCRIPTION
## Linked PR
- Based on PR #957 

### Changes
- **Not a priority for now so just added to a PR for later review**
- Small change to component `CheckboxIO` to show a slider in a simplified option when receiving the props `basic` 
- Just another layout addition - hope is good and helpful to others - Show all tools in the first column of each action, combining also the `isSequential` option that used to be at the end of the row.

### Images
<img width="1032" alt="Screen Shot 2021-09-23 at 11 52 43 AM" src="https://user-images.githubusercontent.com/16461988/134437224-8e983c4d-3d97-43b1-b731-11733c98f7bc.png">
<img width="1019" alt="Screen Shot 2021-09-23 at 11 52 36 AM" src="https://user-images.githubusercontent.com/16461988/134437235-e550606a-bd2e-4d19-953b-3f495044bb53.png">
<img width="1022" alt="Screen Shot 2021-09-23 at 11 52 23 AM" src="https://user-images.githubusercontent.com/16461988/134437236-e0463794-4713-423b-8bc5-8b9654cff1e9.png">

