### PR TITLE
#590B Row-based restrictions for Outcomes

### DIFF
--- a/src/containers/Outcomes/OutcomesDetail.tsx
+++ b/src/containers/Outcomes/OutcomesDetail.tsx
@@ -16,9 +16,9 @@ const OutcomeDetails: React.FC = () => {
     params: { tableName, id },
   } = useRouter()
   const { outcomeDetail, loading, error } = useOutcomesDetail({ tableName, recordId: id })
-  usePageTitle(outcomeDetail?.header.value || '')
+  usePageTitle(outcomeDetail?.header?.value || '')
 
-  if (error) return <p>{error?.message}</p>
+  if (error) return <Message error header={error?.message} content={error?.detail} />
   if (loading || !outcomeDetail) return <Loading />
 
   const { header, tableTitle, columns, displayDefinitions, item, linkedApplications } =

--- a/src/utils/hooks/useOutcomes.tsx
+++ b/src/utils/hooks/useOutcomes.tsx
@@ -110,6 +110,10 @@ const processRequest = (
   setLoadingMethod(true)
   getRequest(url, { Authorization: `Bearer ${JWT}` })
     .then((response) => {
+      if (response?.error) {
+        setState(response, false, undefined)
+        return
+      }
       if (response?.statusCode) {
         setState(response, false, undefined)
         return


### PR DESCRIPTION
Front-end complement to [back-end PR #600](https://github.com/openmsupply/application-manager-server/pull/600)

The restrictions are done in back-end. This PR just adds some more robust error handling for Details view (when you try and request an item you're not allowed to see).

Please test with snapshot `outcome_row_restrictions` in templates repo `/dev/snapshots`

You can inspect the "outcome_display" table to see how these outcome displays are configured.

Things to try:
- As "Admin" you should see Users and Organisations displays that show all users and orgs, as before
- As a general user, orgs should be restricted to companies you belong to, and users that belong to the company you're currently logged in as. (User "jane_smith" has a lot of companies)
- Try going to the details page of an item you're not allowed to see: note the error message. (e.g.`http://localhost:3000/outcomes/user/7` when logged in as "jane_smith")

Can you think of other restrictions we might wish to have on any outcome tables (row-based)? I'd like to make sure this functionality can handle all requirements.