### PR TITLE
#1017 fix final decision after review stages

### DIFF
--- a/src/components/Review/ReviewLabel.tsx
+++ b/src/components/Review/ReviewLabel.tsx
@@ -33,6 +33,14 @@ export const ReviewLabel: React.FC<ReviewLabelProps> = ({ reviewer, message, str
   <LabelWrapper labelContent={message || strings.REVIEW_NOT_FOUND} reviewer={reviewer} />
 )
 
+export const ReviewCanMakeDecisionLabel: React.FC<ReviewLabelProps> = ({ reviewer, strings }) => {
+  const doneByYourself = !reviewer
+  const consolidationLabel = `${strings.LABEL_REVIEW_MAKE_DECISION_BY} ${
+    doneByYourself ? strings.ASSIGNMENT_YOURSELF : ''
+  }`
+  return <LabelWrapper labelContent={consolidationLabel} reviewer={reviewer} />
+}
+
 export const ReviewSelfAssignmentLabel: React.FC<ReviewLabelProps> = ({ reviewer, strings }) => (
   <LabelWrapper
     labelContent={

--- a/src/components/Review/ReviewSectionRowAssigned.tsx
+++ b/src/components/Review/ReviewSectionRowAssigned.tsx
@@ -22,13 +22,13 @@ const ReviewSectionRowAssigned: React.FC<ReviewSectionComponentProps> = ({
     switch (action) {
       case ReviewAction.unknown:
         return null
-      case ReviewAction.canSelfAssign:
+      case ReviewAction.canMakeDecision:
         return isAssignedToCurrentUser ? (
           <ReviewCanMakeDecisionLabel strings={strings} />
         ) : (
           <ReviewCanMakeDecisionLabel reviewer={assignment.reviewer} strings={strings} />
         )
-      case ReviewAction.canMakeDecision:
+      case ReviewAction.canSelfAssign:
         return isAssignedToCurrentUser ? (
           <ReviewSelfAssignmentLabel strings={strings} />
         ) : (

--- a/src/components/Review/ReviewSectionRowAssigned.tsx
+++ b/src/components/Review/ReviewSectionRowAssigned.tsx
@@ -8,6 +8,7 @@ import {
   ReviewLockedLabel,
   ReviewSelfAssignmentLabel,
   ReviewInProgressLabel,
+  ReviewCanMakeDecisionLabel,
 } from './ReviewLabel'
 
 const ReviewSectionRowAssigned: React.FC<ReviewSectionComponentProps> = ({
@@ -22,6 +23,11 @@ const ReviewSectionRowAssigned: React.FC<ReviewSectionComponentProps> = ({
       case ReviewAction.unknown:
         return null
       case ReviewAction.canSelfAssign:
+        return isAssignedToCurrentUser ? (
+          <ReviewCanMakeDecisionLabel strings={strings} />
+        ) : (
+          <ReviewCanMakeDecisionLabel reviewer={assignment.reviewer} strings={strings} />
+        )
       case ReviewAction.canMakeDecision:
         return isAssignedToCurrentUser ? (
           <ReviewSelfAssignmentLabel strings={strings} />

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -139,6 +139,7 @@ export default {
   LABEL_REVIEW_DECICION_CONFORM: 'Conform',
   LABEL_REVIEW_DECISION_NON_CONFORM: 'Non conform',
   LABEL_REVIEW_IN_PROGRESS: 'Review in Progress',
+  LABEL_REVIEW_MAKE_DECISION_BY: 'Awaiting decision making by',
   LABEL_REVIEW_OVERALL_COMMENT: 'Overall comment',
   LABEL_REVIEW_RESSUBMIT: 'Non conform',
   LABEL_REVIEW_SECTION: 'Please complete the section',

--- a/src/utils/helpers/structure/generateFinalDecisionProgress.ts
+++ b/src/utils/helpers/structure/generateFinalDecisionProgress.ts
@@ -1,0 +1,25 @@
+import {
+  generateConsolidationValidity,
+  generateConsolidatorResponsesProgress,
+  generateReviewerResponsesProgress,
+  generateReviewValidity,
+} from '.'
+import { FullStructure } from '../../types'
+
+const generateFinalDecisionProgress = (newStructure: FullStructure) => {
+  if (newStructure.assignment?.finalDecision?.decisionOnReview) {
+    generateReviewerResponsesProgress(newStructure)
+    generateReviewValidity(newStructure)
+    newStructure.sortedSections?.forEach((section) =>
+      console.log(section.details.code, section.reviewProgress)
+    )
+  } else {
+    generateConsolidatorResponsesProgress(newStructure)
+    generateConsolidationValidity(newStructure)
+    newStructure.sortedSections?.forEach((section) =>
+      console.log(section.details.code, section.consolidationProgress)
+    )
+  }
+}
+
+export default generateFinalDecisionProgress

--- a/src/utils/helpers/structure/generateReviewerResponsesProgress.ts
+++ b/src/utils/helpers/structure/generateReviewerResponsesProgress.ts
@@ -5,10 +5,6 @@ import { FullStructure, SectionState, Page, ReviewProgress } from '../../types'
 const generateReviewerResponsesProgress = (newStructure: FullStructure) => {
   newStructure?.sortedPages?.forEach(generatePageReviewProgress)
   newStructure?.sortedSections?.forEach(generateSectionReviewProgress)
-
-  newStructure?.sortedSections?.forEach((section) =>
-    console.log(section.details.code, section.reviewProgress)
-  )
 }
 
 const generateSectionReviewProgress = (section: SectionState) => {

--- a/src/utils/helpers/structure/generateReviewerResponsesProgress.ts
+++ b/src/utils/helpers/structure/generateReviewerResponsesProgress.ts
@@ -5,6 +5,10 @@ import { FullStructure, SectionState, Page, ReviewProgress } from '../../types'
 const generateReviewerResponsesProgress = (newStructure: FullStructure) => {
   newStructure?.sortedPages?.forEach(generatePageReviewProgress)
   newStructure?.sortedSections?.forEach(generateSectionReviewProgress)
+
+  newStructure?.sortedSections?.forEach((section) =>
+    console.log(section.details.code, section.reviewProgress)
+  )
 }
 
 const generateSectionReviewProgress = (section: SectionState) => {
@@ -13,8 +17,14 @@ const generateSectionReviewProgress = (section: SectionState) => {
 
 const generatePageReviewProgress = (page: Page) => {
   const totalReviewable = page.state.filter(
-    ({ isAssigned, thisReviewLatestResponse, latestApplicationResponse, element }) =>
-      (isAssigned || !!thisReviewLatestResponse) &&
+    ({
+      isAssigned,
+      thisReviewLatestResponse,
+      latestOriginalReviewResponse,
+      latestApplicationResponse,
+      element,
+    }) =>
+      (isAssigned || !!thisReviewLatestResponse || !!latestOriginalReviewResponse) &&
       element.isVisible &&
       latestApplicationResponse?.id
   )

--- a/src/utils/helpers/structure/index.ts
+++ b/src/utils/helpers/structure/index.ts
@@ -3,6 +3,7 @@ import addChangeRequestForReviewer from './addChangeRequestForReviewer'
 import addApplicationResponses from './addApplicationResponses'
 import addElementsById from './addElementsById'
 import addEvaluatedResponsesToStructure from './addEvaluatedResponsesToStructure'
+import addReviewResponses from './addReviewResponses'
 import addSortedSectionsAndPages from './addSortedSectionsAndPages'
 import addThisReviewResponses from './addReviewResponses'
 import buildSectionsStructure from './buildSectionsStructure'
@@ -11,6 +12,7 @@ import generateApplicantChangesRequestedProgress from './generateApplicantChange
 import generateApplicantResponsesProgress from './generateApplicantResponsesProgress'
 import generateConsolidationValidity from './generateConsolidationValidity'
 import generateConsolidatorResponsesProgress from './generateConsolidatorResponsesProgress'
+import generateFinalDecisionProgress from './generateFinalDecisionProgress'
 import generateReviewerChangesRequestedProgress from './generateReviewerChangesRequestedProgress'
 import generateReviewerResponsesProgress from './generateReviewerResponsesProgress'
 import generateReviewSectionActions from './generateReviewSectionActions'
@@ -20,6 +22,7 @@ export {
   addApplicationResponses,
   addChangeRequestForApplicant,
   addChangeRequestForReviewer,
+  addReviewResponses,
   addSortedSectionsAndPages,
   generateApplicantChangesRequestedProgress,
   generateApplicantResponsesProgress,
@@ -30,6 +33,7 @@ export {
   buildSectionsStructure,
   generateConsolidationValidity,
   generateConsolidatorResponsesProgress,
+  generateFinalDecisionProgress,
   generateReviewerChangesRequestedProgress,
   generateReviewerResponsesProgress,
   generateReviewSectionActions,

--- a/src/utils/hooks/useGetDecisionOptions.ts
+++ b/src/utils/hooks/useGetDecisionOptions.ts
@@ -46,7 +46,7 @@ type UseGetDecisionOptions = (
 
 const useGetDecisionOptions: UseGetDecisionOptions = (assignment, thisReview) => {
   const { strings } = useLanguageProvider()
-  const { isLastLevel, isFinalDecision, canSubmitReviewAs } = assignment as ReviewAssignment
+  const { isLastLevel, finalDecision, canSubmitReviewAs } = assignment as ReviewAssignment
   const [decisionOptions, setDecisionOptions] = useState<DecisionOption[]>(
     getInitialDecisionOptions(strings)
   )
@@ -63,7 +63,7 @@ const useGetDecisionOptions: UseGetDecisionOptions = (assignment, thisReview) =>
       let value = false
       // if review is NOT DRAFT then use decision from DB (and make it the only one visible)
       if (!isDraft) isVisible = value = code === decisionInStructure
-      else if (isFinalDecision) {
+      else if (finalDecision) {
         isVisible = code === Decision.NonConform || code === Decision.Conform
         value = false
       }

--- a/src/utils/hooks/useGetReviewStructureForSection/helpers.tsx
+++ b/src/utils/hooks/useGetReviewStructureForSection/helpers.tsx
@@ -6,6 +6,7 @@ import {
   TemplateElement,
   ReviewResponseStatus,
   ReviewStatus,
+  ReviewAssignmentStatus,
 } from '../../generated/graphql'
 import {
   addChangeRequestForReviewer,
@@ -28,6 +29,7 @@ import {
   SectionState,
   PageElement,
   AssignmentDetails,
+  ReviewAssignment,
 } from '../../types'
 
 const getSectionIds = ({
@@ -123,8 +125,8 @@ const generateReviewStructure: GenerateReviewStructure = ({
   const sections = getFilteredSections(sectionIds, newStructure.sortedSections || [])
   generateReviewSectionActions({
     sections,
-    reviewAssignment,
     thisReview: newStructure.thisReview,
+    reviewAssignment: newStructure.assignment as ReviewAssignment,
     currentUserId: currentUser?.userId as number,
   })
 
@@ -150,6 +152,8 @@ const setReviewAndAssignment = (structure: FullStructure, reviewAssignment: Assi
   // review info comes from reviewAssignment that's passed to this hook
   structure.thisReview = review
   structure.assignment = {
+    assignee: reviewAssignment.reviewer,
+    assignmentStatus: reviewAssignment.current.assignmentStatus as ReviewAssignmentStatus,
     isLastLevel,
     finalDecision: isFinalDecision
       ? {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -14,7 +14,6 @@ import {
   User as GraphQLUser,
   Organisation as GraphQLOrg,
   Filter,
-  Application,
   UiLocation,
 } from './generated/graphql'
 
@@ -345,6 +344,8 @@ interface ResponsesByCode {
 }
 
 interface ReviewAssignment {
+  assignee: GraphQLUser
+  assignmentStatus: ReviewAssignmentStatus
   canSubmitReviewAs?: Decision | null
   isLastLevel: boolean
   finalDecision: {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -347,7 +347,9 @@ interface ResponsesByCode {
 interface ReviewAssignment {
   canSubmitReviewAs?: Decision | null
   isLastLevel: boolean
-  isFinalDecision: boolean
+  finalDecision: {
+    decisionOnReview: boolean
+  } | null
 }
 
 type ReviewSectionComponentProps = {


### PR DESCRIPTION
Fixes #1017 

### Brief and screenshots
- basically, the Final decision was only considering previous stages as Consolidation. Changes here are to also consider if only Review was done in the previous stage. I'll add the snapshot used to test in our private repo for testing
- Also fixed how the progress show and how you are able to submit now when previous stage was Review
<img width="715" alt="Screen Shot 2021-09-30 at 11 41 51 AM" src="https://user-images.githubusercontent.com/16461988/135358419-9ebe22d6-8736-43e3-83f7-537ede86cc35.png">
- The idea is that previous review (or Consolidation) review responses are duplicated (after clicking on Make Decision) and the Final decision maker doesn't need to go trough each element to submit. They can just make the final decision. But are also allowed to change the existing reviewResponses (associated to them) to something else if they whish. 
<img width="681" alt="Screen Shot 2021-09-30 at 11 41 59 AM" src="https://user-images.githubusercontent.com/16461988/135358425-b3d38850-ae8b-45e4-b3f5-fe0e7d161a43.png">
- Different from other decisions the "Final decision" also can pick either **Non conform** or **Conform** regardeless of each reviewResponse decision...

### Changes
- Added a new label for when the Reviewer can start a Final decision:
<img width="737" alt="Screen Shot 2021-09-30 at 11 40 45 AM" src="https://user-images.githubusercontent.com/16461988/135358316-1d01b4b4-2944-4674-8b45-c1b319c6f48c.png">
- Added new `setReviewAndAssignment` to function that also checks if `finalDecison` is `decisionOnReview`
- Create new utility method to `generateFinalDecisionProgress` which will only decide to use either method to generate based on Consolidation or Review - only moved to separated utility to keep this already gigantic method simpler.
- Added some specifics tyes to ReviewAssignment and use this field (from Review structure) to pass to `generateReviewSectionAction`. Which also has to find out if this is related to Consolidation or Review to get proper progress coreectly.