### PR TITLE
#1015 Summary to allow applicant adding new responses

### DIFF
--- a/src/components/PageElements/Elements/ApplicantElementWrapper.tsx
+++ b/src/components/PageElements/Elements/ApplicantElementWrapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { SummaryViewWrapperProps } from '../../../formElementPlugins/types'
 import { ApplicationResponse, ReviewResponse } from '../../../utils/generated/graphql'
-import { UpdateIcon } from '../PageElements'
+import { AddIcon, UpdateIcon } from '../PageElements'
 import ViewHistoryButton from '../ViewHistoryButton'
 import ApplicantResponseElement from './ApplicantResponseElement'
 import ReviewResponseElement from './ReviewResponseElement'
@@ -10,6 +10,7 @@ interface ApplicantElementWrapperProps {
   elementCode: string
   latestApplicationResponse: ApplicationResponse
   summaryViewProps: SummaryViewWrapperProps
+  canApplicantAddNew: boolean
   canApplicantEdit: boolean
   enableViewHistory: boolean
   reviewResponse?: ReviewResponse
@@ -23,6 +24,7 @@ const ApplicantElementWrapper: React.FC<ApplicantElementWrapperProps> = ({
   latestApplicationResponse,
   summaryViewProps,
   reviewResponse,
+  canApplicantAddNew,
   canApplicantEdit,
   enableViewHistory,
   updateMethod,
@@ -39,7 +41,11 @@ const ApplicantElementWrapper: React.FC<ApplicantElementWrapperProps> = ({
         summaryViewProps={summaryViewProps}
         isResponseUpdated={!!isChangeRequest || !!isChanged}
       >
-        {canApplicantEdit && <UpdateIcon onClick={updateMethod} />}
+        {canApplicantAddNew ? (
+          <AddIcon onClick={updateMethod} />
+        ) : canApplicantEdit ? (
+          <UpdateIcon onClick={updateMethod} />
+        ) : null}
       </ApplicantResponseElement>
       {canRenderReviewResponse && (
         <ReviewResponseElement

--- a/src/components/PageElements/PageElements.tsx
+++ b/src/components/PageElements/PageElements.tsx
@@ -135,10 +135,15 @@ const PageElements: React.FC<PageElementProps> = ({
             } = state
 
             const isResponseUpdated = !!isChangeRequest || !!isChanged
-            // Applicant can edit the summary page when is first submission and a response has been added
-            // Or when changes required for any question that have been updated (isUpdating true)
+
+            // Applicant can add new response to elements not responded in first submission or changes required
+            const canApplicantAddNew = canEdit && !isUpdating && !latestApplicationResponse?.value
+            // And can edit if not an empty response in first submission or
+            // during updated to changes required any question that have been updated (isUpdating true)
             const canApplicantEdit =
-              canEdit && (isUpdating ? isResponseUpdated : !!latestApplicationResponse?.value)
+              canEdit &&
+              !canApplicantAddNew &&
+              (isUpdating ? isResponseUpdated : !!latestApplicationResponse?.value)
 
             const reviewResponse = previousApplicationResponse?.reviewResponses.nodes[0]
             const summaryViewProps = getSummaryViewProps(element)
@@ -157,6 +162,7 @@ const PageElements: React.FC<PageElementProps> = ({
               previousApplicationResponse,
               summaryViewProps,
               reviewResponse: reviewResponse as ReviewResponse,
+              canApplicantAddNew,
               canApplicantEdit,
               enableViewHistory,
               isChanged,
@@ -266,6 +272,10 @@ const RenderElementWrapper: React.FC<{ extraSpacing?: boolean }> = ({ children, 
 
 export const UpdateIcon: React.FC<{ onClick: Function }> = ({ onClick }) => (
   <Icon className="clickable" name="edit" size="large" color="blue" onClick={onClick} />
+)
+
+export const AddIcon: React.FC<{ onClick: Function }> = ({ onClick }) => (
+  <Icon className="clickable" name="add" size="large" color="blue" onClick={onClick} />
 )
 
 export const UpdatedLabel: React.FC = () => {


### PR DESCRIPTION
Fixes #1015

Quick fix to allow adding new responses from Application summary page in first submission

Now on first submission you can click to add a new responses -> clicking will take applicant back to page to incude response:
<img width="740" alt="Screen Shot 2021-09-30 at 2 50 07 PM" src="https://user-images.githubusercontent.com/16461988/135372824-fe324aa2-1d13-4c6d-b2df-18046dfad942.png">

When updating from changes-requested option to add doesn't show to keep existing logic:
<img width="750" alt="Screen Shot 2021-09-30 at 2 51 26 PM" src="https://user-images.githubusercontent.com/16461988/135372828-6181afa7-d754-48dd-9898-9d6a994f6062.png">

