### PR TITLE
#1007 applicationData for Action evaluation previews

### DIFF
--- a/src/containers/TemplateBuilder/shared/Evaluation.tsx
+++ b/src/containers/TemplateBuilder/shared/Evaluation.tsx
@@ -69,10 +69,8 @@ const Evaluation: React.FC<EvaluationProps> = ({
       thisResponse: fullStructure?.responsesByCode?.[currentElementCode]?.text,
     },
     currentUser,
-    applicationData: fullStructure ? fullStructure?.info : applicationData,
+    applicationData: applicationData ? applicationData : fullStructure?.info,
   }
-
-  console.log('objects', objects)
 
   const evaluationParameters = {
     objects,

--- a/src/containers/TemplateBuilder/shared/Evaluation.tsx
+++ b/src/containers/TemplateBuilder/shared/Evaluation.tsx
@@ -17,7 +17,8 @@ type EvaluationProps = {
   evaluation: EvaluatorNode
   currentElementCode: string
   setEvaluation: (evaluation: EvaluatorNode) => void
-  fullStructure?: FullStructure
+  fullStructure?: FullStructure // for Form
+  applicationData?: any // for Actions
   label: string
   updateKey?: (key: string) => void
   deleteKey?: () => void
@@ -53,6 +54,7 @@ const Evaluation: React.FC<EvaluationProps> = ({
   label,
   currentElementCode,
   fullStructure,
+  applicationData,
   updateKey,
   deleteKey,
 }) => {
@@ -67,8 +69,10 @@ const Evaluation: React.FC<EvaluationProps> = ({
       thisResponse: fullStructure?.responsesByCode?.[currentElementCode]?.text,
     },
     currentUser,
-    applicationData: fullStructure?.info,
+    applicationData: fullStructure ? fullStructure?.info : applicationData,
   }
+
+  console.log('objects', objects)
 
   const evaluationParameters = {
     objects,

--- a/src/containers/TemplateBuilder/shared/Parameters.tsx
+++ b/src/containers/TemplateBuilder/shared/Parameters.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { Accordion, Button, Header, Icon } from 'semantic-ui-react'
 import { EvaluatorNode, FullStructure } from '../../../utils/types'
+import { useActionState } from '../template/Actions/Actions'
 import CheckboxIO from './CheckboxIO'
 import Evaluation from './Evaluation'
 import JsonIO from './JsonIO'
@@ -21,6 +22,7 @@ export const Parameters: React.FC<ParametersProps> = ({
   currentElementCode,
   fullStructure,
 }) => {
+  const { applicationData } = useActionState()
   const [asGui, setAsGui] = useState(true)
   const [isActive, setIsActive] = useState(false)
 
@@ -88,6 +90,7 @@ export const Parameters: React.FC<ParametersProps> = ({
                     }}
                     key={key}
                     evaluation={value}
+                    applicationData={applicationData}
                     currentElementCode={currentElementCode}
                     fullStructure={fullStructure}
                     label={key}

--- a/src/containers/TemplateBuilder/template/Actions/ActionConfig.tsx
+++ b/src/containers/TemplateBuilder/template/Actions/ActionConfig.tsx
@@ -9,6 +9,7 @@ import Evaluation from '../../shared/Evaluation'
 import { useOperationState } from '../../shared/OperationContext'
 import { Parameters, ParametersType } from '../../shared/Parameters'
 import TextIO from '../../shared/TextIO'
+import { useFullApplicationState } from '../ApplicationWrapper'
 import { disabledMessage, useTemplateState } from '../TemplateWrapper'
 import { useActionState } from './Actions'
 import FromExistingAction from './FromExistingAction'
@@ -44,7 +45,7 @@ const ActionConfig: React.FC<ActionConfigProps> = ({ templateAction, onClose }) 
   } = useTemplateState()
   const { updateTemplate } = useOperationState()
   const [state, setState] = useState<ActionUpdateState | null>(null)
-  const { allActionsByCode } = useActionState()
+  const { allActionsByCode, applicationData } = useActionState()
 
   useEffect(() => {
     if (!templateAction) return setState(null)
@@ -121,6 +122,7 @@ const ActionConfig: React.FC<ActionConfigProps> = ({ templateAction, onClose }) 
             currentElementCode={''}
             evaluation={state?.condition}
             setEvaluation={(condition) => setState({ ...state, condition })}
+            applicationData={applicationData}
           />
         </div>
         <div className="flex-row-center-center">

--- a/src/containers/TemplateBuilder/template/Actions/Actions.tsx
+++ b/src/containers/TemplateBuilder/template/Actions/Actions.tsx
@@ -9,6 +9,7 @@ import {
   Trigger,
   useGetAllActionsQuery,
 } from '../../../../utils/generated/graphql'
+import { ApplicationDetails } from '../../../../utils/types'
 import CheckboxIO from '../../shared/CheckboxIO'
 import DropdownIO from '../../shared/DropdownIO'
 import { EvaluationHeader } from '../../shared/Evaluation'
@@ -18,18 +19,32 @@ import TextIO from '../../shared/TextIO'
 import { stringSort } from '../Permissions/PermissionNameInfo/PermissionNameInfo'
 import { disabledMessage, useTemplateState } from '../TemplateWrapper'
 import TriggerDisplay from './TriggerDisplay'
+import { useFormStructureState } from '../Form/FormWrapper'
+import { getRequest } from '../../../../utils/helpers/fetchMethods'
+import config from '../../../../config'
 
 type ActionsByCode = { [actionCode: string]: ActionPlugin }
 
 type ActionContext = {
   allActionsByCode: ActionsByCode
+  applicationData: any
 }
 
-const Context = createContext<ActionContext>({ allActionsByCode: {} })
+const Context = createContext<ActionContext>({ allActionsByCode: {}, applicationData: {} })
 
 const ActionsWrapper: React.FC = () => {
-  const [state, setState] = useState<ActionContext | null>(null)
+  const [state, setState] = useState<ActionContext>({ allActionsByCode: {}, applicationData: {} })
   const { data } = useGetAllActionsQuery()
+  const { configApplicationId } = useFormStructureState()
+
+  useEffect(() => {
+    if (!configApplicationId) return
+    const url = `${config.serverREST}/admin/get-application-data?applicationId=${configApplicationId}`
+    getRequest(url).then((applicationData) => {
+      console.log(applicationData)
+      setState({ ...state, applicationData })
+    })
+  }, [])
 
   useEffect(() => {
     const allActions = data?.actionPlugins?.nodes
@@ -41,7 +56,7 @@ const ActionsWrapper: React.FC = () => {
       allActionsByCode[String(actionPlugin?.code)] = actionPlugin as ActionPlugin
     })
 
-    setState({ allActionsByCode })
+    setState({ ...state, allActionsByCode })
   }, [data])
 
   if (!state) return <Loading />

--- a/src/containers/TemplateBuilder/template/Actions/Actions.tsx
+++ b/src/containers/TemplateBuilder/template/Actions/Actions.tsx
@@ -28,23 +28,23 @@ type ActionsByCode = { [actionCode: string]: ActionPlugin }
 type ActionContext = {
   allActionsByCode: ActionsByCode
   applicationData: any
+  loading: boolean
 }
 
-const Context = createContext<ActionContext>({ allActionsByCode: {}, applicationData: {} })
+const Context = createContext<ActionContext>({
+  allActionsByCode: {},
+  applicationData: {},
+  loading: true,
+})
 
 const ActionsWrapper: React.FC = () => {
-  const [state, setState] = useState<ActionContext>({ allActionsByCode: {}, applicationData: {} })
+  const [state, setState] = useState<ActionContext>({
+    allActionsByCode: {},
+    applicationData: {},
+    loading: true,
+  })
   const { data } = useGetAllActionsQuery()
   const { configApplicationId } = useFormStructureState()
-
-  useEffect(() => {
-    if (!configApplicationId) return
-    const url = `${config.serverREST}/admin/get-application-data?applicationId=${configApplicationId}`
-    getRequest(url).then((applicationData) => {
-      console.log(applicationData)
-      setState({ ...state, applicationData })
-    })
-  }, [])
 
   useEffect(() => {
     const allActions = data?.actionPlugins?.nodes
@@ -56,10 +56,17 @@ const ActionsWrapper: React.FC = () => {
       allActionsByCode[String(actionPlugin?.code)] = actionPlugin as ActionPlugin
     })
 
-    setState({ ...state, allActionsByCode })
-  }, [data])
+    if (!configApplicationId) return
+    const url = `${config.serverREST}/admin/get-application-data?applicationId=${configApplicationId}`
+    getRequest(url).then((applicationData) => {
+      console.log(applicationData)
+      setState({ allActionsByCode, applicationData, loading: false })
+    })
+  }, [data, configApplicationId])
 
-  if (!state) return <Loading />
+  console.log('state', state)
+
+  if (state.loading) return <Loading />
 
   return (
     <Context.Provider value={state}>

--- a/src/containers/TemplateBuilder/template/Actions/Actions.tsx
+++ b/src/containers/TemplateBuilder/template/Actions/Actions.tsx
@@ -27,14 +27,13 @@ type ActionsByCode = { [actionCode: string]: ActionPlugin }
 
 type ActionContext = {
   allActionsByCode: ActionsByCode
-  applicationData: any
-  loading: boolean
+  applicationData: { [key: string]: any }
+  loading?: boolean
 }
 
 const Context = createContext<ActionContext>({
   allActionsByCode: {},
   applicationData: {},
-  loading: true,
 })
 
 const ActionsWrapper: React.FC = () => {
@@ -59,12 +58,9 @@ const ActionsWrapper: React.FC = () => {
     if (!configApplicationId) return
     const url = `${config.serverREST}/admin/get-application-data?applicationId=${configApplicationId}`
     getRequest(url).then((applicationData) => {
-      console.log(applicationData)
       setState({ allActionsByCode, applicationData, loading: false })
     })
   }, [data, configApplicationId])
-
-  console.log('state', state)
 
   if (state.loading) return <Loading />
 


### PR DESCRIPTION
Fix #1007 

Requires back-end https://github.com/openmsupply/application-manager-server/pull/608 in order to fetch server-side applicationData for Actions

This is pretty rudimentary, but it gives us the thing that was most needed for TemplateBuilder -- seeing the result of evaluator queries in Actions editor. In particular, we can check the values going to "modifyRecord" are what we expect in the editor rather than having to test the whole template.