### PR TITLE
#611B Allow any template to be made available without disabling another

### DIFF
--- a/src/containers/TemplateBuilder/template/General/General.tsx
+++ b/src/containers/TemplateBuilder/template/General/General.tsx
@@ -21,15 +21,12 @@ const General: React.FC = () => {
   const { updateTemplate } = useOperationState()
   const { structure } = useApplicationState()
   const { template } = useTemplateState()
-  const { data: availableTemplatesData, refetch: refetchAvailable } =
-    useGetTemplatesAvailableForCodeQuery({
-      variables: { code: template.code },
-    })
+  const { refetch: refetchAvailable } = useGetTemplatesAvailableForCodeQuery({
+    variables: { code: template.code },
+  })
   const [isMessageConfigOpen, setIsMessageConfigOpen] = useState(false)
 
-  const canSetAvailable =
-    availableTemplatesData?.templates?.nodes?.length === 0 &&
-    template.status !== TemplateStatus.Available
+  const canSetAvailable = template.status !== TemplateStatus.Available
 
   const canSetDraft = template.status !== TemplateStatus.Draft && template.applicationCount === 0
 


### PR DESCRIPTION
Front-end component for [back-end PR #612](https://github.com/openmsupply/application-manager-server/pull/612)

All it does is make the "Make Available" button enabled all the time in the Template Builder, as the job of disabling the other versions is now handled by the database. So you can set a template version to AVAILABLE without having to go into the currently available one and disabling it first.