### PR TITLE
Quick fix: File upload summary view

### DIFF
--- a/src/formElementPlugins/fileUpload/src/SummaryView.tsx
+++ b/src/formElementPlugins/fileUpload/src/SummaryView.tsx
@@ -4,7 +4,7 @@ import config from '../../../config'
 import prefs from '../config.json'
 import { SummaryViewProps } from '../../types'
 
-const host = config.serverREST
+const downloadUrl = `${config.serverREST}/public`
 
 const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
   return (
@@ -19,16 +19,16 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, respons
             <List.Item key={file.filename} style={{ maxWidth: 150 }}>
               <Grid verticalAlign="top" celled style={{ boxShadow: 'none' }}>
                 <Grid.Row centered style={{ boxShadow: 'none' }} verticalAlign="top">
-                  <a href={host + file.fileUrl} target="_blank">
+                  <a href={downloadUrl + file.fileUrl} target="_blank">
                     <Image
-                      src={host + file.thumbnailUrl}
+                      src={downloadUrl + file.thumbnailUrl}
                       style={{ maxHeight: prefs.summaryViewThumbnailHeight }}
                     />
                   </a>
                 </Grid.Row>
                 <Grid.Row centered style={{ boxShadow: 'none' }}>
                   <p style={{ wordBreak: 'break-word' }}>
-                    <a href={host + file.fileUrl} target="_blank">
+                    <a href={downloadUrl + file.fileUrl} target="_blank">
                       {file.filename}
                     </a>
                   </p>


### PR DESCRIPTION
I missed one when updating all the urls to use new API paths. Summary view for file Upload wasn't displaying the file images correctly.

This fixes that.