### PR TITLE
#1029 add field is interactive to template

### DIFF
--- a/docs/internal/admin/Template-Builder.md
+++ b/docs/internal/admin/Template-Builder.md
@@ -4,7 +4,7 @@
 
 ### Displayed options
 
-#### isInteractive
+#### canApplicantMakeChangess
 
 **Optional** Default: **true**.
 When this option is set to false it means no Reviewer can interact with Applicant, so option for "List of Questions" is hidden.

--- a/docs/internal/admin/Template-Builder.md
+++ b/docs/internal/admin/Template-Builder.md
@@ -1,3 +1,10 @@
 # Template Builder
 
-**TODO**
+## General tab
+
+### Displayed options
+
+#### isInteractive
+
+**Optional** Default: **true**.
+When this option is set to false it means no Reviewer can interact with Applicant, so option for "List of Questions" is hidden.

--- a/src/containers/Review/ReviewSubmit.tsx
+++ b/src/containers/Review/ReviewSubmit.tsx
@@ -21,13 +21,13 @@ type ReviewSubmitProps = {
 
 const ReviewSubmit: React.FC<ReviewSubmitProps> = (props) => {
   const {
-    structure: { thisReview, assignment, isInteractive },
+    structure: { thisReview, assignment, canApplicantMakeChanges },
     previousAssignment,
   } = props
 
   const reviewDecision = thisReview?.reviewDecision
   const { decisionOptions, getDecision, setDecision, getAndSetDecisionError, isDecisionError } =
-    useGetDecisionOptions(isInteractive, assignment, thisReview)
+    useGetDecisionOptions(canApplicantMakeChanges, assignment, thisReview)
 
   return (
     <Form id="review-submit-area">

--- a/src/containers/Review/ReviewSubmit.tsx
+++ b/src/containers/Review/ReviewSubmit.tsx
@@ -21,13 +21,13 @@ type ReviewSubmitProps = {
 
 const ReviewSubmit: React.FC<ReviewSubmitProps> = (props) => {
   const {
-    structure: { thisReview, assignment },
+    structure: { thisReview, assignment, isInteractive },
     previousAssignment,
   } = props
 
   const reviewDecision = thisReview?.reviewDecision
   const { decisionOptions, getDecision, setDecision, getAndSetDecisionError, isDecisionError } =
-    useGetDecisionOptions(assignment, thisReview)
+    useGetDecisionOptions(isInteractive, assignment, thisReview)
 
   return (
     <Form id="review-submit-area">

--- a/src/containers/TemplateBuilder/template/General/General.tsx
+++ b/src/containers/TemplateBuilder/template/General/General.tsx
@@ -98,12 +98,12 @@ const General: React.FC = () => {
 
       <CheckboxIO
         title="Interactive"
-        value={!!template?.isInteractive}
+        value={!!template?.canApplicantMakeChanges}
         setValue={(checked) => {
-          updateTemplate(template.id, { isInteractive: checked })
+          updateTemplate(template.id, { canApplicantMakeChanges: checked })
         }}
         disabled={!template.isDraft}
-        disabledMessage="Can only change isInteractive of draft template"
+        disabledMessage="Can only change canApplicantMakeChanges of draft template"
       />
 
       <Category />

--- a/src/containers/TemplateBuilder/template/General/General.tsx
+++ b/src/containers/TemplateBuilder/template/General/General.tsx
@@ -93,7 +93,17 @@ const General: React.FC = () => {
           updateTemplate(template.id, { isLinear: checked })
         }}
         disabled={!template.isDraft}
-        disabledMessage="Can only change code of draft template"
+        disabledMessage="Can only change isLinear of draft template"
+      />
+
+      <CheckboxIO
+        title="Interactive"
+        value={!!template?.isInteractive}
+        setValue={(checked) => {
+          updateTemplate(template.id, { isInteractive: checked })
+        }}
+        disabled={!template.isDraft}
+        disabledMessage="Can only change isInteractive of draft template"
       />
 
       <Category />

--- a/src/containers/TemplateBuilder/template/TemplateWrapper.tsx
+++ b/src/containers/TemplateBuilder/template/TemplateWrapper.tsx
@@ -119,6 +119,7 @@ type TemplateContextState = {
     applicationCount: number
     namePlural: string
     isLinear: boolean
+    isInteractive: boolean
   }
   refetch: () => void
   category?: TemplateCategory
@@ -142,6 +143,7 @@ const defaultTemplateContextState: TemplateContextState = {
     applicationCount: 0,
     namePlural: '',
     isLinear: false,
+    isInteractive: true,
   },
   refetch: () => {},
   sections: [],
@@ -182,6 +184,7 @@ const TemplateWrapper: React.FC = () => {
           code: template?.code || '',
           namePlural: template?.namePlural || '',
           isLinear: !!template?.isLinear,
+          isInteractive: !!template?.isInteractive,
           status: template?.status || TemplateStatus.Disabled,
           applicationCount: template?.applications?.totalCount || 0,
           isDraft: template.status === TemplateStatus.Draft,

--- a/src/containers/TemplateBuilder/template/TemplateWrapper.tsx
+++ b/src/containers/TemplateBuilder/template/TemplateWrapper.tsx
@@ -119,7 +119,7 @@ type TemplateContextState = {
     applicationCount: number
     namePlural: string
     isLinear: boolean
-    isInteractive: boolean
+    canApplicantMakeChanges: boolean
   }
   refetch: () => void
   category?: TemplateCategory
@@ -143,7 +143,7 @@ const defaultTemplateContextState: TemplateContextState = {
     applicationCount: 0,
     namePlural: '',
     isLinear: false,
-    isInteractive: true,
+    canApplicantMakeChanges: true,
   },
   refetch: () => {},
   sections: [],
@@ -184,7 +184,7 @@ const TemplateWrapper: React.FC = () => {
           code: template?.code || '',
           namePlural: template?.namePlural || '',
           isLinear: !!template?.isLinear,
-          isInteractive: !!template?.isInteractive,
+          canApplicantMakeChanges: !!template?.canApplicantMakeChanges,
           status: template?.status || TemplateStatus.Disabled,
           applicationCount: template?.applications?.totalCount || 0,
           isDraft: template.status === TemplateStatus.Draft,

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -2406,8 +2406,8 @@ export type TemplateFilter = {
   code?: Maybe<StringFilter>;
   /** Filter by the object’s `isLinear` field. */
   isLinear?: Maybe<BooleanFilter>;
-  /** Filter by the object’s `isInteractive` field. */
-  isInteractive?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `canApplicantMakeChanges` field. */
+  canApplicantMakeChanges?: Maybe<BooleanFilter>;
   /** Filter by the object’s `startMessage` field. */
   startMessage?: Maybe<JsonFilter>;
   /** Filter by the object’s `status` field. */
@@ -4886,7 +4886,7 @@ export type Template = Node & {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -5076,8 +5076,8 @@ export enum TemplatesOrderBy {
   CodeDesc = 'CODE_DESC',
   IsLinearAsc = 'IS_LINEAR_ASC',
   IsLinearDesc = 'IS_LINEAR_DESC',
-  IsInteractiveAsc = 'IS_INTERACTIVE_ASC',
-  IsInteractiveDesc = 'IS_INTERACTIVE_DESC',
+  CanApplicantMakeChangesAsc = 'CAN_APPLICANT_MAKE_CHANGES_ASC',
+  CanApplicantMakeChangesDesc = 'CAN_APPLICANT_MAKE_CHANGES_DESC',
   StartMessageAsc = 'START_MESSAGE_ASC',
   StartMessageDesc = 'START_MESSAGE_DESC',
   StatusAsc = 'STATUS_ASC',
@@ -5108,8 +5108,8 @@ export type TemplateCondition = {
   code?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `isLinear` field. */
   isLinear?: Maybe<Scalars['Boolean']>;
-  /** Checks for equality with the object’s `isInteractive` field. */
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `canApplicantMakeChanges` field. */
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   /** Checks for equality with the object’s `startMessage` field. */
   startMessage?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `status` field. */
@@ -13054,7 +13054,7 @@ export type UpdateTemplateOnActionQueueForActionQueueTemplateIdFkeyPatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -13182,7 +13182,7 @@ export type UpdateTemplateOnTemplateForTemplateTemplateCategoryIdFkeyPatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -13312,7 +13312,7 @@ export type UpdateTemplateOnTemplateSectionForTemplateSectionTemplateIdFkeyPatch
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -13427,7 +13427,7 @@ export type UpdateTemplateOnTemplateStageForTemplateStageTemplateIdFkeyPatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -13537,7 +13537,7 @@ export type UpdateTemplateOnTemplateFilterJoinForTemplateFilterJoinTemplateIdFke
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -14441,7 +14441,7 @@ export type UpdateTemplateOnTemplatePermissionForTemplatePermissionTemplateIdFke
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -14587,7 +14587,7 @@ export type UpdateTemplateOnApplicationForApplicationTemplateIdFkeyPatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -14796,7 +14796,7 @@ export type UpdateTemplateOnTemplateActionForTemplateActionTemplateIdFkeyPatch =
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -15838,7 +15838,7 @@ export type UpdateTemplateOnTriggerScheduleForTriggerScheduleTemplateIdFkeyPatch
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -16705,7 +16705,7 @@ export type UpdateTemplateOnReviewAssignmentForReviewAssignmentTemplateIdFkeyPat
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -17886,7 +17886,7 @@ export type UpdateTemplateOnFileForFileTemplateIdFkeyPatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -17922,7 +17922,7 @@ export type TemplatePatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -17950,7 +17950,7 @@ export type FileTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -21777,7 +21777,7 @@ export type ReviewAssignmentTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -22488,7 +22488,7 @@ export type TriggerScheduleTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -23256,7 +23256,7 @@ export type TemplateActionTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -23329,7 +23329,7 @@ export type ApplicationTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -23408,7 +23408,7 @@ export type TemplatePermissionTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -23889,7 +23889,7 @@ export type TemplateFilterJoinTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -24109,7 +24109,7 @@ export type TemplateStageTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -24166,7 +24166,7 @@ export type TemplateSectionTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -24229,7 +24229,7 @@ export type TemplateTemplateCategoryIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -24299,7 +24299,7 @@ export type ActionQueueTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -25603,7 +25603,7 @@ export type TemplateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
-  isInteractive?: Maybe<Scalars['Boolean']>;
+  canApplicantMakeChanges?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -30068,7 +30068,7 @@ export type StageFragment = (
 
 export type TemplateFragmentFragment = (
   { __typename?: 'Template' }
-  & Pick<Template, 'code' | 'id' | 'name' | 'status' | 'namePlural' | 'isLinear' | 'isInteractive' | 'startMessage' | 'submissionMessage' | 'version' | 'icon'>
+  & Pick<Template, 'code' | 'id' | 'name' | 'status' | 'namePlural' | 'isLinear' | 'canApplicantMakeChanges' | 'startMessage' | 'submissionMessage' | 'version' | 'icon'>
   & { templateCategory?: Maybe<(
     { __typename?: 'TemplateCategory' }
     & Pick<TemplateCategory, 'id' | 'code' | 'title' | 'icon' | 'uiLocation'>
@@ -31299,7 +31299,7 @@ export const TemplateFragmentFragmentDoc = gql`
   status
   namePlural
   isLinear
-  isInteractive
+  canApplicantMakeChanges
   startMessage
   submissionMessage
   version

--- a/src/utils/generated/graphql.tsx
+++ b/src/utils/generated/graphql.tsx
@@ -2406,6 +2406,8 @@ export type TemplateFilter = {
   code?: Maybe<StringFilter>;
   /** Filter by the object’s `isLinear` field. */
   isLinear?: Maybe<BooleanFilter>;
+  /** Filter by the object’s `isInteractive` field. */
+  isInteractive?: Maybe<BooleanFilter>;
   /** Filter by the object’s `startMessage` field. */
   startMessage?: Maybe<JsonFilter>;
   /** Filter by the object’s `status` field. */
@@ -4884,6 +4886,7 @@ export type Template = Node & {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -5073,6 +5076,8 @@ export enum TemplatesOrderBy {
   CodeDesc = 'CODE_DESC',
   IsLinearAsc = 'IS_LINEAR_ASC',
   IsLinearDesc = 'IS_LINEAR_DESC',
+  IsInteractiveAsc = 'IS_INTERACTIVE_ASC',
+  IsInteractiveDesc = 'IS_INTERACTIVE_DESC',
   StartMessageAsc = 'START_MESSAGE_ASC',
   StartMessageDesc = 'START_MESSAGE_DESC',
   StatusAsc = 'STATUS_ASC',
@@ -5103,6 +5108,8 @@ export type TemplateCondition = {
   code?: Maybe<Scalars['String']>;
   /** Checks for equality with the object’s `isLinear` field. */
   isLinear?: Maybe<Scalars['Boolean']>;
+  /** Checks for equality with the object’s `isInteractive` field. */
+  isInteractive?: Maybe<Scalars['Boolean']>;
   /** Checks for equality with the object’s `startMessage` field. */
   startMessage?: Maybe<Scalars['JSON']>;
   /** Checks for equality with the object’s `status` field. */
@@ -13047,6 +13054,7 @@ export type UpdateTemplateOnActionQueueForActionQueueTemplateIdFkeyPatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -13174,6 +13182,7 @@ export type UpdateTemplateOnTemplateForTemplateTemplateCategoryIdFkeyPatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -13303,6 +13312,7 @@ export type UpdateTemplateOnTemplateSectionForTemplateSectionTemplateIdFkeyPatch
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -13417,6 +13427,7 @@ export type UpdateTemplateOnTemplateStageForTemplateStageTemplateIdFkeyPatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -13526,6 +13537,7 @@ export type UpdateTemplateOnTemplateFilterJoinForTemplateFilterJoinTemplateIdFke
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -14429,6 +14441,7 @@ export type UpdateTemplateOnTemplatePermissionForTemplatePermissionTemplateIdFke
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -14574,6 +14587,7 @@ export type UpdateTemplateOnApplicationForApplicationTemplateIdFkeyPatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -14782,6 +14796,7 @@ export type UpdateTemplateOnTemplateActionForTemplateActionTemplateIdFkeyPatch =
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -15823,6 +15838,7 @@ export type UpdateTemplateOnTriggerScheduleForTriggerScheduleTemplateIdFkeyPatch
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -16689,6 +16705,7 @@ export type UpdateTemplateOnReviewAssignmentForReviewAssignmentTemplateIdFkeyPat
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -17869,6 +17886,7 @@ export type UpdateTemplateOnFileForFileTemplateIdFkeyPatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -17904,6 +17922,7 @@ export type TemplatePatch = {
   namePlural?: Maybe<Scalars['String']>;
   code?: Maybe<Scalars['String']>;
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -17931,6 +17950,7 @@ export type FileTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -21757,6 +21777,7 @@ export type ReviewAssignmentTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -22467,6 +22488,7 @@ export type TriggerScheduleTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -23234,6 +23256,7 @@ export type TemplateActionTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -23306,6 +23329,7 @@ export type ApplicationTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -23384,6 +23408,7 @@ export type TemplatePermissionTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -23864,6 +23889,7 @@ export type TemplateFilterJoinTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -24083,6 +24109,7 @@ export type TemplateStageTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -24139,6 +24166,7 @@ export type TemplateSectionTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -24201,6 +24229,7 @@ export type TemplateTemplateCategoryIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -24270,6 +24299,7 @@ export type ActionQueueTemplateIdFkeyTemplateCreateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -25573,6 +25603,7 @@ export type TemplateInput = {
   namePlural?: Maybe<Scalars['String']>;
   code: Scalars['String'];
   isLinear?: Maybe<Scalars['Boolean']>;
+  isInteractive?: Maybe<Scalars['Boolean']>;
   startMessage?: Maybe<Scalars['JSON']>;
   status?: Maybe<TemplateStatus>;
   submissionMessage?: Maybe<Scalars['JSON']>;
@@ -30037,7 +30068,7 @@ export type StageFragment = (
 
 export type TemplateFragmentFragment = (
   { __typename?: 'Template' }
-  & Pick<Template, 'code' | 'id' | 'name' | 'status' | 'namePlural' | 'isLinear' | 'startMessage' | 'submissionMessage' | 'version' | 'icon'>
+  & Pick<Template, 'code' | 'id' | 'name' | 'status' | 'namePlural' | 'isLinear' | 'isInteractive' | 'startMessage' | 'submissionMessage' | 'version' | 'icon'>
   & { templateCategory?: Maybe<(
     { __typename?: 'TemplateCategory' }
     & Pick<TemplateCategory, 'id' | 'code' | 'title' | 'icon' | 'uiLocation'>
@@ -31268,6 +31299,7 @@ export const TemplateFragmentFragmentDoc = gql`
   status
   namePlural
   isLinear
+  isInteractive
   startMessage
   submissionMessage
   version

--- a/src/utils/graphql/fragments/template.fragment.ts
+++ b/src/utils/graphql/fragments/template.fragment.ts
@@ -8,7 +8,7 @@ export default gql`
     status
     namePlural
     isLinear
-    isInteractive
+    canApplicantMakeChanges
     startMessage
     submissionMessage
     version

--- a/src/utils/graphql/fragments/template.fragment.ts
+++ b/src/utils/graphql/fragments/template.fragment.ts
@@ -8,6 +8,7 @@ export default gql`
     status
     namePlural
     isLinear
+    isInteractive
     startMessage
     submissionMessage
     version

--- a/src/utils/hooks/useGetDecisionOptions.ts
+++ b/src/utils/hooks/useGetDecisionOptions.ts
@@ -3,14 +3,11 @@ import { Decision, ReviewStatus } from '../generated/graphql'
 import { LanguageStrings, useLanguageProvider } from '../../contexts/Localisation'
 import { DecisionOption, ReviewAssignment, ReviewDetails } from '../types'
 
-const getInitialDecisionOptions = (strings: LanguageStrings): DecisionOption[] => {
-  return [
-    {
-      code: Decision.ListOfQuestions,
-      title: strings.DECISION_LIST_OF_QUESTIONS,
-      isVisible: false,
-      value: false,
-    },
+const getInitialDecisionOptions = (
+  strings: LanguageStrings,
+  isInteractive: boolean
+): DecisionOption[] => {
+  let availableOptions = [
     {
       code: Decision.NonConform,
       title: strings.DECISION_NON_CONFORM,
@@ -30,10 +27,22 @@ const getInitialDecisionOptions = (strings: LanguageStrings): DecisionOption[] =
       value: false,
     },
   ]
+
+  // Only display LOQ options if template is interactive with Applicant
+  if (isInteractive)
+    availableOptions.push({
+      code: Decision.ListOfQuestions,
+      title: strings.DECISION_LIST_OF_QUESTIONS,
+      isVisible: false,
+      value: false,
+    })
+
+  return availableOptions
 }
 
 // hook used to manage state of options shown in review submit, as per type definition below
 type UseGetDecisionOptions = (
+  isInteractive: boolean,
   assignment?: ReviewAssignment,
   thisReview?: ReviewDetails | null
 ) => {
@@ -44,11 +53,11 @@ type UseGetDecisionOptions = (
   isDecisionError: boolean
 }
 
-const useGetDecisionOptions: UseGetDecisionOptions = (assignment, thisReview) => {
+const useGetDecisionOptions: UseGetDecisionOptions = (isInteractive, assignment, thisReview) => {
   const { strings } = useLanguageProvider()
   const { isLastLevel, finalDecision, canSubmitReviewAs } = assignment as ReviewAssignment
   const [decisionOptions, setDecisionOptions] = useState<DecisionOption[]>(
-    getInitialDecisionOptions(strings)
+    getInitialDecisionOptions(strings, isInteractive)
   )
   const [isDecisionError, setIsDecisionError] = useState(false)
 

--- a/src/utils/hooks/useGetDecisionOptions.ts
+++ b/src/utils/hooks/useGetDecisionOptions.ts
@@ -5,7 +5,7 @@ import { DecisionOption, ReviewAssignment, ReviewDetails } from '../types'
 
 const getInitialDecisionOptions = (
   strings: LanguageStrings,
-  isInteractive: boolean
+  canApplicantMakeChanges: boolean
 ): DecisionOption[] => {
   let availableOptions = [
     {
@@ -29,7 +29,7 @@ const getInitialDecisionOptions = (
   ]
 
   // Only display LOQ options if template is interactive with Applicant
-  if (isInteractive)
+  if (canApplicantMakeChanges)
     availableOptions.push({
       code: Decision.ListOfQuestions,
       title: strings.DECISION_LIST_OF_QUESTIONS,
@@ -42,7 +42,7 @@ const getInitialDecisionOptions = (
 
 // hook used to manage state of options shown in review submit, as per type definition below
 type UseGetDecisionOptions = (
-  isInteractive: boolean,
+  canApplicantMakeChanges: boolean,
   assignment?: ReviewAssignment,
   thisReview?: ReviewDetails | null
 ) => {
@@ -53,11 +53,15 @@ type UseGetDecisionOptions = (
   isDecisionError: boolean
 }
 
-const useGetDecisionOptions: UseGetDecisionOptions = (isInteractive, assignment, thisReview) => {
+const useGetDecisionOptions: UseGetDecisionOptions = (
+  canApplicantMakeChanges,
+  assignment,
+  thisReview
+) => {
   const { strings } = useLanguageProvider()
   const { isLastLevel, finalDecision, canSubmitReviewAs } = assignment as ReviewAssignment
   const [decisionOptions, setDecisionOptions] = useState<DecisionOption[]>(
-    getInitialDecisionOptions(strings, isInteractive)
+    getInitialDecisionOptions(strings, canApplicantMakeChanges)
   )
   const [isDecisionError, setIsDecisionError] = useState(false)
 

--- a/src/utils/hooks/useLoadApplication.ts
+++ b/src/utils/hooks/useLoadApplication.ts
@@ -156,7 +156,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
       })
     })
 
-    const isInteractive = application.template?.isInteractive ?? true
+    const canApplicantMakeChanges = application.template?.canApplicantMakeChanges ?? true
 
     const templateStages = application.template?.templateStages.nodes as TemplateStage[]
 
@@ -181,7 +181,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
           colour: stage.colour as string,
         })),
         sections: buildSectionsStructure({ sectionDetails, baseElements }),
-        isInteractive,
+        canApplicantMakeChanges,
         attemptSubmission: false,
       }
 

--- a/src/utils/hooks/useLoadApplication.ts
+++ b/src/utils/hooks/useLoadApplication.ts
@@ -156,6 +156,8 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
       })
     })
 
+    const isInteractive = application.template?.isInteractive ?? true
+
     const templateStages = application.template?.templateStages.nodes as TemplateStage[]
 
     const evaluatorParams: EvaluatorParameters = {
@@ -179,6 +181,7 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
           colour: stage.colour as string,
         })),
         sections: buildSectionsStructure({ sectionDetails, baseElements }),
+        isInteractive,
         attemptSubmission: false,
       }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -248,6 +248,7 @@ interface FullStructure {
   lastValidationTimestamp?: number
   attemptSubmission: boolean
   info: ApplicationDetails
+  isInteractive: boolean
   sections: SectionsStructure
   stages: StageDetails[]
   responsesByCode?: ResponsesByCode

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -248,7 +248,7 @@ interface FullStructure {
   lastValidationTimestamp?: number
   attemptSubmission: boolean
   info: ApplicationDetails
-  canApplicantMakeDecisions: boolean
+  canApplicantMakeChanges: boolean
   sections: SectionsStructure
   stages: StageDetails[]
   responsesByCode?: ResponsesByCode

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -248,7 +248,7 @@ interface FullStructure {
   lastValidationTimestamp?: number
   attemptSubmission: boolean
   info: ApplicationDetails
-  isInteractive: boolean
+  canApplicantMakeDecisions: boolean
   sections: SectionsStructure
   stages: StageDetails[]
   responsesByCode?: ResponsesByCode


### PR DESCRIPTION
Fixes #1029 

### Linked PR
- Backend https://github.com/openmsupply/application-manager-server/pull/621

### Changes
- Check for new template field `isInteracive` (which by default is **true**) to display the option "List of Questions" in Review submission. 
- If the field is **false** the option to submit a LOQ is not displayed anymore. That is specifically to be used in the new UserRegistration build on private snapshot demo_laos, to not allow interaction with user who isn't registered yet.
- Display the new option in the TemplateBuilder page as well -> Add a line to docs.

### Testing
- Load core_templates snapshot by running `yarn database_init` with no arguments
- Now you have to create another user to have the permission to review OrgJoin applications:
  - Go ahead and register a new user "Reviewer", using your email account.
  - Confirm the email
- Now you also need to create a company for new user... And approve (as Admin)
- Login ad Admin and grant this user permission to review OrgJoin
<img width="618" alt="Screen Shot 2021-11-12 at 11 50 17 AM" src="https://user-images.githubusercontent.com/16461988/141380413-6db57f39-7fa1-47eb-b9f3-993123a1b095.png">

- Log in as Admin and create an application to Join the new company. Then **Submit**.
- Now with the same user you should be able to view the list of OrgJoin applications (and change on the url to `http://localhost:3000/applications?type=OrgJoin&user-role=reviewer` so you can view applications as reviewer/assigner)
- Click to assign the application to the new user: Reviewer
- Log in as Reviewer and start the review, select one Reject option: See there is only the decision **Non-conform** to use, since **List of Questions** is not allowed for this application. 