### PR TITLE
#1034 Missing JWT in snapshot/template export/import queries

### DIFF
--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -21,6 +21,8 @@ const Snapshots: React.FC = () => {
 
   const [data, setData] = useState<string[] | null>(null)
 
+  const JWT = localStorage.getItem(config.localStorageJWTKey)
+
   useEffect(() => {
     setData(null)
     setCompareFrom('')
@@ -47,6 +49,7 @@ const Snapshots: React.FC = () => {
     try {
       const resultJson = await postRequest({
         url: `${takeSnapshotUrl}?name=${normaliseSnapshotName(name)}`,
+        headers: { Authorization: `Bearer ${JWT}` },
       })
 
       if (resultJson.success) return setIsLoading(false)
@@ -60,7 +63,10 @@ const Snapshots: React.FC = () => {
   const useSnapshot = async (name: string) => {
     setIsLoading(true)
     try {
-      const resultJson = await postRequest({ url: `${useSnapshotUrl}?name=${name}` })
+      const resultJson = await postRequest({
+        url: `${useSnapshotUrl}?name=${name}`,
+        headers: { Authorization: `Bearer ${JWT}` },
+      })
 
       if (resultJson.success) return setIsLoading(false)
 
@@ -73,10 +79,10 @@ const Snapshots: React.FC = () => {
   const deleteSnapshot = async (name: string) => {
     setIsLoading(true)
     try {
-      const resultRaw = await fetch(`${deleteSnapshotUrl}?name=${name}`, {
-        method: 'POST',
+      const resultJson = await postRequest({
+        url: `${deleteSnapshotUrl}?name=${name}`,
+        headers: { Authorization: `Bearer ${JWT}` },
       })
-      const resultJson = await resultRaw.json()
       if (resultJson.success) {
         await getList()
         setIsLoading(false)
@@ -102,6 +108,7 @@ const Snapshots: React.FC = () => {
       const resultJson = await postRequest({
         otherBody: data,
         url: `${uploadSnapshotUrl}?name=${snapshotName}`,
+        headers: { Authorization: `Bearer ${JWT}` },
       })
 
       if (resultJson.success) {

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -165,14 +165,14 @@ const Snapshots: React.FC = () => {
                   <Icon
                     name="download"
                     size="large"
-                    className="clickable"
+                    className="clickable blue"
                     onClick={() => downloadSnapshot(snapshotName)}
                   />
                 </Table.Cell>
                 <Table.Cell textAlign="left">
                   <Icon
                     size="large"
-                    className="clickable blue"
+                    className="clickable"
                     name="trash alternate"
                     onClick={() => deleteSnapshot(snapshotName)}
                   />

--- a/src/containers/Dev/Snapshots.tsx
+++ b/src/containers/Dev/Snapshots.tsx
@@ -122,6 +122,17 @@ const Snapshots: React.FC = () => {
     }
   }
 
+  const downloadSnapshot = async (snapshotName: string) => {
+    const res = await fetch(`${snapshotFilesUrl}/${snapshotName}.zip`, {
+      headers: { Authorization: `Bearer ${JWT}` },
+    })
+    const data = await res.blob()
+    var a = document.createElement('a')
+    a.href = window.URL.createObjectURL(data)
+    a.download = `${snapshotName}.zip`
+    a.click()
+  }
+
   const renderSnapshotList = () => {
     // const compareLinkRef = useRef<HTMLAnchorElement>(null)
     if (!data) return null
@@ -151,14 +162,17 @@ const Snapshots: React.FC = () => {
                   />
                 </Table.Cell>
                 <Table.Cell>
-                  <a href={`${snapshotFilesUrl}/${snapshotName}.zip`} target="_blank">
-                    <Icon name="download" size="large" />
-                  </a>
+                  <Icon
+                    name="download"
+                    size="large"
+                    className="clickable"
+                    onClick={() => downloadSnapshot(snapshotName)}
+                  />
                 </Table.Cell>
                 <Table.Cell textAlign="left">
                   <Icon
                     size="large"
-                    className="clickable"
+                    className="clickable blue"
                     name="trash alternate"
                     onClick={() => deleteSnapshot(snapshotName)}
                   />

--- a/src/containers/TemplateBuilder/Templates.tsx
+++ b/src/containers/TemplateBuilder/Templates.tsx
@@ -8,6 +8,7 @@ import TextIO from './shared/TextIO'
 import useGetTemplates, { Template } from './useGetTemplates'
 import { useLanguageProvider } from '../../contexts/Localisation'
 import usePageTitle from '../../utils/hooks/usePageTitle'
+import config from '../../config'
 
 type CellPropsTemplate = Template & { numberOfTemplates?: number }
 type CellProps = { template: CellPropsTemplate; refetch: () => void }
@@ -87,6 +88,7 @@ const ExportButton: React.FC<CellProps> = ({ template: { code, version, id } }) 
   const downloadLinkRef = useRef<HTMLAnchorElement>(null)
   const { exportTemplate } = useOperationState()
   const snapshotName = `${code}-${version}`
+  const JWT = localStorage.getItem(config.localStorageJWTKey)
 
   return (
     <div key="export">
@@ -95,7 +97,16 @@ const ExportButton: React.FC<CellProps> = ({ template: { code, version, id } }) 
         className="clickable"
         onClick={async (e) => {
           e.stopPropagation()
-          if (await exportTemplate({ id, snapshotName })) downloadLinkRef?.current?.click()
+          if (await exportTemplate({ id, snapshotName })) {
+            const res = await fetch(`${snapshotFilesUrl}/${snapshotName}.zip`, {
+              headers: { Authorization: `Bearer ${JWT}` },
+            })
+            const data = await res.blob()
+            var a = document.createElement('a')
+            a.href = window.URL.createObjectURL(data)
+            a.download = `${snapshotName}.zip`
+            a.click()
+          }
         }}
       >
         <Icon className="clickable" key="export" name="sign-out" />

--- a/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
+++ b/src/containers/TemplateBuilder/shared/OperationContextHelpers.tsx
@@ -266,14 +266,17 @@ const safeFetch = async (
   body: any,
   setErrorAndLoadingState: SetErrorAndLoadingState
 ) => {
+  const JWT = localStorage.getItem(config.localStorageJWTKey)
   setErrorAndLoadingState({ isLoading: true })
   try {
     const resultJson = await postRequest({
       url,
-      headers: typeof body === 'string' ? { 'Content-Type': 'application/json' } : {},
-      jsonBody: body,
+      headers:
+        typeof body === 'string'
+          ? { Authorization: `Bearer ${JWT}`, 'Content-Type': 'application/json' }
+          : { Authorization: `Bearer ${JWT}` },
+      otherBody: body,
     })
-
     if (!!resultJson?.success) {
       setErrorAndLoadingState({ isLoading: false })
       return true


### PR DESCRIPTION
Fixes #1034 

~~There's one part not quite working still --- download/export. That's because it currently relies on a plan HTML `<a>` link so can't pass JWT into it. Will hopefully get this sorted soon, before we merge this. Have asked @andreievg for suggestion.~~ Should be good now!

Also fixes the "import template" issue (not "MULTIPART" file on server). 