### PR TITLE
#620B Note about proper Markdown links in email notifications

### DIFF
--- a/docs/internal/admin/Template-Builder.md
+++ b/docs/internal/admin/Template-Builder.md
@@ -8,3 +8,9 @@
 
 **Optional** Default: **true**.
 When this option is set to false it means no Reviewer can interact with Applicant, so option for "List of Questions" is hidden.
+
+
+
+### Notes (things to remember to document)
+
+- Hyperlinks in email need to be proper Markdown links and not just rely on native email client text parsing. (Not really a Template Builder issue, but probably need to mention somewhere)


### PR DESCRIPTION
Small note/reminder regarding how to prevent [#620](https://github.com/openmsupply/application-manager-server/issues/620), as requested.