### PR TITLE
#884 Evaluate submission message after submission

### DIFF
--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -66,8 +66,6 @@ const ApplicationPage: React.FC<ApplicationProps> = ({
     },
   } = fullStructure
 
-  console.log(fullStructure)
-
   return (
     <Container id="application-form">
       <Grid stackable>

--- a/src/containers/Application/ApplicationPage.tsx
+++ b/src/containers/Application/ApplicationPage.tsx
@@ -66,6 +66,8 @@ const ApplicationPage: React.FC<ApplicationProps> = ({
     },
   } = fullStructure
 
+  console.log(fullStructure)
+
   return (
     <Container id="application-form">
       <Grid stackable>

--- a/src/containers/Application/ApplicationSubmission.tsx
+++ b/src/containers/Application/ApplicationSubmission.tsx
@@ -1,18 +1,24 @@
-import React from 'react'
-import { Button, Header, Icon, List, Segment, Container } from 'semantic-ui-react'
+import React, { useEffect, useState } from 'react'
+import { Button, Header, Icon, List, Segment, Container, Loader } from 'semantic-ui-react'
 import Markdown from '../../utils/helpers/semanticReactMarkdown'
 import { ApplicationProps } from '../../utils/types'
 import { useUserState } from '../../contexts/UserState'
 import { Stage } from '../../components/Review'
 import { useRouter } from '../../utils/hooks/useRouter'
+import evaluate from '@openmsupply/expression-evaluator'
+import { EvaluatorParameters } from '../../utils/types'
 import { useLanguageProvider } from '../../contexts/Localisation'
 import { Link } from 'react-router-dom'
 import { ApplicationStatus } from '../../utils/generated/graphql'
+import globalConfig from '../../config'
+import useGetApplicationStructure from '../../utils/hooks/useGetApplicationStructure'
+import { Loading } from '../../components'
 
 const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
+  const [submissionMessageEvaluated, setSubmissionMessageEvaluated] = useState<string>()
   const { strings } = useLanguageProvider()
   const {
-    userState: { isNonRegistered },
+    userState: { isNonRegistered, currentUser },
     logout,
   } = useUserState()
 
@@ -24,15 +30,38 @@ const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
     info: {
       current: { status },
       submissionMessage,
-      name,
     },
     stages,
   } = structure
+
+  const { fullStructure } = useGetApplicationStructure({
+    structure,
+  })
 
   // Check if application not submitted and redirect to the summary page
   // Note: The summary page has its own redirection logic to a specific page (with invalid items).
   if (status === ApplicationStatus.Draft || status === ApplicationStatus.ChangesRequired)
     push(`/application/${serialNumber}/summary`)
+
+  // Evaluate submission message
+  useEffect(() => {
+    if (!fullStructure || !fullStructure?.responsesByCode) return
+    const JWT = localStorage.getItem(globalConfig.localStorageJWTKey)
+    const graphQLEndpoint = globalConfig.serverGraphQL
+    const evaluatorParams: EvaluatorParameters = {
+      objects: {
+        responses: fullStructure.responsesByCode,
+        currentUser,
+        applicationData: fullStructure.info,
+      },
+      APIfetch: fetch,
+      graphQLConnection: { fetch: fetch.bind(window), endpoint: graphQLEndpoint },
+      headers: { Authorization: 'Bearer ' + JWT },
+    }
+    evaluate(submissionMessage, evaluatorParams).then((result) => {
+      setSubmissionMessageEvaluated(result as string)
+    })
+  }, [fullStructure])
 
   return (
     <Container id="application-summary">
@@ -41,7 +70,11 @@ const ApplicationSubmission: React.FC<ApplicationProps> = ({ structure }) => {
           <Icon name="clock outline" className="information-colour" size="huge" />
           {strings.LABEL_PROCESSING}
         </Header>
-        <Markdown text={submissionMessage || ''} />
+        {submissionMessageEvaluated ? (
+          <Markdown text={submissionMessageEvaluated || ''} />
+        ) : (
+          <Loader />
+        )}
       </Segment>
       {!isNonRegistered && (
         <>

--- a/src/formElementPlugins/ApplicationViewWrapper.tsx
+++ b/src/formElementPlugins/ApplicationViewWrapper.tsx
@@ -21,7 +21,6 @@ import globalConfig from '../config'
 import { SemanticICONS } from 'semantic-ui-react'
 
 const graphQLEndpoint = globalConfig.serverGraphQL
-const JWT = localStorage.getItem(globalConfig.localStorageJWTKey)
 
 const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) => {
   const { strings } = useLanguageProvider()
@@ -70,6 +69,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
 
   // Update dynamic parameters when responses change
   useEffect(() => {
+    const JWT = localStorage.getItem(globalConfig.localStorageJWTKey)
     Object.entries(parameterExpressions).forEach(([field, expression]) => {
       evaluateExpression(expression as EvaluatorNode, {
         objects: { responses: allResponses, currentUser, applicationData },
@@ -92,6 +92,7 @@ const ApplicationViewWrapper: React.FC<ApplicationViewWrapperProps> = (props) =>
   }, [currentResponse, isStrictPage])
 
   const onUpdate = async (value: LooseString) => {
+    const JWT = localStorage.getItem(globalConfig.localStorageJWTKey)
     const responses = { thisResponse: value, ...allResponses }
     const newValidationState = await calculateValidationState({
       validationExpression,

--- a/src/utils/hooks/useLoadApplication.ts
+++ b/src/utils/hooks/useLoadApplication.ts
@@ -166,13 +166,14 @@ const useLoadApplication = ({ serialNumber, networkFetch }: UseGetApplicationPro
       graphQLConnection: { fetch: fetch.bind(window), endpoint: graphQLEndpoint },
       headers: { Authorization: 'Bearer ' + JWT },
     }
-    const templateMessages: any = [
-      evaluate(application.template?.startMessage || '', evaluatorParams),
-      evaluate(application.template?.submissionMessage || '', evaluatorParams),
-    ]
-    Promise.all(templateMessages).then(([startMessage, submissionMessage]: any) => {
+
+    evaluate(application.template?.startMessage || '', evaluatorParams).then((startMessage) => {
       let newStructure: FullStructure = {
-        info: { ...applicationDetails, submissionMessage, startMessage },
+        info: {
+          ...applicationDetails,
+          submissionMessage: application.template?.submissionMessage,
+          startMessage: startMessage as string,
+        },
         stages: templateStages.map((stage) => ({
           id: stage.id,
           name: stage.title as string,


### PR DESCRIPTION
Fix #884 

Had to make "ApplicationSubmission" page fetch the full structure so it can use responses from application in submission message.

Also done here:
-- in ApplicationViewWrapper, fetch JWT from local storage on demand, as it's not always there on load when coming from non-logged in state (which causes problems with some subsequent API calls)

Suggest testing this with new "add internal user" template so you can see the effect on the Submission page ("CreateIntUser-1.zip" in `/demo_angola/templates` in templates repo)