### PR TITLE
#1052 Checkbox updates

### DIFF
--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -321,6 +321,15 @@ _One or more checkboxes, any number of which can be selected/toggled_
 
 - **type**: `string` -- Can be "toggle" to display as a toggle switch, or "slider" to display as a slider switch (defaults to regular checkbox).
 - **layout**: `string` -- if "inline", displays checkboxes horizontally in rows. Useful if there are a lot of checkboxes.
+- **resetButton**: `boolean` -- if `true`, element will show a "Reset" button, which allows user to reset selections to the initial (loading) state. (Default: `false`)
+- **keyMap**: `object` -- if the input `checkboxes` property (above) has different property names that what is required (for example, if pulling from an API), then this `keyMap` parameter can be used to re-map the input property names to the requried property names. For example, if your input "checkbox" data contained an array of objects of the type `{ name: "Nicole", active: true}`, you would provide a `keyMap` object like this:
+```
+{
+  label: "name",
+  selected: "active"
+}
+```
+This tells the element to look at the "name" field for the `label`, and the "active" field for the `selected` status. Note that all the "checkbox" fields can be re-mapped, but it is only required that you provide the ones that are different.
 
 #### Response type
 

--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -348,6 +348,9 @@ This tells the element to look at the "name" field for the `label`, and the "act
     ...Other properties
     selectedValuesArray: [
       <checkbox elements -- same as the values above but filtered for selected-only>
+    ],
+    unselectedValuesArray: [
+      <checkbox elements -- same as the values above but filtered for UNselected-only>
     ]
 }
 

--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -308,16 +308,19 @@ _One or more checkboxes, any number of which can be selected/toggled_
 - **checkboxes**: `array[string | checkbox]` -- an array of labels, one per checkbox. For more complexity, an array of Checkbox objects can be provided, with the following properties:
 
 ```
-
 {
   label: <string> - text to display next to checkbox (Can be empty string but not omitted)
   text: <string> - value to store in Response "text" field and shown in Summary View. Will be same as label if omitted.
   textNegative: <string> - value to store in Response "text" field if checkbox is un-selected. (Optional -- defaults to empty string)
   key: <string | number> - unique code used as key/property name for Response object. Defaults to numerical index of array if omitted
   selected: <boolean> - initial state of checkbox
+  ...Other properties
 }
-
 ```
+
+"Other properties" refers to any additional properties included in the object. For example, an API call might return objects with a bunch of additional fields. These are not required for the Checbox display, but will be passed along and stored as part of the response, so any of these properties can be referred to in subsequent elements or actions.
+
+To handle objects returned that don't have the required fields, you can use the `keyMap` parameter (below) to map fields to required key names.
 
 - **type**: `string` -- Can be "toggle" to display as a toggle switch, or "slider" to display as a slider switch (defaults to regular checkbox).
 - **layout**: `string` -- if "inline", displays checkboxes horizontally in rows. Useful if there are a lot of checkboxes.
@@ -342,6 +345,7 @@ This tells the element to look at the "name" field for the `label`, and the "act
         <key-name-2> : { text: <text value>, isSelected: <boolean>}
         ... for all checkbox keys
         }
+    ...Other properties
     selectedValuesArray: [
       <checkbox elements -- same as the values above but filtered for selected-only>
     ]

--- a/src/containers/TemplateBuilder/shared/Evaluation.tsx
+++ b/src/containers/TemplateBuilder/shared/Evaluation.tsx
@@ -13,8 +13,6 @@ import CheckboxIO from './CheckboxIO'
 import JsonIO from './JsonIO'
 import TextIO from './TextIO'
 
-const JWT = localStorage.getItem(config.localStorageJWTKey)
-
 type EvaluationProps = {
   evaluation: EvaluatorNode
   currentElementCode: string
@@ -73,7 +71,7 @@ const Evaluation: React.FC<EvaluationProps> = ({
     currentUser,
     applicationData: applicationData ? applicationData : fullStructure?.info,
   }
-
+  const JWT = localStorage.getItem(config.localStorageJWTKey)
   const evaluationParameters = {
     objects,
     APIfetch: fetch,

--- a/src/containers/TemplateBuilder/template/Form/ElementConfig.tsx
+++ b/src/containers/TemplateBuilder/template/Form/ElementConfig.tsx
@@ -106,7 +106,6 @@ const ElementConfig: React.FC<ElementConfigProps> = ({ element, onClose }) => {
   }
 
   const updateElement = async () => {
-    console.log('here')
     const result = await updateTemplateSection(selectedSectionId, {
       templateElementsUsingId: {
         updateById: [{ id: state.id, patch: state }],

--- a/src/formElementPlugins/checkbox/localisation/default/strings.json
+++ b/src/formElementPlugins/checkbox/localisation/default/strings.json
@@ -1,3 +1,4 @@
 {
-  "LABEL_SUMMMARY_NOTHING_SELECTED": "Nothing Selected"
+  "LABEL_SUMMMARY_NOTHING_SELECTED": "Nothing Selected",
+  "BUTTON_RESET_SELECTION": "Reset selections"
 }

--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -49,7 +49,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       values: Object.fromEntries(
         checkboxElements.map((cb) => [
           cb.key,
-          { text: cb.text, textNegative: cb.textNegative, selected: cb.selected },
+          { ...cb, text: cb.text, textNegative: cb.textNegative, selected: cb.selected },
         ])
       ),
       selectedValuesArray: checkboxElements.filter((cb) => cb.selected),
@@ -145,6 +145,7 @@ const getInitialState = (
           }
         else
           return {
+            ...cb,
             label: cb?.[checkboxPropertyNames.label],
             text: cb?.[checkboxPropertyNames.text] || cb?.[checkboxPropertyNames.label],
             textNegative: cb?.[checkboxPropertyNames.textNegative] || '',

--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -53,6 +53,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
         ])
       ),
       selectedValuesArray: checkboxElements.filter((cb) => cb.selected),
+      unselectedValuesArray: checkboxElements.filter((cb) => !cb.selected),
     })
   }, [checkboxElements])
 

--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -30,13 +30,13 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const { label, description, checkboxes, type, layout, resetButton = false, keyMap } = parameters
 
   const [checkboxElements, setCheckboxElements] = useState<Checkbox[]>(
-    getInitialState(initialValue, checkboxes)
+    getInitialState(initialValue, checkboxes, keyMap)
   )
   const [initialState, setInitialState] = useState<Checkbox[]>()
 
   // When checkbox array changes after initial load (e.g. when its being dynamically loaded from an API)
   useEffect(() => {
-    const initState = getInitialState(initialValue, checkboxes)
+    const initState = getInitialState(initialValue, checkboxes, keyMap)
     setCheckboxElements(initState)
     setInitialState(initState)
   }, [checkboxes])
@@ -101,7 +101,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       ))}
       {resetButton && (
         <div style={{ marginTop: 10 }}>
-          <Button primary content="Reset selections" compact onClick={resetState} />
+          <Button primary content={strings.BUTTON_RESET_SELECTION} compact onClick={resetState} />
         </div>
       )}
     </>
@@ -110,12 +110,31 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
 export default ApplicationView
 
-const getInitialState = (initialValue: CheckboxSavedState, checkboxes: Checkbox[]) => {
+type KeyMap = {
+  label?: string
+  text?: string
+  textNegative?: string
+  key?: string
+  selected?: string
+}
+
+const getInitialState = (
+  initialValue: CheckboxSavedState,
+  checkboxes: Checkbox[],
+  keyMap: KeyMap | undefined
+) => {
   // Returns a consistent array of Checkbox objects, regardless of input structure
   const { values: initValues } = initialValue
+  const checkboxPropertyNames = {
+    label: keyMap?.label ?? 'label',
+    text: keyMap?.text ?? 'text',
+    textNegative: keyMap?.textNegative ?? 'textNegative',
+    key: keyMap?.key ?? 'key',
+    selected: keyMap?.selected ?? 'selected',
+  }
   return (
     checkboxes
-      .map((cb: Checkbox, index: number) => {
+      .map((cb: any, index: number) => {
         if (typeof cb === 'string' || typeof cb === 'number')
           return {
             label: String(cb),
@@ -126,11 +145,11 @@ const getInitialState = (initialValue: CheckboxSavedState, checkboxes: Checkbox[
           }
         else
           return {
-            label: cb.label,
-            text: cb?.text || cb.label,
-            textNegative: cb?.textNegative || '',
-            key: cb?.key || index,
-            selected: cb?.selected || false,
+            label: cb?.[checkboxPropertyNames.label],
+            text: cb?.[checkboxPropertyNames.text] || cb?.[checkboxPropertyNames.label],
+            textNegative: cb?.[checkboxPropertyNames.textNegative] || '',
+            key: cb?.[checkboxPropertyNames.key] || index,
+            selected: cb?.[checkboxPropertyNames.selected] || false,
           }
       })
       // Replaces with any already-selected values from database

--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { Checkbox, Form } from 'semantic-ui-react'
+import { Button, Checkbox, Form } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
 import { useLanguageProvider } from '../../../contexts/Localisation'
 import config from '../pluginConfig.json'
@@ -27,15 +27,18 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const { getPluginStrings } = useLanguageProvider()
   const strings = getPluginStrings('checkbox')
   const { isEditable } = element
-  const { label, description, checkboxes, type, layout } = parameters
+  const { label, description, checkboxes, type, layout, resetButton = false, keyMap } = parameters
 
   const [checkboxElements, setCheckboxElements] = useState<Checkbox[]>(
     getInitialState(initialValue, checkboxes)
   )
+  const [initialState, setInitialState] = useState<Checkbox[]>()
 
   // When checkbox array changes after initial load (e.g. when its being dynamically loaded from an API)
   useEffect(() => {
-    setCheckboxElements(getInitialState(initialValue, checkboxes))
+    const initState = getInitialState(initialValue, checkboxes)
+    setCheckboxElements(initState)
+    setInitialState(initState)
   }, [checkboxes])
 
   useEffect(() => {
@@ -61,12 +64,14 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       }, '')
       .replace(/^$/, `*<${strings.LABEL_SUMMMARY_NOTHING_SELECTED}>*`)
 
-  function toggle(e: any, data: any) {
+  const toggle = (e: any, data: any) => {
     const { index } = data
     const changedCheckbox = { ...checkboxElements[index] }
     changedCheckbox.selected = !changedCheckbox.selected
     setCheckboxElements(checkboxElements.map((cb, i) => (i === index ? changedCheckbox : cb)))
   }
+
+  const resetState = () => setCheckboxElements(initialState as Checkbox[])
 
   const styles =
     layout === 'inline'
@@ -94,6 +99,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
           />
         </Form.Field>
       ))}
+      {resetButton && (
+        <div style={{ marginTop: 10 }}>
+          <Button primary content="Reset selections" compact onClick={resetState} />
+        </div>
+      )}
     </>
   )
 }


### PR DESCRIPTION
Fix #1052 

~~Just quickly putting this in Draft PR so @nmadruga can begin using it, still need to thoroughly test it and tweak it.~~

One other little addition -- if the API returns more fields that the required ones, then these will also be passed along and saved with the response. For example, when fetching permission names, values like "id" will be captured and stored with the response even though they're not required for display.

Extra: fixed one more JWT error in `Evaluation.tsx` -- same issue as yesterday's fix, this is just one more I found.