### PR TITLE
#1054 Quick fix: Admin loading problem fix

### DIFF
--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link, Route, Switch } from 'react-router-dom'
 import { Header } from 'semantic-ui-react'
-import { NoMatch } from '.'
+import { Loading, NoMatch } from '.'
 import Snapshots from '../containers/Dev/Snapshots'
 import TemplateWrapper from '../containers/TemplateBuilder/template/TemplateWrapper'
 import Templates from '../containers/TemplateBuilder/Templates'
@@ -15,8 +15,10 @@ const Admin: React.FC = () => {
     match: { path },
   } = useRouter()
   const {
-    userState: { isAdmin },
+    userState: { isAdmin, isLoading },
   } = useUserState()
+
+  if (isLoading) return <Loading />
 
   if (!isAdmin) return <NoMatch />
 

--- a/src/containers/Main/SiteLayout.tsx
+++ b/src/containers/Main/SiteLayout.tsx
@@ -53,9 +53,6 @@ const SiteLayout: React.FC = () => {
             <Route>
               <NoMatch />
             </Route>
-            <Route>
-              <NoMatch />
-            </Route>
           </Switch>
         </Container>
         <Footer />


### PR DESCRIPTION
Fix #1054 

Quick fix for this, since it's been annoying me for a few weeks now. The 404 component shouldn't show when userState is still loading, so this just checks for that before the "isAdmin" check.