### PR TITLE
#1058 Handle changing checkbox input parameters correctly

### DIFF
--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -34,16 +34,13 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const [checkboxElements, setCheckboxElements] = useState<Checkbox[]>(
     getInitialState(initialValue, checkboxes, keyMap, isFirstRender)
   )
-  const [initialState, setInitialState] = useState<Checkbox[]>()
 
   // When checkbox array changes after initial load (e.g. when its being dynamically loaded from an API)
   useEffect(() => {
     if (checkboxes[0] !== config.parameterLoadingValues.label && isFirstRender) {
       setIsFirstRender(false)
     }
-    const initState = getInitialState(initialValue, checkboxes, keyMap, isFirstRender)
-    setCheckboxElements(initState)
-    setInitialState(initState)
+    setCheckboxElements(getInitialState(initialValue, checkboxes, keyMap, isFirstRender))
   }, [checkboxes])
 
   useEffect(() => {
@@ -77,7 +74,8 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     setCheckboxElements(checkboxElements.map((cb, i) => (i === index ? changedCheckbox : cb)))
   }
 
-  const resetState = () => setCheckboxElements(initialState as Checkbox[])
+  const resetState = () =>
+    setCheckboxElements(getInitialState(initialValue, checkboxes, keyMap, isFirstRender))
 
   const styles =
     layout === 'inline'

--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -29,14 +29,19 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const { isEditable } = element
   const { label, description, checkboxes, type, layout, resetButton = false, keyMap } = parameters
 
+  const [isFirstRender, setIsFirstRender] = useState(true)
+
   const [checkboxElements, setCheckboxElements] = useState<Checkbox[]>(
-    getInitialState(initialValue, checkboxes, keyMap)
+    getInitialState(initialValue, checkboxes, keyMap, isFirstRender)
   )
   const [initialState, setInitialState] = useState<Checkbox[]>()
 
   // When checkbox array changes after initial load (e.g. when its being dynamically loaded from an API)
   useEffect(() => {
-    const initState = getInitialState(initialValue, checkboxes, keyMap)
+    if (checkboxes[0] !== config.parameterLoadingValues.label && isFirstRender) {
+      setIsFirstRender(false)
+    }
+    const initState = getInitialState(initialValue, checkboxes, keyMap, isFirstRender)
     setCheckboxElements(initState)
     setInitialState(initState)
   }, [checkboxes])
@@ -122,7 +127,8 @@ type KeyMap = {
 const getInitialState = (
   initialValue: CheckboxSavedState,
   checkboxes: Checkbox[],
-  keyMap: KeyMap | undefined
+  keyMap: KeyMap | undefined,
+  isFirstRender: boolean
 ) => {
   // Returns a consistent array of Checkbox objects, regardless of input structure
   const { values: initValues } = initialValue
@@ -133,31 +139,31 @@ const getInitialState = (
     key: keyMap?.key ?? 'key',
     selected: keyMap?.selected ?? 'selected',
   }
-  return (
-    checkboxes
-      .map((cb: any, index: number) => {
-        if (typeof cb === 'string' || typeof cb === 'number')
-          return {
-            label: String(cb),
-            text: String(cb),
-            textNegative: '',
-            key: index,
-            selected: false,
-          }
-        else
-          return {
-            ...cb,
-            label: cb?.[checkboxPropertyNames.label],
-            text: cb?.[checkboxPropertyNames.text] || cb?.[checkboxPropertyNames.label],
-            textNegative: cb?.[checkboxPropertyNames.textNegative] || '',
-            key: cb?.[checkboxPropertyNames.key] || index,
-            selected: cb?.[checkboxPropertyNames.selected] || false,
-          }
-      })
-      // Replaces with any already-selected values from database
-      .map((cb) => ({
+  const checkboxElements = checkboxes.map((cb: any, index: number) => {
+    if (typeof cb === 'string' || typeof cb === 'number')
+      return {
+        label: String(cb),
+        text: String(cb),
+        textNegative: '',
+        key: index,
+        selected: false,
+      }
+    else
+      return {
+        ...cb,
+        label: cb?.[checkboxPropertyNames.label],
+        text: cb?.[checkboxPropertyNames.text] || cb?.[checkboxPropertyNames.label],
+        textNegative: cb?.[checkboxPropertyNames.textNegative] || '',
+        key: cb?.[checkboxPropertyNames.key] || index,
+        selected: cb?.[checkboxPropertyNames.selected] || false,
+      }
+  })
+  // On first render, we set elements to the *saved* state, but after that we
+  // replace them with the new, changed checkbox values
+  return isFirstRender
+    ? checkboxElements.map((cb) => ({
         ...cb,
         selected: initValues?.[cb.key] ? initValues[cb.key].selected : cb.selected,
       }))
-  )
+    : checkboxElements
 }


### PR DESCRIPTION
Fix #1058 

This was a bit trickier than I originally thought it would be, as I had to figure out a way for the plugin to know whether the change was a "proper" change, or just the initial loading values. In the former case, the state should be replaced by the new values, but in the latter case (initial load), the checkbox state should be loaded from the saved response. And it's complicated by the fact that we also want to ignore the "Loading" values and not consider them a proper "change".

Anyway, the good thing is I think I can probably apply this technique to other plugins, which might make what I was trying to achieve with proper "default" values somewhat easier. We'll see.

To test (using Nicole's grant permissions template):
- on initial load, all permissions should show unchecked
- select a user, the checkboxes should be populated with the correct permission selections
- delete user from previous question, they should revert to all unchecked
- re-load the user, then select some additional checkboxes
- refresh the page, the extra selections should remain selected

I have one question: currently the "Reset selections" button reverts it to the state it was in *when the page was loaded*. Do you think this is correct, or should it revert to the default selections (current permissions) for the selected user?