### PR TITLE
#1061 Checkbox presentation improvements

### DIFF
--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -333,7 +333,7 @@ To handle objects returned that don't have the required fields, you can use the 
     – Option1: YES
     - Option 2: NO
     - \<checkbox `label`\>: \<`text`\/`textNegative` value\>  
-Note: this display option on suitable if you have seperately defined `label`, `text` and `textNegative` fields for each checkbox. 
+Note: this display option is only suitable if you have separately defined `label`, `text` and `textNegative` fields for each checkbox. 
 - **keyMap**: `object` -- if the input `checkboxes` property (above) has different property names that what is required (for example, if pulling from an API), then this `keyMap` parameter can be used to re-map the input property names to the requried property names. For example, if your input "checkbox" data contained an array of objects of the type `{ name: "Nicole", active: true}`, you would provide a `keyMap` object like this:
 ```
 {

--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -325,6 +325,15 @@ To handle objects returned that don't have the required fields, you can use the 
 - **type**: `string` -- Can be "toggle" to display as a toggle switch, or "slider" to display as a slider switch (defaults to regular checkbox).
 - **layout**: `string` -- if "inline", displays checkboxes horizontally in rows. Useful if there are a lot of checkboxes.
 - **resetButton**: `boolean` -- if `true`, element will show a "Reset" button, which allows user to reset selections to the initial (loading) state. (Default: `false`)
+- **textDisplay**: (Options: `text`, `list` (default), `propertyList`) -- specifies how to show the applicant's response on the Summary page:
+  - `list`: shows the selected checkboxes in a (Markdown) list
+  - `text`: shows the selected values in a comma-seperated text string
+  - `propertyList`: displays in a list with properties (the checkbox `label` field) and values (the checkbox `text` or `textNegative` values, depending on selection).  
+  e.g.  
+    – Option1: YES
+    - Option 2: NO
+    - \<checkbox `label`\>: \<`text`\/`textNegative` value\>  
+Note: this display option on suitable if you have seperately defined `label`, `text` and `textNegative` fields for each checkbox. 
 - **keyMap**: `object` -- if the input `checkboxes` property (above) has different property names that what is required (for example, if pulling from an API), then this `keyMap` parameter can be used to re-map the input property names to the requried property names. For example, if your input "checkbox" data contained an array of objects of the type `{ name: "Nicole", active: true}`, you would provide a `keyMap` object like this:
 ```
 {
@@ -339,7 +348,12 @@ This tells the element to look at the "name" field for the `label`, and the "act
 ```
 
 {
-    text: <string> -- comma separated list of all selected checkbox "text" values, shown in Summary view (or Review)
+    text: <string> -- comma separated list of all selected checkbox "text" 
+    textUnselected: <string> -- comma separated list of all unselected checkbox "text"
+    textMarkdownList: <string> -- selected text values formatted as a Markdown list
+    textUnselectedMarkdownList: <string> -- unselected text values formatted as a Markdown list
+    textMarkdownPropertyList: <string> -- all checboxes displayed as a Markdown <label>: <text/textNegative> list (see "textDisplay -> propertyList" above)
+    values, shown in Summary view (or Review)
     values: {
         <key-name-1> : { text: <text value>, isSelected: <boolean>}
         <key-name-2> : { text: <text value>, isSelected: <boolean>}

--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -46,8 +46,19 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   useEffect(() => {
     // Don't save response if parameters are still loading
     if (checkboxElements[0].text === config.parameterLoadingValues.label) return
+    const {
+      text,
+      textUnselected,
+      textMarkdownList,
+      textUnselectedMarkdownList,
+      textMarkdownPropertyList,
+    } = createTextStrings(checkboxElements, strings.LABEL_SUMMMARY_NOTHING_SELECTED)
     onSave({
-      text: createTextString(checkboxElements),
+      text,
+      textUnselected,
+      textMarkdownList,
+      textUnselectedMarkdownList,
+      textMarkdownPropertyList,
       values: Object.fromEntries(
         checkboxElements.map((cb) => [
           cb.key,
@@ -58,14 +69,6 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
       unselectedValuesArray: checkboxElements.filter((cb) => !cb.selected),
     })
   }, [checkboxElements])
-
-  const createTextString = (checkboxes: Checkbox[]) =>
-    checkboxes
-      .reduce((output, cb) => {
-        const text = cb.selected ? cb.text : cb.textNegative
-        return output + (output === '' ? text : ', ' + text)
-      }, '')
-      .replace(/^$/, `*<${strings.LABEL_SUMMMARY_NOTHING_SELECTED}>*`)
 
   const toggle = (e: any, data: any) => {
     const { index } = data
@@ -164,4 +167,36 @@ const getInitialState = (
         selected: initValues?.[cb.key] ? initValues[cb.key].selected : cb.selected,
       }))
     : checkboxElements
+}
+
+const createTextStrings = (checkboxes: Checkbox[], nothingSelectedText: string) => {
+  let text = ''
+  let textUnselected = ''
+  let textMarkdownList = ''
+  let textUnselectedMarkdownList = ''
+  let textMarkdownPropertyList = ''
+  checkboxes.forEach((cb) => {
+    textMarkdownPropertyList =
+      textMarkdownPropertyList + `- ${cb.label}: ${cb.selected ? cb.text : cb.textNegative}\n`
+    if (cb.selected) {
+      text = text === '' ? cb.text : `${text}, ${cb.text}`
+      textMarkdownList = textMarkdownList + `- ${cb.text}\n`
+    } else {
+      textUnselected = textUnselected === '' ? cb.text : `${textUnselected}, ${cb.text}`
+      textUnselectedMarkdownList = textUnselectedMarkdownList + `- ${cb.text}\n`
+      if (cb.textNegative) {
+        text = text === '' ? cb.textNegative : `${text}, ${cb.textNegative}`
+        textMarkdownList = textMarkdownList + `- ${cb.textNegative}\n`
+      }
+    }
+  })
+  if (text === '') text = `*${nothingSelectedText}*`
+  if (textMarkdownList === '') textMarkdownList = `- *${nothingSelectedText}*\n`
+  return {
+    text,
+    textUnselected,
+    textMarkdownList,
+    textUnselectedMarkdownList,
+    textMarkdownPropertyList,
+  }
 }

--- a/src/formElementPlugins/checkbox/src/SummaryView.tsx
+++ b/src/formElementPlugins/checkbox/src/SummaryView.tsx
@@ -1,8 +1,36 @@
 import React from 'react'
+import { Form } from 'semantic-ui-react'
+import { ResponseFull } from '../../../utils/types'
 import { SummaryViewProps } from '../../types'
 
-const SummaryView: React.FC<SummaryViewProps> = ({ DefaultSummaryView }) => {
-  return <DefaultSummaryView />
+enum TextDisplay {
+  TEXT = 'text',
+  LIST = 'list',
+  PROPERTYLIST = 'propertyList',
+}
+
+const getMarkdownText = (textDisplay: string, response: ResponseFull) => {
+  switch (textDisplay) {
+    case TextDisplay.LIST:
+      return response?.textMarkdownList ?? response.text
+    case TextDisplay.PROPERTYLIST:
+      return response?.textMarkdownPropertyList ?? response.text
+    default:
+      return response.text
+  }
+}
+
+const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
+  const { textDisplay = TextDisplay.LIST, label, description } = parameters
+  return (
+    <Form.Field className="element-summary-view">
+      <label style={{ color: 'black' }}>
+        <Markdown text={label} semanticComponent="noParagraph" />
+      </label>
+      <Markdown text={description} />
+      <Markdown text={(response ? getMarkdownText(textDisplay, response) : '') as string} />
+    </Form.Field>
+  )
 }
 
 export default SummaryView

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -339,6 +339,11 @@ interface ResponseFull {
   list?: any // Used in ListBuilder
   date?: any // Used in DatePicker
   number?: number | null // Used in Number plugin
+  // Next 4 used in Checkbox Summary view
+  textUnselected?: string
+  textMarkdownList?: string
+  textUnselectedMarkdownList?: string
+  textMarkdownPropertyList?: string
   timeCreated?: Date
   reviewResponse?: ReviewResponse
   customValidation?: ValidationState


### PR DESCRIPTION
Fix #1061 

Gives us more flexibility as to how we can display checkbox selections (for example, permission lists in "Grant Permissions" notification email), and also presents a nicer display in standard "SummaryView".

To see the effect in SummaryView, please load snapshot `/dev/snapshots/[TEMP]checkbox_improvements` and look at the "Feature Showcase" template -- Section 1, Page 4. Or you can just look at the way the permissions are displayed in the new permission checkbox templates (in email and verification message).

Specs described in updated docs
<img alt="Screen Shot 2021-12-02 at 12 27 25 AM" src="https://user-images.githubusercontent.com/5456533/144226680-79ef19f8-7f35-4c05-b2fb-a13e5e83ee85.png">
