### PR TITLE
#1068 Application Data fix

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -1876,6 +1876,7 @@ a:hover {
 .object-properties-container {
   .flex-column-start-center();
   margin-left: 30px;
+  max-width: 500px;
 }
 .evaluator-operator-container {
   .flex-column-start-stretch();

--- a/src/containers/TemplateBuilder/shared/Evaluation.tsx
+++ b/src/containers/TemplateBuilder/shared/Evaluation.tsx
@@ -17,11 +17,12 @@ type EvaluationProps = {
   evaluation: EvaluatorNode
   currentElementCode: string
   setEvaluation: (evaluation: EvaluatorNode) => void
-  fullStructure?: FullStructure // for Form
+  fullStructure?: FullStructure // for Form Elements
   applicationData?: any // for Actions
   label: string
   updateKey?: (key: string) => void
   deleteKey?: () => void
+  type?: 'FormElement' | 'Action'
 }
 
 type EvaluationHeaderProps = {
@@ -57,21 +58,28 @@ const Evaluation: React.FC<EvaluationProps> = ({
   applicationData,
   updateKey,
   deleteKey,
+  type,
 }) => {
   const {
     userState: { currentUser },
   } = useUserState()
   const [isActive, setIsActive] = useState(false)
   const [asGui, setAsGui] = useState(true)
-  const objects = {
-    responses: {
-      ...fullStructure?.responsesByCode,
-      thisResponse: fullStructure?.responsesByCode?.[currentElementCode]?.text,
-    },
-    currentUser,
-    applicationData: applicationData ? applicationData : fullStructure?.info,
-  }
   const JWT = localStorage.getItem(config.localStorageJWTKey)
+  const objects =
+    type === 'Action'
+      ? { applicationData }
+      : type === 'FormElement'
+      ? {
+          responses: {
+            ...fullStructure?.responsesByCode,
+            thisResponse: fullStructure?.responsesByCode?.[currentElementCode]?.text,
+          },
+          currentUser,
+          applicationData: fullStructure?.info,
+        }
+      : undefined
+
   const evaluationParameters = {
     objects,
     APIfetch: fetch,
@@ -133,7 +141,7 @@ const Evaluation: React.FC<EvaluationProps> = ({
                   evaluationParameters
                 )}
             </div>
-            {fullStructure && (
+            {objects && (
               <div className="object-properties-container">
                 <Label>Object Properties</Label>
                 <div className="spacer-20" />

--- a/src/containers/TemplateBuilder/shared/Parameters.tsx
+++ b/src/containers/TemplateBuilder/shared/Parameters.tsx
@@ -17,6 +17,7 @@ type ParametersProps = {
   fullStructure?: FullStructure
   requiredParameters?: string[]
   optionalParameters?: string[]
+  type?: 'FormElement' | 'Action'
 }
 
 export const Parameters: React.FC<ParametersProps> = ({
@@ -26,6 +27,7 @@ export const Parameters: React.FC<ParametersProps> = ({
   fullStructure,
   requiredParameters,
   optionalParameters,
+  type,
 }) => {
   const { applicationData } = useActionState()
   const [asGui, setAsGui] = useState(true)
@@ -125,9 +127,10 @@ export const Parameters: React.FC<ParametersProps> = ({
                     }}
                     key={key}
                     evaluation={value}
-                    applicationData={applicationData}
-                    currentElementCode={currentElementCode}
                     fullStructure={fullStructure}
+                    applicationData={applicationData}
+                    type={type}
+                    currentElementCode={currentElementCode}
                     label={key}
                   />
                 ))}

--- a/src/containers/TemplateBuilder/template/Actions/ActionConfig.tsx
+++ b/src/containers/TemplateBuilder/template/Actions/ActionConfig.tsx
@@ -1,5 +1,4 @@
 import { EvaluatorNode } from '@openmsupply/expression-evaluator/lib/types'
-import { stat } from 'fs'
 import React from 'react'
 import { useEffect, useState } from 'react'
 import { Icon, Label, Modal, Header } from 'semantic-ui-react'
@@ -10,7 +9,6 @@ import Evaluation from '../../shared/Evaluation'
 import { useOperationState } from '../../shared/OperationContext'
 import { Parameters, ParametersType } from '../../shared/Parameters'
 import TextIO from '../../shared/TextIO'
-import { useFullApplicationState } from '../ApplicationWrapper'
 import { disabledMessage, useTemplateState } from '../TemplateWrapper'
 import { useActionState } from './Actions'
 import FromExistingAction from './FromExistingAction'
@@ -140,6 +138,7 @@ const ActionConfig: React.FC<ActionConfigProps> = ({ templateAction, onClose }) 
                 evaluation={state?.condition}
                 setEvaluation={(condition) => setState({ ...state, condition })}
                 applicationData={applicationData}
+                type="Action"
               />
             </div>
           </div>
@@ -150,6 +149,7 @@ const ActionConfig: React.FC<ActionConfigProps> = ({ templateAction, onClose }) 
             setParameters={(parameterQueries) => setState({ ...state, parameterQueries })}
             requiredParameters={(currentActionPlugin?.requiredParameters as string[]) || []}
             optionalParameters={(currentActionPlugin?.optionalParameters as string[]) || []}
+            type="Action"
           />
           <div className="spacer-20" />
           <div className="flex-row-center-center">

--- a/src/containers/TemplateBuilder/template/Form/ElementConfig.tsx
+++ b/src/containers/TemplateBuilder/template/Form/ElementConfig.tsx
@@ -237,6 +237,7 @@ const ElementConfig: React.FC<ElementConfigProps> = ({ element, onClose }) => {
                 fullStructure={structure}
                 evaluation={state[key]}
                 setEvaluation={(evaluation) => setState({ ...state, [key]: evaluation })}
+                type="FormElement"
               />
             ))}
           </div>
@@ -247,6 +248,7 @@ const ElementConfig: React.FC<ElementConfigProps> = ({ element, onClose }) => {
             fullStructure={structure}
             parameters={state.parameters}
             setParameters={(parameters) => setState({ ...state, parameters })}
+            type="FormElement"
           />
           <div className="spacer-20" />
           <div className="flex-row-center-center">

--- a/src/containers/TemplateBuilder/template/General/MessagesConfig.tsx
+++ b/src/containers/TemplateBuilder/template/General/MessagesConfig.tsx
@@ -66,7 +66,6 @@ const MessagesConfig: React.FC<MessagesConfigProps> = ({ isOpen, onClose }) => {
             label={title}
             key={key}
             currentElementCode={''}
-            fullStructure={structure}
             evaluation={state[key]}
             setEvaluation={(evaluation) => setState({ ...state, [key]: evaluation })}
           />

--- a/src/containers/TemplateBuilder/template/Permissions/PermissionNameInfo/InfoComponents.tsx
+++ b/src/containers/TemplateBuilder/template/Permissions/PermissionNameInfo/InfoComponents.tsx
@@ -66,12 +66,12 @@ export const PermissionActionInfo: React.FC<PermissionActionsProps> = ({ templat
         evaluation={templateAction?.condition}
         setEvaluation={() => {}}
       />
-      <Parameters
+      {/* <Parameters
         key="parametersElement"
         currentElementCode={''}
         parameters={templateAction?.parameterQueries || {}}
         setParameters={() => {}}
-      />
+      /> */}
     </div>
   )
 }
@@ -90,12 +90,12 @@ export const TemplateElementInfo: React.FC<TemplateElementProps> = ({ templateEl
           text={`${templateElement?.code} - ${templateElement?.title}`}
         />
       </div>
-      <Parameters
+      {/* <Parameters
         key="parametersElement"
         currentElementCode={''}
         parameters={templateElement?.parameters || {}}
         setParameters={() => {}}
-      />
+      /> */}
     </div>
   )
 }

--- a/src/containers/TemplateBuilder/template/Permissions/PermissionNameList.tsx
+++ b/src/containers/TemplateBuilder/template/Permissions/PermissionNameList.tsx
@@ -40,11 +40,12 @@ const PermissionNameList: React.FC<PermissionNameListProps> = ({
               <TextIO
                 title="Permission Name"
                 text={templatePermission?.permissionName?.name || ''}
-                icon="info circle"
-                iconColor="blue"
-                onIconClick={() =>
-                  setPermissionNameInfo(templatePermission?.permissionName as PermissionName)
-                }
+                // DISABLED FOR NOW, TILL WE FIGURE OUT A BETTER WAY TO DISPLAY IT
+                // icon="info circle"
+                // iconColor="blue"
+                // onIconClick={() =>
+                //   setPermissionNameInfo(templatePermission?.permissionName as PermissionName)
+                // }
               />
               <TextIO
                 title="Permission Policy"


### PR DESCRIPTION
Fix #1068 

- Make sure the data shown "Object Properties" panel matches what will actually be used when the template is used
- Show "Object Properties" panel for Actions as well
- Limit width of "ObjectProperties" panel to 500px
- Disabled the "Info" panel displayed from the "i" icon in Permission Names, cos it's an absolute mess and unusable without a lot of work. (Have just commented out the icon so it can't be launched). Will have to revisit this with a better UI at some point