### PR TITLE
Fix "disabled" message on Save button

### DIFF
--- a/src/containers/TemplateBuilder/template/Actions/ActionConfig.tsx
+++ b/src/containers/TemplateBuilder/template/Actions/ActionConfig.tsx
@@ -186,7 +186,7 @@ const ActionConfig: React.FC<ActionConfigProps> = ({ templateAction, onClose }) 
             <ButtonWithFallback
               title={strings.TEMPLATE_BUTTON_SAVE}
               disabled={!isDraft || !shouldUpdate}
-              disabledMessage={!isDraft ? disabledMessage : 'No changes'}
+              disabledMessage={!isDraft ? disabledMessage : strings.TEMPLATE_MESSAGE_SAVE_DISABLED}
               onClick={updateAction}
             />
             <ButtonWithFallback

--- a/src/containers/TemplateBuilder/template/Actions/ActionConfig.tsx
+++ b/src/containers/TemplateBuilder/template/Actions/ActionConfig.tsx
@@ -186,7 +186,7 @@ const ActionConfig: React.FC<ActionConfigProps> = ({ templateAction, onClose }) 
             <ButtonWithFallback
               title={strings.TEMPLATE_BUTTON_SAVE}
               disabled={!isDraft || !shouldUpdate}
-              disabledMessage={disabledMessage}
+              disabledMessage={!isDraft ? disabledMessage : 'No changes'}
               onClick={updateAction}
             />
             <ButtonWithFallback

--- a/src/containers/TemplateBuilder/template/Form/ElementConfig.tsx
+++ b/src/containers/TemplateBuilder/template/Form/ElementConfig.tsx
@@ -314,7 +314,7 @@ const ElementConfig: React.FC<ElementConfigProps> = ({ element, onClose }) => {
             <ButtonWithFallback
               title={strings.TEMPLATE_BUTTON_SAVE}
               disabled={!isDraft || !shouldUpdate}
-              disabledMessage={!isDraft ? disabledMessage : 'No changes'}
+              disabledMessage={!isDraft ? disabledMessage : strings.TEMPLATE_MESSAGE_SAVE_DISABLED}
               onClick={updateElement}
             />
             <ButtonWithFallback

--- a/src/containers/TemplateBuilder/template/Form/ElementConfig.tsx
+++ b/src/containers/TemplateBuilder/template/Form/ElementConfig.tsx
@@ -314,7 +314,7 @@ const ElementConfig: React.FC<ElementConfigProps> = ({ element, onClose }) => {
             <ButtonWithFallback
               title={strings.TEMPLATE_BUTTON_SAVE}
               disabled={!isDraft || !shouldUpdate}
-              disabledMessage={disabledMessage}
+              disabledMessage={!isDraft ? disabledMessage : 'No changes'}
               onClick={updateElement}
             />
             <ButtonWithFallback

--- a/src/containers/User/UserArea.tsx
+++ b/src/containers/User/UserArea.tsx
@@ -111,6 +111,14 @@ const MainMenuBar: React.FC<MainMenuBarProps> = ({ templates, outcomes }) => {
       value: '/admin/localisations',
     },
   ]
+  // Only include Snapshots menu item in Dev mode
+  if (process.env.NODE_ENV === 'development')
+    adminOptions.splice(1, 0, {
+      key: 'snapshots',
+      text: 'Snapshots',
+      value: '/admin/snapshots',
+    })
+
   // Add Admin templates to Admin menu
   adminOptions.push(
     ...templates

--- a/src/utils/defaultLanguageStrings.ts
+++ b/src/utils/defaultLanguageStrings.ts
@@ -319,6 +319,7 @@ export default {
   TEMPLATE_APPEARS_IN: 'Appears in',
   TEMPLATE_MESSAGE_SAVE_AND_CLOSE: 'There are changes not saved. Would you like to save and close?',
   TEMPLATE_MESSAGE_SAVE_SUCCESS: 'Changes saved',
+  TEMPLATE_MESSAGE_SAVE_DISABLED: 'No changes',
   TEMPLATE_MESSAGE_REMOVE_ELEMENT_TITLE: 'Remove element',
   TEMPLATE_MESSAGE_REMOVE_ELEMENT_CONTENT: 'Are you sure you would like to remove this element?',
   UNASSIGN_TITLE: 'Unassignment of reviewer',


### PR DESCRIPTION
Just a little thing I discovered after already building last night -- the tool-tip message for the "Save" button when disable was not appropriate for this context.

Now shows a different message depending on whether it's disabled due to not being in draft, or because no changes have been made yet.

Edit: Also quickly chucked in a link to "Snapshots" in the Admin menu, but only for dev mode -- I got sick of typing it 😜