### PR TITLE
Max width on dashboard container

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -1183,6 +1183,8 @@ a:hover {
 #dashboard {
   .flex-column();
 
+  max-width: 1100px; // Restrict to 3 columns
+
   .template-category {
     .flex-column();
     flex-wrap: wrap;


### PR DESCRIPTION
Oops -- something we neglected previously (I thought we'd already done it). The Dashboard needs to have a max-width so it doesn't show more than three template columns across, otherwise it looks really bad:
![Screen Shot 2021-12-15 at 1 19 27 PM](https://user-images.githubusercontent.com/5456533/146100077-a6d074ef-74be-4b38-b8d2-d297b9467ee4.png)

![Screen Shot 2021-12-15 at 1 20 16 PM](https://user-images.githubusercontent.com/5456533/146100081-c5eaee41-131b-41b9-a7b5-ad2fb5d76bd4.png)

Noticed when adding admin permissions.
