### PR TITLE
Template builder -- show page 1 by default

### DIFF
--- a/src/containers/TemplateBuilder/template/Form/Elements.tsx
+++ b/src/containers/TemplateBuilder/template/Form/Elements.tsx
@@ -167,7 +167,6 @@ const ElementMove: React.FC<{ elementId: number }> = ({ elementId }) => {
   }
 
   const doubleMove = (forward = true) => {
-    console.log('yow')
     if ((!forward && currentPage.isLast) || (forward && currentPage.isFirst)) {
       moveToSection(forward ? currentSection.previousSection : currentSection.nextSection)
     } else {

--- a/src/containers/TemplateBuilder/template/Form/Form.tsx
+++ b/src/containers/TemplateBuilder/template/Form/Form.tsx
@@ -23,7 +23,7 @@ const contextNotDefined = () => {
 }
 const defaultFormState: FormState = {
   selectedSectionId: -1,
-  selectedPageNumber: -1,
+  selectedPageNumber: 1,
   setSelectedSectionId: contextNotDefined,
   setSelectedPageNumber: contextNotDefined,
   unselect: contextNotDefined,
@@ -33,6 +33,8 @@ const FormContext = createContext<FormState>(defaultFormState)
 const Form: React.FC = () => {
   const { moveStructure } = useFormStructureState()
   const [state, setState] = useState<FormState>(defaultFormState)
+
+  console.log('state', state)
 
   useEffect(() => {
     setState({

--- a/src/containers/TemplateBuilder/template/Form/Form.tsx
+++ b/src/containers/TemplateBuilder/template/Form/Form.tsx
@@ -34,8 +34,6 @@ const Form: React.FC = () => {
   const { moveStructure } = useFormStructureState()
   const [state, setState] = useState<FormState>(defaultFormState)
 
-  console.log('state', state)
-
   useEffect(() => {
     setState({
       // Select first section on refresh if none is loaded

--- a/src/containers/TemplateBuilder/template/Form/Sections.tsx
+++ b/src/containers/TemplateBuilder/template/Form/Sections.tsx
@@ -62,7 +62,7 @@ const Sections: React.FC = () => {
               key={section.details.id}
               onClick={() => {
                 setSelectedSectionId(section.details.id)
-                setSelectedPageNumber(-1)
+                setSelectedPageNumber(1)
               }}
               className={`clickable ${
                 section.details.id === selectedSectionId ? 'builder-selected ' : ''


### PR DESCRIPTION
We missed this the other day -- when the "Form" tab loads, it opens with Section 1, Page 1, however when selecting a new Section, there was no page elements shown again.

Fix for that -- now when selecting new section the first page of that section is loaded.