### PR TITLE
Review decision -- include comment in submit

### DIFF
--- a/src/utils/graphql/mutations/updateReview.mutation.ts
+++ b/src/utils/graphql/mutations/updateReview.mutation.ts
@@ -17,6 +17,7 @@ export default gql`
           nodes {
             id
             decision
+            comment
             timeUpdated
           }
         }


### PR DESCRIPTION
Very small change, something that was causing a small problem developing the "activity_log" for back-end. The "comment" field for "review_decision" was being written in a separate mutation, not in the review submission mutation. This just includes the comment in the main mutation as well, just in case the comment mutation hasn't finished before the submission one (which is what was causing the issue)