### PR TITLE
#642B Reset version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-11",
+  "version": "0.1.1-15",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-3",
+  "version": "0.1.1-4",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-0",
+  "version": "0.1.0",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.0",
+  "version": "0.1.1-11",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-8",
+  "version": "0.1.1-9",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-17",
+  "version": "0.1.1-18",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-7",
+  "version": "0.1.1-8",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-19",
+  "version": "0.1.1-1",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-1",
+  "version": "0.1.1-2",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-15",
+  "version": "0.1.1-16",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-2",
+  "version": "0.1.1-3",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-6",
+  "version": "0.1.1-7",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-5",
+  "version": "0.1.1-6",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-18",
+  "version": "0.1.1-19",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.0",
+  "version": "0.1.1-0",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-4",
+  "version": "0.1.1-5",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.1.1-16",
+  "version": "0.1.1-17",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@
 const { port, hostname, protocol } = window.location
 const getUrl = (path: string) => `${protocol}//${hostname}:${port}/${path}`
 const isProductionBuild = process.env.NODE_ENV === 'production'
+const { version } = require('../package.json')
 
 const serverURL = isProductionBuild ? getUrl('server') : 'http://localhost:8080'
 
@@ -11,7 +12,7 @@ const config = {
     : 'http://localhost:5000/graphql',
   serverREST: `${serverURL}/api`,
   uploadEndpoint: '/upload',
-  version: 'dev',
+  version,
   pluginsFolder: 'formElementPlugins',
   nonRegisteredUser: 'nonRegistered',
   localStorageJWTKey: 'persistJWT',


### PR DESCRIPTION
Front-end complement of back-end PR https://github.com/openmsupply/application-manager-server/pull/657

All is does it reset the version back to 0.1.0 and use the value from "package.json" as the source of truth for version number throughout the app.

Note:
- back-end script will be responsible for updating the version numbers for both back and front end
- following semantic versioning, "pre-release" version numbers are in the format "0.1.0-1", "0.1.0-2" etc. -- these get auto-generated using `yarn version ...` (in back-end PR)