### PR TITLE
#1032 Restore text element default

### DIFF
--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -37,7 +37,8 @@ These fields are common to all element types and have their own field in the `te
   - default: `{"value": true}`
 - **is_editable**: `JSON` -- dynamic query determining whether can be edited (Would only be false in rare circumstances)
   - default: `{"value": true}`
-- **defaultValue**: `JSON` - the default value for the response. Can be a dynamic query. Note: several plugins have their own "default" parameter, which may be easier to use in many situations but doesn't support dynamic lookups. If you need a dynamic value, use this field. For this field, the returned object must conform to the object shape for the respective question type (i.e. it needs a `text` field) -- see individual element types for response shape
+- **defaultValue**: `JSON` - the default value for the response. Note: several plugins have their own "default" parameter, which may be easier to use in many situations. What's the difference? In this one, the default response is generated when the application is first created, and from then on it behaves just like a normal question element. The default parameter for individual elements is calculated when the element is rendered, so it can change in response to other changes. If you need a default value to be made from answers the user provided earlier in the form, that would be the one to use. See individual elements for the respective details.  
+**Important**: When you use this `defaultValue` parameter, it must conform to the shape of the saved response for that question type, since it is saved directly as a response when created, not processed in the form itself -- see individual element types for correct response shape
 - **validation**: `JSON` -- a dynamic expression for checking if the user's response is a valid input.
   - default: `{"value": true}` or just `true`
 - **validation_message**: `string` -- the message that shows in the UI when validation fails.  
@@ -63,6 +64,7 @@ _Free-form, single-line text input element_
 - **label**: `string` -- Text that shows in the HTML "label" attribute of the form element (Markdown string, with dynamic expression evaluation)
 - **description**: `string` -- additional explanatory text (usually not required) [Optional]
 - **placeholder**: `string`-- text to display before user input (HTML "placeholder" attribute) [Optional]
+- **default**: `string` -- default response, will change dynamically in response to form changes until the user has edited it [Optional]
 - **maskedInput**: `boolean` -- if `true`, displays user input as masked (hidden) characters -- i.e. for passwords. [Optional]
 - **maxWidth**: `number` -- the maximum width (in pixels) for the text input box (defaults to fill the width of the container)
 - **maxLength**: `number` -- response must be no longer than this many characters. If the user tries to type more, the response will be truncated to the maximum length.  
@@ -103,6 +105,7 @@ _Free-form, multi-line text input element_
 - **label**: `string` -- Text that shows in the HTML "label" attribute of the form element (Markdown string, with dynamic expression evaluation)
 - **description**: `string` -- additional explanatory text (usually not required) [Optional]
 - **placeholder**: `string`-- text to display before user input (HTML "placeholder" attribute) [Optional]
+- **default**: `string` -- default response, will change dynamically in response to form changes until the user has edited it [Optional]
 - **lines**: `number` -- height of the TextArea input, in number of lines/rows (default: 5)
 - **maxLength**: `number` -- response must be no longer than this many characters. If the user tries to type more, the response will be truncated to the maximum length. (See Note in ShortText above for how to integrate `maxLength` with validation.)
 

--- a/src/formElementPlugins/longText/pluginConfig.json
+++ b/src/formElementPlugins/longText/pluginConfig.json
@@ -5,7 +5,8 @@
   "parameterLoadingValues": {
     "label": "Loading...",
     "description": "",
-    "placeholder": "Loading..."
+    "placeholder": "Loading...",
+    "default": ""
   },
   "//": "categories types: 'Input'|'Informative'",
   "category": "Input"

--- a/src/formElementPlugins/longText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/longText/src/ApplicationView.tsx
@@ -22,7 +22,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const { isEditable } = element
 
   useEffect(() => {
-    if ((!value && defaultText) || (!hasEdited && defaultText)) {
+    if (defaultText && (!hasEdited || !value)) {
       onSave({ text: defaultText })
       setValue(defaultText)
     } else onUpdate(value)

--- a/src/formElementPlugins/longText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/longText/src/ApplicationView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { Form, Input } from 'semantic-ui-react'
+import { Form } from 'semantic-ui-react'
 import { ApplicationViewProps } from '../../types'
 
 const ApplicationView: React.FC<ApplicationViewProps> = ({
@@ -13,10 +13,20 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   Markdown,
 }) => {
   const [value, setValue] = useState<string | null | undefined>(currentResponse?.text)
+  const [hasEdited, setHasEdited] = useState(
+    currentResponse?.text !== null && currentResponse?.text !== parameters?.default
+  )
 
-  const { label, description, placeholder, lines, maxLength } = parameters
+  const { label, description, placeholder, lines, maxLength, default: defaultText } = parameters
 
   const { isEditable } = element
+
+  useEffect(() => {
+    if ((!value && defaultText) || (!hasEdited && defaultText)) {
+      onSave({ text: defaultText })
+      setValue(defaultText)
+    } else onUpdate(value)
+  }, [defaultText])
 
   function handleChange(e: any) {
     let text = e.target.value
@@ -25,6 +35,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     }
     onUpdate(text)
     setValue(text)
+    setHasEdited(true)
   }
 
   function handleLoseFocus(e: any) {

--- a/src/formElementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/shortText/src/ApplicationView.tsx
@@ -28,7 +28,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   } = parameters
 
   useEffect(() => {
-    if ((!value && defaultText) || (!hasEdited && defaultText)) {
+    if (defaultText && (!hasEdited || !value)) {
       onSave({ text: defaultText })
       setValue(defaultText)
     } else onUpdate(value)

--- a/src/formElementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/shortText/src/ApplicationView.tsx
@@ -7,12 +7,15 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   parameters,
   onUpdate,
   setIsActive,
+  currentResponse,
   validationState,
   onSave,
   Markdown,
-  currentResponse,
 }) => {
   const [value, setValue] = useState<string | null | undefined>(currentResponse?.text)
+  const [hasEdited, setHasEdited] = useState(
+    currentResponse?.text !== null && currentResponse?.text !== parameters?.default
+  )
   const { isEditable } = element
   const {
     placeholder,
@@ -21,7 +24,15 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     description,
     maxWidth,
     maxLength = Infinity,
+    default: defaultText,
   } = parameters
+
+  useEffect(() => {
+    if ((!value && defaultText) || (!hasEdited && defaultText)) {
+      onSave({ text: defaultText })
+      setValue(defaultText)
+    } else onUpdate(value)
+  }, [defaultText])
 
   function handleChange(e: any) {
     let text = e.target.value
@@ -30,6 +41,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     }
     onUpdate(text)
     setValue(text)
+    setHasEdited(true)
   }
 
   function handleLoseFocus(e: any) {


### PR DESCRIPTION
Fix #1032 

Restored the "default" field of shortText and longText elements, so templates have the option to use this parameter, or the shared "defaultValue" parameter -- since they behave quite differently. I've added an explanation in the docs as to what the difference is.

I have a made a snapshot: `/dev/snapshots/text_field_demo` in the templates repo. There is a template type called "Short Text Demo", which is accessible from the User menu dropdown. You can play around with the values and see the behaviour of the fields with dynamic defaults (Can log in as "Carl" and start a new form if you want)

Expected behaviour:
- Fields with dynamic defaults should change as their source values (other fields) change
- Once the user has edited the value, it will no longer change in response to changes in the source fields