### PR TITLE
#1115B Layout tweaks

### DIFF
--- a/semantic/src/site/elements/header.overrides
+++ b/semantic/src/site/elements/header.overrides
@@ -98,11 +98,6 @@
   margin-top: 0 !important;
 }
 
-// Add space between section title and assignment/review rows on Review home
-.section-title {
-  margin-bottom: 30px !important;
-}
-
 // Adjustments (overrides) to default header styles
 
 .header-space-around-none {

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -833,6 +833,9 @@ a:hover {
       margin-bottom: 5px;
       // max-width: 700px;
     }
+    .ui.label.simple-label {
+      height: 100%;
+    }
   }
   .ui.grid > .row {
     border-radius: 6px;

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -818,15 +818,25 @@ a:hover {
   .ui.grid {
     margin: 0;
     .assigning-row {
-      background-color: @surfacesMed;
+      background-color: @surfacesLight;
+      align-items: center;
+      min-height: 40px;
+      margin-bottom: 5px;
+      .ui.label {
+        line-height: 1.5;
+      }
+      .centered-flex-box-row {
+        display: flex;
+      }
+    }
+    .reviewer-row {
+      margin-bottom: 5px;
+      // max-width: 700px;
     }
   }
   .ui.grid > .row {
     border-radius: 6px;
     padding: 0px;
-    margin-right: 10px;
-    margin-left: 10px;
-    margin-bottom: 10px;
   }
 }
 // Notes tab

--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -813,6 +813,22 @@ a:hover {
   }
 }
 
+// Assignment tab
+#assignment-tab {
+  .ui.grid {
+    margin: 0;
+    .assigning-row {
+      background-color: @surfacesMed;
+    }
+  }
+  .ui.grid > .row {
+    border-radius: 6px;
+    padding: 0px;
+    margin-right: 10px;
+    margin-left: 10px;
+    margin-bottom: 10px;
+  }
+}
 // Notes tab
 
 #notes-tab {

--- a/src/components/Review/ReviewSectionRowAction.tsx
+++ b/src/components/Review/ReviewSectionRowAction.tsx
@@ -69,7 +69,11 @@ const ReviewSectionRowAction: React.FC<ReviewSectionComponentProps> = (props) =>
     }
   }
 
-  return <Grid.Column textAlign="right">{getContent()}</Grid.Column>
+  return (
+    <Grid.Column textAlign="right" width={3} style={{ width: '100%' }}>
+      {getContent()}
+    </Grid.Column>
+  )
 }
 
 const getApplicantChangesUpdatedCount = (reviewProgress?: ReviewProgress) =>

--- a/src/components/Review/ReviewSectionRowAssigned.tsx
+++ b/src/components/Review/ReviewSectionRowAssigned.tsx
@@ -67,7 +67,11 @@ const ReviewSectionRowAssigned: React.FC<ReviewSectionComponentProps> = ({
         )
     }
   }
-  return <Grid.Column className="assigned-column">{getLabel()}</Grid.Column>
+  return (
+    <Grid.Column className="assigned-column" width={5}>
+      {getLabel()}
+    </Grid.Column>
+  )
 }
 
 export default ReviewSectionRowAssigned

--- a/src/components/Review/ReviewSectionRowLastActionDate.tsx
+++ b/src/components/Review/ReviewSectionRowLastActionDate.tsx
@@ -45,7 +45,7 @@ const ReviewSectionRowLastActionDate: React.FC<ReviewSectionComponentProps> = ({
     }
   }
 
-  return <Grid.Column>{getContent()}</Grid.Column>
+  return <Grid.Column width={3}>{getContent()}</Grid.Column>
 }
 
 const LastDate: React.FC<{ title: string; indicator?: React.ReactNode }> = ({

--- a/src/components/Review/ReviewSectionRowProgress.tsx
+++ b/src/components/Review/ReviewSectionRowProgress.tsx
@@ -44,7 +44,7 @@ const ReviewSectionRowProgress: React.FC<ReviewSectionComponentProps> = ({
     }
   }
 
-  return <Grid.Column>{getContent()}</Grid.Column>
+  return isAssignedToCurrentUser ? <Grid.Column width={5}>{getContent()}</Grid.Column> : null
 }
 
 export default ReviewSectionRowProgress

--- a/src/components/Review/ReviewSectionRowProgress.tsx
+++ b/src/components/Review/ReviewSectionRowProgress.tsx
@@ -44,7 +44,7 @@ const ReviewSectionRowProgress: React.FC<ReviewSectionComponentProps> = ({
     }
   }
 
-  return isAssignedToCurrentUser ? <Grid.Column width={5}>{getContent()}</Grid.Column> : null
+  return <Grid.Column width={5}>{getContent()}</Grid.Column>
 }
 
 export default ReviewSectionRowProgress

--- a/src/containers/Review/assignment/AssignmentRows.tsx
+++ b/src/containers/Review/assignment/AssignmentRows.tsx
@@ -34,11 +34,7 @@ const AssignmentRows: React.FC<AssignmentRowsProps> = ({
         <Segment key={id}>
           <Header className="section-title" as="h5" content={title} />
           {Object.entries(assignmentGroupedLevel).map(([level, assignments]) => (
-            <div
-              className="flex-column"
-              key={`assignment-group-level-${level}`}
-              // style={{ gap: 10 }}
-            >
+            <div className="flex-column" key={`assignment-group-level-${level}`}>
               <AssignmentSectionRow
                 assignments={assignments}
                 sectionCode={code}

--- a/src/containers/Review/assignment/AssignmentRows.tsx
+++ b/src/containers/Review/assignment/AssignmentRows.tsx
@@ -31,12 +31,11 @@ const AssignmentRows: React.FC<AssignmentRowsProps> = ({
   return (
     <>
       {Object.values(fullStructure.sections).map(({ details: { id, title, code } }) => (
-        <Segment className="stripes" key={id}>
+        <Segment key={id}>
           <Header className="section-title" as="h5" content={title} />
           {Object.entries(assignmentGroupedLevel).map(([level, assignments]) => (
-            <>
+            <div key={`assignment-group-level-${level}`}>
               <AssignmentSectionRow
-                key={`assignment-row-section-${code}-level-${level}`}
                 assignments={assignments}
                 sectionCode={code}
                 reviewLevel={Number(level)}
@@ -54,7 +53,7 @@ const AssignmentRows: React.FC<AssignmentRowsProps> = ({
                   />
                 ) : null
               )}
-            </>
+            </div>
           ))}
         </Segment>
       ))}

--- a/src/containers/Review/assignment/AssignmentRows.tsx
+++ b/src/containers/Review/assignment/AssignmentRows.tsx
@@ -34,7 +34,11 @@ const AssignmentRows: React.FC<AssignmentRowsProps> = ({
         <Segment key={id}>
           <Header className="section-title" as="h5" content={title} />
           {Object.entries(assignmentGroupedLevel).map(([level, assignments]) => (
-            <div key={`assignment-group-level-${level}`}>
+            <div
+              className="flex-column"
+              key={`assignment-group-level-${level}`}
+              // style={{ gap: 10 }}
+            >
               <AssignmentSectionRow
                 assignments={assignments}
                 sectionCode={code}

--- a/src/containers/Review/assignment/AssignmentSectionRow.tsx
+++ b/src/containers/Review/assignment/AssignmentSectionRow.tsx
@@ -136,18 +136,14 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
       ?.levels.find(({ number }) => reviewLevel === number)?.name || strings.LEVEL_NOT_FOUND
 
   return (
-    <Grid
-      columns={2}
-      className="section-single-row-box-container"
-      // style={{  }}
-    >
+    <Grid columns={2} className="section-single-row-box-container">
       <Grid.Row className="assigning-row">
-        <Grid.Column className="review-level" width={5}>
+        <Grid.Column className="review-level" width={7}>
           <Label className="simple-label">
             {strings.REVIEW_FILTER_LEVEL}: <strong>{levelName}</strong>
           </Label>
         </Grid.Column>
-        <Grid.Column className="centered-flex-box-row" width={11}>
+        <Grid.Column className="centered-flex-box-row" width={9}>
           {originalAssignee ? (
             <AssigneeLabel
               assignee={originalAssignee}

--- a/src/containers/Review/assignment/AssignmentSectionRow.tsx
+++ b/src/containers/Review/assignment/AssignmentSectionRow.tsx
@@ -136,14 +136,18 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
       ?.levels.find(({ number }) => reviewLevel === number)?.name || strings.LEVEL_NOT_FOUND
 
   return (
-    <Grid columns={2} className="section-single-row-box-container">
-      <Grid.Row>
-        <Grid.Column className="review-level">
+    <Grid
+      columns={2}
+      className="section-single-row-box-container"
+      // style={{  }}
+    >
+      <Grid.Row className="assigning-row">
+        <Grid.Column className="review-level" width={5}>
           <Label className="simple-label">
             {strings.REVIEW_FILTER_LEVEL}: <strong>{levelName}</strong>
           </Label>
         </Grid.Column>
-        <Grid.Column className="centered-flex-box-row">
+        <Grid.Column className="centered-flex-box-row" width={11}>
           {originalAssignee ? (
             <AssigneeLabel
               assignee={originalAssignee}

--- a/src/containers/Review/assignment/ReviewSectionRow.tsx
+++ b/src/containers/Review/assignment/ReviewSectionRow.tsx
@@ -55,8 +55,8 @@ const ReviewSectionRow: React.FC<ReviewSectionRowProps> = ({
   return (
     <div key={`section_${sectionCode}_assignment_${assignmentId}`}>
       {canRenderRow && (
-        <Grid className="review-section-row" verticalAlign="middle">
-          <Grid.Row columns={4}>
+        <Grid className="flex-row" verticalAlign="middle">
+          <Grid.Row columns={4} className="reviewer-row">
             <ReviewSectionRowAssigned {...props} />
             <ReviewSectionRowLastActionDate {...props} />
             <ReviewSectionRowProgress {...props} />


### PR DESCRIPTION
I'm not super happy with this, but there's just too many combinations of assignment rows and review rows with so many different possible things inside them, that it's too hard to make them *all* look good.

Right-justifying the actions at the end of each type of row is not possible without overhauling the whole layout structure which would be a big job.

I think this will have to do for now.

![Screen Shot 2022-02-17 at 3 40 29 PM](https://user-images.githubusercontent.com/5456533/154394291-5d5abb7d-4fbd-4470-98d0-df560720d876.png)
