### PR TITLE
1110 fix bugs related to assignment consolidation

### DIFF
--- a/src/components/Review/ReviewSectionRowAction.tsx
+++ b/src/components/Review/ReviewSectionRowAction.tsx
@@ -84,6 +84,7 @@ const getConsolidatorChangesRequestedCount = (progress?: ChangeRequestsProgress)
 // Possible generate action button: START REVIEW, CONTINUE REVIEW, UPDATE REVIEW, RE-REVIEW or MAKE DECISION
 const GenerateActionButton: React.FC<ReviewSectionComponentProps> = ({
   reviewStructure,
+  reviewAssignment,
   section: { details, reviewProgress, consolidationProgress, changeRequestsProgress },
   previousAssignment,
   action,
@@ -98,12 +99,13 @@ const GenerateActionButton: React.FC<ReviewSectionComponentProps> = ({
 
   const remakeReview = useRemakePreviousReview({
     reviewStructure,
+    reviewAssignment,
     previousAssignment,
   })
 
-  const restartReview = useRestartReview(reviewStructure)
+  const restartReview = useRestartReview({ reviewStructure, reviewAssignment })
 
-  const createReview = useCreateReview(reviewStructure)
+  const createReview = useCreateReview({ reviewStructure, reviewAssignment })
 
   const getButtonName = () => {
     switch (action) {

--- a/src/containers/Review/ReviewPage.tsx
+++ b/src/containers/Review/ReviewPage.tsx
@@ -61,7 +61,7 @@ const ReviewPage: React.FC<{
 
   const { isSectionActive, toggleSection } = useQuerySectionActivation({
     defaultActiveSectionCodes: [],
-    allSections: Object.keys(fullApplicationStructure.sections).map((section) => section),
+    allSections: Object.keys(fullApplicationStructure.sections),
   })
 
   const { addScrollable, scrollTo } = useScrollableAttachments()

--- a/src/containers/Review/ReviewPage.tsx
+++ b/src/containers/Review/ReviewPage.tsx
@@ -61,9 +61,7 @@ const ReviewPage: React.FC<{
 
   const { isSectionActive, toggleSection } = useQuerySectionActivation({
     defaultActiveSectionCodes: [],
-    allSections: (reviewStructure?.sortedSections as SectionState[]).map(
-      (section) => section.details.code
-    ),
+    allSections: Object.keys(fullApplicationStructure.sections).map((section) => section),
   })
 
   const { addScrollable, scrollTo } = useScrollableAttachments()

--- a/src/containers/Review/assignment/AssigneeLabel.tsx
+++ b/src/containers/Review/assignment/AssigneeLabel.tsx
@@ -4,7 +4,7 @@ import { useLanguageProvider } from '../../../contexts/Localisation'
 
 interface AssigneeLabelProps {
   assignee: string
-  isSubmitted: boolean
+  isCompleted: boolean
   isSelfAssigned: boolean
   isReassignment: boolean
   setIsReassignment: React.Dispatch<React.SetStateAction<boolean>>
@@ -13,7 +13,7 @@ interface AssigneeLabelProps {
 
 const AssigneeLabel: React.FC<AssigneeLabelProps> = ({
   assignee,
-  isSubmitted,
+  isCompleted,
   isSelfAssigned,
   isReassignment,
   setIsReassignment,
@@ -26,7 +26,7 @@ const AssigneeLabel: React.FC<AssigneeLabelProps> = ({
         {isReassignment ? strings.LABEL_UNASSIGN_FROM : strings.LABEL_REVIEWER}:{' '}
         <strong>{assignee}</strong>
       </Label>
-      {isSubmitted ? null : (
+      {isCompleted ? null : (
         <>
           {!isReassignment && !isSelfAssigned && (
             <>

--- a/src/containers/Review/assignment/AssignmentRows.tsx
+++ b/src/containers/Review/assignment/AssignmentRows.tsx
@@ -50,6 +50,7 @@ const AssignmentRows: React.FC<AssignmentRowsProps> = ({
                     key={`review-row-section-${code}-assignment-${assignment.id}`}
                     sectionId={id}
                     reviewStructure={reviewStructuresState[assignment.id]}
+                    reviewAssignment={assignment}
                     previousAssignment={assignmentInPreviousStage}
                   />
                 ) : null

--- a/src/containers/Review/assignment/AssignmentRows.tsx
+++ b/src/containers/Review/assignment/AssignmentRows.tsx
@@ -1,5 +1,5 @@
 import React, { SetStateAction } from 'react'
-import { Container, Grid, Header, Segment } from 'semantic-ui-react'
+import { Header, Segment } from 'semantic-ui-react'
 import { useReviewStructureState } from '../../../contexts/ReviewStructuresState'
 import {
   AssignmentDetails,

--- a/src/containers/Review/assignment/AssignmentSectionRow.tsx
+++ b/src/containers/Review/assignment/AssignmentSectionRow.tsx
@@ -74,7 +74,6 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
     // elements,
     assignee: assignedSections[sectionCode]?.newAssignee,
   })
-
   if (!assignmentOptions) return null
 
   const onAssigneeSelection = async (assignee: number) => {
@@ -125,11 +124,6 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
     ({ text }) => text != strings.ASSIGNMENT_YOURSELF
   )
 
-  const isSubmitted =
-    assignments.find(
-      (assignment) => assignment.current.assignmentStatus === ReviewAssignmentStatus.Assigned
-    )?.review?.current.reviewStatus === ReviewStatus.Submitted || false
-
   const levelName =
     structure.stages
       .find(({ stage: { number } }) => number === structure.info.current.stage.number)
@@ -147,7 +141,7 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
           {originalAssignee ? (
             <AssigneeLabel
               assignee={originalAssignee}
-              isSubmitted={isSubmitted}
+              isCompleted={assignmentOptions.isCompleted}
               isSelfAssigned={isSelfAssignment}
               isReassignment={isReassignment}
               setIsReassignment={setIsReassignment}

--- a/src/containers/Review/assignment/ReviewSectionRow.tsx
+++ b/src/containers/Review/assignment/ReviewSectionRow.tsx
@@ -19,12 +19,14 @@ type ReviewSectionRowProps = {
   sectionId: number
   previousAssignment: AssignmentDetails
   reviewStructure: FullStructure
+  reviewAssignment: AssignmentDetails
 }
 
 const ReviewSectionRow: React.FC<ReviewSectionRowProps> = ({
   sectionId,
   previousAssignment,
   reviewStructure,
+  reviewAssignment,
 }) => {
   const section = reviewStructure.sortedSections?.find(
     (section) => section.details.id === sectionId
@@ -40,6 +42,7 @@ const ReviewSectionRow: React.FC<ReviewSectionRowProps> = ({
 
   const props: ReviewSectionComponentProps = {
     reviewStructure,
+    reviewAssignment,
     section,
     previousAssignment,
     action: section?.assignment?.action || ReviewAction.unknown,

--- a/src/containers/Review/assignment/useGetAssignmentOptions.ts
+++ b/src/containers/Review/assignment/useGetAssignmentOptions.ts
@@ -1,15 +1,5 @@
-import {
-  AssignmentDetails,
-  AssignmentOptions,
-  AssignmentOption,
-  PageElement,
-  User,
-} from '../../../utils/types'
-import {
-  ReviewAssignmentStatus,
-  ReviewStatus,
-  TemplateElementCategory,
-} from '../../../utils/generated/graphql'
+import { AssignmentDetails, AssignmentOptions, AssignmentOption } from '../../../utils/types'
+import { ReviewAssignmentStatus, ReviewStatus } from '../../../utils/generated/graphql'
 import { useLanguageProvider } from '../../../contexts/Localisation'
 
 const NOT_ASSIGNED = 0
@@ -50,20 +40,12 @@ const useGetAssignmentOptions = () => {
       ({ isCurrentUserAssigner, isSelfAssignable }) => isCurrentUserAssigner || isSelfAssignable
     )
 
-    // // Dont' want to render assignment section row if they have no actions
-    // if (currentUserAssignable.length === 0) return null
-    // const numberOfAssignableElements = elements.filter(
-    //   ({ element }) =>
-    //     (!sectionCode || element.sectionCode === sectionCode) &&
-    //     element.category === TemplateElementCategory.Question
-    // ).length
-
-    // if (numberOfAssignableElements === 0) return null
-
-    const currentlyAssigned = assignments.find(
-      (assignment) =>
-        assignment.current.assignmentStatus === ReviewAssignmentStatus.Assigned &&
-        matchAssignmentToSection(assignment, sectionCode)
+    const currentlyAssigned = assignments.find((assignment) =>
+      assignment.current.assignmentStatus === ReviewAssignmentStatus.Assigned &&
+      // Restriction only apply to level one that isn't lastLevel
+      (assignment.review?.level || 1 > 1 || assignment.isLastLevel)
+        ? true
+        : matchAssignmentToSection(assignment, sectionCode)
     )
 
     if (!previousAssignee && currentlyAssigned)

--- a/src/utils/helpers/structure/generateConsolidatorResponsesProgress.ts
+++ b/src/utils/helpers/structure/generateConsolidatorResponsesProgress.ts
@@ -1,13 +1,42 @@
 import { ReviewResponseDecision } from '../../generated/graphql'
 import { FullStructure, SectionState, Page, PageElement, ConsolidationProgress } from '../../types'
 
-const generateConsolidatorResponsesProgress = (newStructure: FullStructure) => {
-  newStructure?.sortedPages?.forEach(generatePageConsolidationProgress)
-  newStructure?.sortedSections?.forEach(generateSectionConsolidationProgress)
+const initial: ConsolidationProgress = {
+  doneAgreeConform: 0,
+  doneAgreeNonConform: 0,
+  doneDisagree: 0,
+  doneActiveDisagree: 0,
+  doneActiveAgreeConform: 0,
+  doneActiveAgreeNonConform: 0,
+  doneNewReviewable: 0,
+  totalConform: 0,
+  totalNonConform: 0,
+  // BaseReviewProgress
+  totalActive: 0,
+  totalReviewable: 0,
+  totalPendingReview: 0,
+  totalNewReviewable: 0,
 }
 
-const generateSectionConsolidationProgress = (section: SectionState) => {
-  section.consolidationProgress = getConsolidationProgress(Object.values(section.pages))
+const generateConsolidatorResponsesProgress = (newStructure: FullStructure) => {
+  newStructure?.sortedPages?.forEach((page) =>
+    generatePageConsolidationProgress(page, newStructure.assignment?.assignedSections as string[])
+  )
+  newStructure?.sortedSections?.forEach((section) =>
+    generateSectionConsolidationProgress(
+      section,
+      newStructure.assignment?.assignedSections as string[]
+    )
+  )
+}
+
+const generateSectionConsolidationProgress = (
+  section: SectionState,
+  assignedSections: string[]
+) => {
+  section.consolidationProgress = assignedSections.includes(section.details.code)
+    ? getConsolidationProgress(Object.values(section.pages))
+    : initial
 }
 
 const conformOriginal = (element: PageElement) =>
@@ -23,72 +52,58 @@ const reviewLowerLevelUpdates = (element: PageElement) => element.isNewReviewRes
 const reviewedLowerLevelUpdates = (element: PageElement) =>
   element.thisReviewLatestResponse?.decision
 
-const generatePageConsolidationProgress = (page: Page) => {
-  const totalReviewable = page.state.filter(
-    ({ isAssigned, thisReviewLatestResponse, element }) =>
-      (isAssigned || !!thisReviewLatestResponse) && element.isVisible
-  )
+const generatePageConsolidationProgress = (page: Page, assignedSections: string[]) => {
+  if (assignedSections.includes(page.sectionCode)) page.consolidationProgress = initial
+  else {
+    const totalReviewable = page.state.filter(
+      ({ isAssigned, thisReviewLatestResponse, element }) =>
+        (isAssigned || !!thisReviewLatestResponse) && element.isVisible
+    )
 
-  const totalActive = totalReviewable.filter(activeThisReview)
-  const totalNewReviewable = totalReviewable.filter(reviewLowerLevelUpdates)
+    const totalActive = totalReviewable.filter(activeThisReview)
+    const totalNewReviewable = totalReviewable.filter(reviewLowerLevelUpdates)
 
-  // totalConform of originalReviewResponse
-  const totalConform = totalReviewable.filter(conformOriginal)
-  // totalNonConform of originalReviewResponse
-  const totalNonConform = totalReviewable.filter(nonConformOriginal)
-  // reviews pending - used before starting a new review (also need to check isAssigned)
-  const totalPendingReview = totalReviewable.filter(({ isPendingReview }) => isPendingReview)
+    // totalConform of originalReviewResponse
+    const totalConform = totalReviewable.filter(conformOriginal)
+    // totalNonConform of originalReviewResponse
+    const totalNonConform = totalReviewable.filter(nonConformOriginal)
+    // reviews pending - used before starting a new review (also need to check isAssigned)
+    const totalPendingReview = totalReviewable.filter(({ isPendingReview }) => isPendingReview)
 
-  const totalAgree = totalReviewable.filter(agreeThisReview)
+    const totalAgree = totalReviewable.filter(agreeThisReview)
 
-  const doneDisagree = totalReviewable.filter(disagreeThiReview)
-  const doneAgreeConform = totalAgree.filter(conformOriginal)
-  const doneAgreeNonConform = totalAgree.filter(nonConformOriginal)
+    const doneDisagree = totalReviewable.filter(disagreeThiReview)
+    const doneAgreeConform = totalAgree.filter(conformOriginal)
+    const doneAgreeNonConform = totalAgree.filter(nonConformOriginal)
 
-  const doneActiveDisagree = doneDisagree.filter(activeThisReview)
-  const doneActiveAgreeConform = doneAgreeConform.filter(activeThisReview)
-  const doneActiveAgreeNonConform = doneAgreeNonConform.filter(activeThisReview)
+    const doneActiveDisagree = doneDisagree.filter(activeThisReview)
+    const doneActiveAgreeConform = doneAgreeConform.filter(activeThisReview)
+    const doneActiveAgreeNonConform = doneAgreeNonConform.filter(activeThisReview)
 
-  const doneNewReviewable = totalNewReviewable.filter(reviewedLowerLevelUpdates)
+    const doneNewReviewable = totalNewReviewable.filter(reviewedLowerLevelUpdates)
 
-  page.consolidationProgress = {
-    doneAgreeConform: doneAgreeConform.length,
-    doneAgreeNonConform: doneAgreeNonConform.length,
-    doneDisagree: doneDisagree.length,
-    doneActiveDisagree: doneActiveDisagree.length,
-    doneActiveAgreeConform: doneActiveAgreeConform.length,
-    doneActiveAgreeNonConform: doneActiveAgreeNonConform.length,
-    doneNewReviewable: doneNewReviewable.length,
-    totalConform: totalConform.length,
-    totalNonConform: totalNonConform.length,
-    // BaseReviewProgress
-    totalReviewable: totalReviewable.length,
-    totalPendingReview: totalPendingReview.length,
-    totalActive: totalActive.length,
-    totalNewReviewable: totalNewReviewable.length,
+    page.consolidationProgress = {
+      doneAgreeConform: doneAgreeConform.length,
+      doneAgreeNonConform: doneAgreeNonConform.length,
+      doneDisagree: doneDisagree.length,
+      doneActiveDisagree: doneActiveDisagree.length,
+      doneActiveAgreeConform: doneActiveAgreeConform.length,
+      doneActiveAgreeNonConform: doneActiveAgreeNonConform.length,
+      doneNewReviewable: doneNewReviewable.length,
+      totalConform: totalConform.length,
+      totalNonConform: totalNonConform.length,
+      // BaseReviewProgress
+      totalReviewable: totalReviewable.length,
+      totalPendingReview: totalPendingReview.length,
+      totalActive: totalActive.length,
+      totalNewReviewable: totalNewReviewable.length,
+    }
   }
 }
 
 // Simple helper that will iterate over elements and sum up all of the values for keys
 // returning an object of keys with sums
 export const getConsolidationProgress = (elements: (Page | SectionState)[]) => {
-  const initial: ConsolidationProgress = {
-    doneAgreeConform: 0,
-    doneAgreeNonConform: 0,
-    doneDisagree: 0,
-    doneActiveDisagree: 0,
-    doneActiveAgreeConform: 0,
-    doneActiveAgreeNonConform: 0,
-    doneNewReviewable: 0,
-    totalConform: 0,
-    totalNonConform: 0,
-    // BaseReviewProgress
-    totalActive: 0,
-    totalReviewable: 0,
-    totalPendingReview: 0,
-    totalNewReviewable: 0,
-  }
-
   return elements.reduce((sum, page) => {
     const {
       doneAgreeConform,

--- a/src/utils/helpers/structure/generateConsolidatorResponsesProgress.ts
+++ b/src/utils/helpers/structure/generateConsolidatorResponsesProgress.ts
@@ -53,7 +53,7 @@ const reviewedLowerLevelUpdates = (element: PageElement) =>
   element.thisReviewLatestResponse?.decision
 
 const generatePageConsolidationProgress = (page: Page, assignedSections: string[]) => {
-  if (assignedSections.includes(page.sectionCode)) page.consolidationProgress = initial
+  if (!assignedSections.includes(page.sectionCode)) page.consolidationProgress = initial
   else {
     const totalReviewable = page.state.filter(
       ({ isAssigned, thisReviewLatestResponse, element }) =>

--- a/src/utils/helpers/structure/generateConsolidatorResponsesProgress.ts
+++ b/src/utils/helpers/structure/generateConsolidatorResponsesProgress.ts
@@ -1,42 +1,13 @@
 import { ReviewResponseDecision } from '../../generated/graphql'
 import { FullStructure, SectionState, Page, PageElement, ConsolidationProgress } from '../../types'
 
-const initial: ConsolidationProgress = {
-  doneAgreeConform: 0,
-  doneAgreeNonConform: 0,
-  doneDisagree: 0,
-  doneActiveDisagree: 0,
-  doneActiveAgreeConform: 0,
-  doneActiveAgreeNonConform: 0,
-  doneNewReviewable: 0,
-  totalConform: 0,
-  totalNonConform: 0,
-  // BaseReviewProgress
-  totalActive: 0,
-  totalReviewable: 0,
-  totalPendingReview: 0,
-  totalNewReviewable: 0,
-}
-
 const generateConsolidatorResponsesProgress = (newStructure: FullStructure) => {
-  newStructure?.sortedPages?.forEach((page) =>
-    generatePageConsolidationProgress(page, newStructure.assignment?.assignedSections as string[])
-  )
-  newStructure?.sortedSections?.forEach((section) =>
-    generateSectionConsolidationProgress(
-      section,
-      newStructure.assignment?.assignedSections as string[]
-    )
-  )
+  newStructure?.sortedPages?.forEach(generatePageConsolidationProgress)
+  newStructure?.sortedSections?.forEach(generateSectionConsolidationProgress)
 }
 
-const generateSectionConsolidationProgress = (
-  section: SectionState,
-  assignedSections: string[]
-) => {
-  section.consolidationProgress = assignedSections.includes(section.details.code)
-    ? getConsolidationProgress(Object.values(section.pages))
-    : initial
+const generateSectionConsolidationProgress = (section: SectionState) => {
+  section.consolidationProgress = getConsolidationProgress(Object.values(section.pages))
 }
 
 const conformOriginal = (element: PageElement) =>
@@ -52,58 +23,72 @@ const reviewLowerLevelUpdates = (element: PageElement) => element.isNewReviewRes
 const reviewedLowerLevelUpdates = (element: PageElement) =>
   element.thisReviewLatestResponse?.decision
 
-const generatePageConsolidationProgress = (page: Page, assignedSections: string[]) => {
-  if (assignedSections.includes(page.sectionCode)) page.consolidationProgress = initial
-  else {
-    const totalReviewable = page.state.filter(
-      ({ isAssigned, thisReviewLatestResponse, element }) =>
-        (isAssigned || !!thisReviewLatestResponse) && element.isVisible
-    )
+const generatePageConsolidationProgress = (page: Page) => {
+  const totalReviewable = page.state.filter(
+    ({ isAssigned, thisReviewLatestResponse, element }) =>
+      (isAssigned || !!thisReviewLatestResponse) && element.isVisible
+  )
 
-    const totalActive = totalReviewable.filter(activeThisReview)
-    const totalNewReviewable = totalReviewable.filter(reviewLowerLevelUpdates)
+  const totalActive = totalReviewable.filter(activeThisReview)
+  const totalNewReviewable = totalReviewable.filter(reviewLowerLevelUpdates)
 
-    // totalConform of originalReviewResponse
-    const totalConform = totalReviewable.filter(conformOriginal)
-    // totalNonConform of originalReviewResponse
-    const totalNonConform = totalReviewable.filter(nonConformOriginal)
-    // reviews pending - used before starting a new review (also need to check isAssigned)
-    const totalPendingReview = totalReviewable.filter(({ isPendingReview }) => isPendingReview)
+  // totalConform of originalReviewResponse
+  const totalConform = totalReviewable.filter(conformOriginal)
+  // totalNonConform of originalReviewResponse
+  const totalNonConform = totalReviewable.filter(nonConformOriginal)
+  // reviews pending - used before starting a new review (also need to check isAssigned)
+  const totalPendingReview = totalReviewable.filter(({ isPendingReview }) => isPendingReview)
 
-    const totalAgree = totalReviewable.filter(agreeThisReview)
+  const totalAgree = totalReviewable.filter(agreeThisReview)
 
-    const doneDisagree = totalReviewable.filter(disagreeThiReview)
-    const doneAgreeConform = totalAgree.filter(conformOriginal)
-    const doneAgreeNonConform = totalAgree.filter(nonConformOriginal)
+  const doneDisagree = totalReviewable.filter(disagreeThiReview)
+  const doneAgreeConform = totalAgree.filter(conformOriginal)
+  const doneAgreeNonConform = totalAgree.filter(nonConformOriginal)
 
-    const doneActiveDisagree = doneDisagree.filter(activeThisReview)
-    const doneActiveAgreeConform = doneAgreeConform.filter(activeThisReview)
-    const doneActiveAgreeNonConform = doneAgreeNonConform.filter(activeThisReview)
+  const doneActiveDisagree = doneDisagree.filter(activeThisReview)
+  const doneActiveAgreeConform = doneAgreeConform.filter(activeThisReview)
+  const doneActiveAgreeNonConform = doneAgreeNonConform.filter(activeThisReview)
 
-    const doneNewReviewable = totalNewReviewable.filter(reviewedLowerLevelUpdates)
+  const doneNewReviewable = totalNewReviewable.filter(reviewedLowerLevelUpdates)
 
-    page.consolidationProgress = {
-      doneAgreeConform: doneAgreeConform.length,
-      doneAgreeNonConform: doneAgreeNonConform.length,
-      doneDisagree: doneDisagree.length,
-      doneActiveDisagree: doneActiveDisagree.length,
-      doneActiveAgreeConform: doneActiveAgreeConform.length,
-      doneActiveAgreeNonConform: doneActiveAgreeNonConform.length,
-      doneNewReviewable: doneNewReviewable.length,
-      totalConform: totalConform.length,
-      totalNonConform: totalNonConform.length,
-      // BaseReviewProgress
-      totalReviewable: totalReviewable.length,
-      totalPendingReview: totalPendingReview.length,
-      totalActive: totalActive.length,
-      totalNewReviewable: totalNewReviewable.length,
-    }
+  page.consolidationProgress = {
+    doneAgreeConform: doneAgreeConform.length,
+    doneAgreeNonConform: doneAgreeNonConform.length,
+    doneDisagree: doneDisagree.length,
+    doneActiveDisagree: doneActiveDisagree.length,
+    doneActiveAgreeConform: doneActiveAgreeConform.length,
+    doneActiveAgreeNonConform: doneActiveAgreeNonConform.length,
+    doneNewReviewable: doneNewReviewable.length,
+    totalConform: totalConform.length,
+    totalNonConform: totalNonConform.length,
+    // BaseReviewProgress
+    totalReviewable: totalReviewable.length,
+    totalPendingReview: totalPendingReview.length,
+    totalActive: totalActive.length,
+    totalNewReviewable: totalNewReviewable.length,
   }
 }
 
 // Simple helper that will iterate over elements and sum up all of the values for keys
 // returning an object of keys with sums
 export const getConsolidationProgress = (elements: (Page | SectionState)[]) => {
+  const initial: ConsolidationProgress = {
+    doneAgreeConform: 0,
+    doneAgreeNonConform: 0,
+    doneDisagree: 0,
+    doneActiveDisagree: 0,
+    doneActiveAgreeConform: 0,
+    doneActiveAgreeNonConform: 0,
+    doneNewReviewable: 0,
+    totalConform: 0,
+    totalNonConform: 0,
+    // BaseReviewProgress
+    totalActive: 0,
+    totalReviewable: 0,
+    totalPendingReview: 0,
+    totalNewReviewable: 0,
+  }
+
   return elements.reduce((sum, page) => {
     const {
       doneAgreeConform,

--- a/src/utils/helpers/structure/generateReviewerResponsesProgress.ts
+++ b/src/utils/helpers/structure/generateReviewerResponsesProgress.ts
@@ -2,58 +2,78 @@ import { ReviewResponseDecision } from '../../generated/graphql'
 
 import { FullStructure, SectionState, Page, ReviewProgress } from '../../types'
 
+const initial: ReviewProgress = {
+  doneConform: 0,
+  doneNonConform: 0,
+  doneNewReviewable: 0,
+  // BaseReviewProgress
+  totalActive: 0,
+  totalReviewable: 0,
+  totalPendingReview: 0,
+  totalNewReviewable: 0,
+}
+
 const generateReviewerResponsesProgress = (newStructure: FullStructure) => {
-  newStructure?.sortedPages?.forEach(generatePageReviewProgress)
-  newStructure?.sortedSections?.forEach(generateSectionReviewProgress)
+  newStructure?.sortedPages?.forEach((page) =>
+    generatePageReviewProgress(page, newStructure.assignment?.assignedSections as string[])
+  )
+  newStructure?.sortedSections?.forEach((section) =>
+    generateSectionReviewProgress(section, newStructure.assignment?.assignedSections as string[])
+  )
 }
 
-const generateSectionReviewProgress = (section: SectionState) => {
-  section.reviewProgress = getReviewProgress(Object.values(section.pages))
+const generateSectionReviewProgress = (section: SectionState, assignedSections: string[]) => {
+  section.reviewProgress = assignedSections.includes(section.details.code)
+    ? getReviewProgress(Object.values(section.pages))
+    : initial
 }
 
-const generatePageReviewProgress = (page: Page) => {
-  const totalReviewable = page.state.filter(
-    ({
-      isAssigned,
-      thisReviewLatestResponse,
-      latestOriginalReviewResponse,
-      latestApplicationResponse,
-      element,
-    }) =>
-      (isAssigned || !!thisReviewLatestResponse || !!latestOriginalReviewResponse) &&
-      element.isVisible &&
-      latestApplicationResponse?.id
-  )
+const generatePageReviewProgress = (page: Page, assignedSections: string[]) => {
+  if (!assignedSections.includes(page.sectionCode)) page.reviewProgress = initial
+  else {
+    const totalReviewable = page.state.filter(
+      ({
+        isAssigned,
+        thisReviewLatestResponse,
+        latestOriginalReviewResponse,
+        latestApplicationResponse,
+        element,
+      }) =>
+        (isAssigned || !!thisReviewLatestResponse || !!latestOriginalReviewResponse) &&
+        element.isVisible &&
+        latestApplicationResponse?.id
+    )
 
-  // Only consider review responses that are linked to latest application response
-  // or if part of changes requested if they have already been changed
-  const totalReviewableLinkedToLatestApplicationResponse = totalReviewable.filter(
-    ({ isPendingReview, isChangeRequest, isChanged }) =>
-      !isPendingReview && (!isChangeRequest || isChanged)
-  )
+    // Only consider review responses that are linked to latest application response
+    // or if part of changes requested if they have already been changed
+    const totalReviewableLinkedToLatestApplicationResponse = totalReviewable.filter(
+      ({ isPendingReview, isChangeRequest, isChanged }) =>
+        !isPendingReview && (!isChangeRequest || isChanged)
+    )
 
-  const doneConform = totalReviewableLinkedToLatestApplicationResponse.filter(
-    (element) => element.thisReviewLatestResponse?.decision === ReviewResponseDecision.Approve
-  )
-  const doneNonConform = totalReviewableLinkedToLatestApplicationResponse.filter(
-    (element) => element.thisReviewLatestResponse?.decision === ReviewResponseDecision.Decline
-  )
-  const totalNewReviewable = totalReviewable.filter((element) => element.isNewApplicationResponse)
-  const doneNewReviewable = totalNewReviewable.filter(
-    (element) => !element.isPendingReview && element.thisReviewLatestResponse?.decision
-  )
+    const doneConform = totalReviewableLinkedToLatestApplicationResponse.filter(
+      (element) => element.thisReviewLatestResponse?.decision === ReviewResponseDecision.Approve
+    )
+    const doneNonConform = totalReviewableLinkedToLatestApplicationResponse.filter(
+      (element) => element.thisReviewLatestResponse?.decision === ReviewResponseDecision.Decline
+    )
+    const totalNewReviewable = totalReviewable.filter((element) => element.isNewApplicationResponse)
+    const doneNewReviewable = totalNewReviewable.filter(
+      (element) => !element.isPendingReview && element.thisReviewLatestResponse?.decision
+    )
 
-  const totalPendingReview = totalReviewable.filter(({ isPendingReview }) => isPendingReview)
+    const totalPendingReview = totalReviewable.filter(({ isPendingReview }) => isPendingReview)
 
-  page.reviewProgress = {
-    doneConform: doneConform.length,
-    doneNonConform: doneNonConform.length,
-    doneNewReviewable: doneNewReviewable.length,
-    // BaseReviewProgress
-    totalReviewable: totalReviewable.length,
-    totalActive: totalReviewable.length,
-    totalPendingReview: totalPendingReview.length,
-    totalNewReviewable: totalNewReviewable.length,
+    page.reviewProgress = {
+      doneConform: doneConform.length,
+      doneNonConform: doneNonConform.length,
+      doneNewReviewable: doneNewReviewable.length,
+      // BaseReviewProgress
+      totalReviewable: totalReviewable.length,
+      totalActive: totalReviewable.length,
+      totalPendingReview: totalPendingReview.length,
+      totalNewReviewable: totalNewReviewable.length,
+    }
   }
 }
 
@@ -64,17 +84,6 @@ const generatePageReviewProgress = (page: Page) => {
  * @returns ReviewProgress of return sum of progresses
  */
 export const getReviewProgress = (elements: (Page | SectionState)[]) => {
-  const initial: ReviewProgress = {
-    doneConform: 0,
-    doneNonConform: 0,
-    doneNewReviewable: 0,
-    // BaseReviewProgress
-    totalActive: 0,
-    totalReviewable: 0,
-    totalPendingReview: 0,
-    totalNewReviewable: 0,
-  }
-
   return elements.reduce((sum, page) => {
     const {
       doneConform,

--- a/src/utils/helpers/structure/generateReviewerResponsesProgress.ts
+++ b/src/utils/helpers/structure/generateReviewerResponsesProgress.ts
@@ -2,78 +2,58 @@ import { ReviewResponseDecision } from '../../generated/graphql'
 
 import { FullStructure, SectionState, Page, ReviewProgress } from '../../types'
 
-const initial: ReviewProgress = {
-  doneConform: 0,
-  doneNonConform: 0,
-  doneNewReviewable: 0,
-  // BaseReviewProgress
-  totalActive: 0,
-  totalReviewable: 0,
-  totalPendingReview: 0,
-  totalNewReviewable: 0,
-}
-
 const generateReviewerResponsesProgress = (newStructure: FullStructure) => {
-  newStructure?.sortedPages?.forEach((page) =>
-    generatePageReviewProgress(page, newStructure.assignment?.assignedSections as string[])
-  )
-  newStructure?.sortedSections?.forEach((section) =>
-    generateSectionReviewProgress(section, newStructure.assignment?.assignedSections as string[])
-  )
+  newStructure?.sortedPages?.forEach(generatePageReviewProgress)
+  newStructure?.sortedSections?.forEach(generateSectionReviewProgress)
 }
 
-const generateSectionReviewProgress = (section: SectionState, assignedSections: string[]) => {
-  section.reviewProgress = assignedSections.includes(section.details.code)
-    ? getReviewProgress(Object.values(section.pages))
-    : initial
+const generateSectionReviewProgress = (section: SectionState) => {
+  section.reviewProgress = getReviewProgress(Object.values(section.pages))
 }
 
-const generatePageReviewProgress = (page: Page, assignedSections: string[]) => {
-  if (!assignedSections.includes(page.sectionCode)) page.reviewProgress = initial
-  else {
-    const totalReviewable = page.state.filter(
-      ({
-        isAssigned,
-        thisReviewLatestResponse,
-        latestOriginalReviewResponse,
-        latestApplicationResponse,
-        element,
-      }) =>
-        (isAssigned || !!thisReviewLatestResponse || !!latestOriginalReviewResponse) &&
-        element.isVisible &&
-        latestApplicationResponse?.id
-    )
+const generatePageReviewProgress = (page: Page) => {
+  const totalReviewable = page.state.filter(
+    ({
+      isAssigned,
+      thisReviewLatestResponse,
+      latestOriginalReviewResponse,
+      latestApplicationResponse,
+      element,
+    }) =>
+      (isAssigned || !!thisReviewLatestResponse || !!latestOriginalReviewResponse) &&
+      element.isVisible &&
+      latestApplicationResponse?.id
+  )
 
-    // Only consider review responses that are linked to latest application response
-    // or if part of changes requested if they have already been changed
-    const totalReviewableLinkedToLatestApplicationResponse = totalReviewable.filter(
-      ({ isPendingReview, isChangeRequest, isChanged }) =>
-        !isPendingReview && (!isChangeRequest || isChanged)
-    )
+  // Only consider review responses that are linked to latest application response
+  // or if part of changes requested if they have already been changed
+  const totalReviewableLinkedToLatestApplicationResponse = totalReviewable.filter(
+    ({ isPendingReview, isChangeRequest, isChanged }) =>
+      !isPendingReview && (!isChangeRequest || isChanged)
+  )
 
-    const doneConform = totalReviewableLinkedToLatestApplicationResponse.filter(
-      (element) => element.thisReviewLatestResponse?.decision === ReviewResponseDecision.Approve
-    )
-    const doneNonConform = totalReviewableLinkedToLatestApplicationResponse.filter(
-      (element) => element.thisReviewLatestResponse?.decision === ReviewResponseDecision.Decline
-    )
-    const totalNewReviewable = totalReviewable.filter((element) => element.isNewApplicationResponse)
-    const doneNewReviewable = totalNewReviewable.filter(
-      (element) => !element.isPendingReview && element.thisReviewLatestResponse?.decision
-    )
+  const doneConform = totalReviewableLinkedToLatestApplicationResponse.filter(
+    (element) => element.thisReviewLatestResponse?.decision === ReviewResponseDecision.Approve
+  )
+  const doneNonConform = totalReviewableLinkedToLatestApplicationResponse.filter(
+    (element) => element.thisReviewLatestResponse?.decision === ReviewResponseDecision.Decline
+  )
+  const totalNewReviewable = totalReviewable.filter((element) => element.isNewApplicationResponse)
+  const doneNewReviewable = totalNewReviewable.filter(
+    (element) => !element.isPendingReview && element.thisReviewLatestResponse?.decision
+  )
 
-    const totalPendingReview = totalReviewable.filter(({ isPendingReview }) => isPendingReview)
+  const totalPendingReview = totalReviewable.filter(({ isPendingReview }) => isPendingReview)
 
-    page.reviewProgress = {
-      doneConform: doneConform.length,
-      doneNonConform: doneNonConform.length,
-      doneNewReviewable: doneNewReviewable.length,
-      // BaseReviewProgress
-      totalReviewable: totalReviewable.length,
-      totalActive: totalReviewable.length,
-      totalPendingReview: totalPendingReview.length,
-      totalNewReviewable: totalNewReviewable.length,
-    }
+  page.reviewProgress = {
+    doneConform: doneConform.length,
+    doneNonConform: doneNonConform.length,
+    doneNewReviewable: doneNewReviewable.length,
+    // BaseReviewProgress
+    totalReviewable: totalReviewable.length,
+    totalActive: totalReviewable.length,
+    totalPendingReview: totalPendingReview.length,
+    totalNewReviewable: totalNewReviewable.length,
   }
 }
 
@@ -84,6 +64,17 @@ const generatePageReviewProgress = (page: Page, assignedSections: string[]) => {
  * @returns ReviewProgress of return sum of progresses
  */
 export const getReviewProgress = (elements: (Page | SectionState)[]) => {
+  const initial: ReviewProgress = {
+    doneConform: 0,
+    doneNonConform: 0,
+    doneNewReviewable: 0,
+    // BaseReviewProgress
+    totalActive: 0,
+    totalReviewable: 0,
+    totalPendingReview: 0,
+    totalNewReviewable: 0,
+  }
+
   return elements.reduce((sum, page) => {
     const {
       doneConform,

--- a/src/utils/hooks/useRemakePreviousReview.ts
+++ b/src/utils/hooks/useRemakePreviousReview.ts
@@ -14,6 +14,7 @@ type PromiseReturnType = ReturnType<UseRemakePreviousReviewMutationReturnType[0]
 // hook used to restart a review, , as per type definition below (returns promise that resolve with mutation result data)
 type UseRemakePreviousReview = (props: {
   reviewStructure: FullStructure
+  reviewAssignment: AssignmentDetails
   previousAssignment: AssignmentDetails
 }) => () => PromiseReturnType
 
@@ -22,13 +23,14 @@ type ConstructReviewPatch = (structure: FullStructure) => ReviewPatch
 // Need to duplicate or create new review responses for all assigned questions
 const useRemakePreviousReview: UseRemakePreviousReview = ({
   reviewStructure,
+  reviewAssignment,
   previousAssignment,
 }) => {
   const [createReview] = useCreateReviewMutation()
-  const { assignmentId: reviewAssignmentId } = reviewStructure.assignment as ReviewAssignment
 
   const getFullReviewStructureAsync = useGetFullReviewStructureAsync({
     reviewStructure,
+    reviewAssignment,
     previousAssignment,
   })
 
@@ -80,7 +82,7 @@ const useRemakePreviousReview: UseRemakePreviousReview = ({
       reviewResponsesUsingId: {
         create: reviewResponseCreate,
       },
-      reviewAssignmentId,
+      reviewAssignmentId: reviewAssignment.id,
       // create new empty decision (do we need to duplicate comment from latest decision ?)
       reviewDecisionsUsingId: {
         create: [{ decision: Decision.NoDecision }],

--- a/src/utils/hooks/useRestartReview.ts
+++ b/src/utils/hooks/useRestartReview.ts
@@ -26,6 +26,7 @@ const useRestartReview: UseRestartReview = ({ reviewStructure, reviewAssignment 
 
   const getFullReviewStructureAsync = useGetFullReviewStructureAsync({
     reviewStructure,
+    reviewAssignment,
   })
 
   const shouldCreateConsolidationReviewResponse = (element: PageElement) => {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -392,6 +392,7 @@ interface ReviewAssignment {
 
 type ReviewSectionComponentProps = {
   reviewStructure: FullStructure
+  reviewAssignment: AssignmentDetails
   section: SectionState
   previousAssignment: AssignmentDetails
   action: ReviewAction


### PR DESCRIPTION
Fixes #1110 and some bugs introduced during #1115 refactor.

### Fixes:
- Stop showing the option to re-assign for already submtited reviews
- Fix ReviewPage not rendering
- Fix assigned consolidator to be showing in all sections
- Fix start button stopped working 😬 
- Fix start button not showing for reviewer
- Fix start button not showing for consolidator

### Still needs fixing:
~~- Start button not creating the review~~
- Requires a full refresh on the page after swapping users - we should check if still required
- When there is a partial review done, login as the other review (that hasn't started) will show the other sections as **Not Assigned** and the option to assign (if they have permission). This is not a huge one and I'm happy to add as a new issue.

UPDATED: 18/02 -- This PR should be fixing many bugs that were introduced in `develop` and would be good to merge asap. Therefor other problems (less critical) found should be added to separated issues to be solved next.
