### PR TITLE
Urgent Fix -- missing responses on review pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "application-manager-web-app",
-  "version": "0.2.0-0",
+  "version": "0.2.0-1",
   "main": "index.tsx",
   "license": "MIT",
   "repository": {

--- a/src/containers/Review/ReviewWrapper.tsx
+++ b/src/containers/Review/ReviewWrapper.tsx
@@ -116,7 +116,7 @@ const ReviewWrapper: React.FC<ReviewWrapperProps> = ({ structure }) => {
           </div>
         </Route>
         <Route exact path={`${path}/:reviewId`}>
-          <ReviewPageWrapper {...{ structure }} />
+          <ReviewPageWrapper {...{ structure: fullStructure }} />
         </Route>
         <Route>
           <NoMatch />


### PR DESCRIPTION
Oops -- can't believe we didn't notice this regression for so long. Looks like it slipped in when I was building the Tab structure. Send the smaller structure instead of fullStructure into the ReviewWrapper.

Luckily Adam picked it up this afternoon before tomorrow's demo:
![photo_2022-02-23 19 57 06](https://user-images.githubusercontent.com/5456533/155273728-d421f779-4961-45c6-876a-2991719d9b1b.jpeg)

Fortunately a really small fix.

@nmadruga I will do a new build tonight using this branch and update the demo. So you can review this PR in your own good time in case there's any other related things that I might have missed.

