### PR TITLE
UI change for evaluator fallback parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.1.4",
-    "@openmsupply/expression-evaluator": "^1.10.0",
+    "@openmsupply/expression-evaluator": "^1.11.1",
     "@types/pluralize": "^0.0.29",
     "apollo3-cache-persist": "^0.8.0",
     "axios": "^0.21.1",

--- a/src/containers/TemplateBuilder/evaluatorGui/EvaluationFallback.tsx
+++ b/src/containers/TemplateBuilder/evaluatorGui/EvaluationFallback.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react'
+import CheckboxIO from '../shared/CheckboxIO'
+import TextIO from '../shared/TextIO'
+import { renderArrayControl } from './guiCommon'
+
+import ComponentLibrary from './semanticComponentLibrary'
+import { EvaluationType } from './types'
+
+const DEFAULT_TYPE = 'string'
+
+const types = ['string', 'array', 'number', 'boolean', 'null', 'object']
+
+type EvaluationOutputTypeProps = {
+  evaluation: EvaluationType
+  setEvaluation: (evaluation: EvaluationType) => void
+}
+
+const EvaluationFallback: React.FC<EvaluationOutputTypeProps> = ({ evaluation, setEvaluation }) => {
+  const { fallback } = evaluation.asOperator
+
+  const [fallbackEnabled, setFallbackEnabled] = useState(!!fallback)
+  const [fallbackType, setFallbackType] = useState(getType(fallback))
+  if (evaluation.type !== 'operator') return null
+
+  const setFallback = (fallbackValue?: any) => {
+    setEvaluation({
+      ...evaluation,
+      asOperator: { ...evaluation.asOperator, fallback: fallbackValue },
+    })
+  }
+
+  const changeFallbackType = (typeValue: any) => {
+    if (typeValue === 'string') setFallback('')
+    if (typeValue === 'number') setFallback(1)
+    if (typeValue === 'boolean') setFallback(true)
+    if (typeValue === 'array') setFallback(['text'])
+    if (typeValue === 'object') setFallback({ key: 'value' })
+    if (typeValue === 'null') setFallback(null)
+    setFallbackType(typeValue)
+  }
+
+  const componentFromTypeMap: { [key: string]: any } = {
+    string: <TextIO minLabelWidth={108} text={fallback} setText={setFallback} />,
+    boolean: <CheckboxIO title="" value={!!fallback} setValue={setFallback} />,
+    number: <ComponentLibrary.NumberInput number={fallback} setNumber={setFallback} />,
+    array: <ComponentLibrary.ObjectInput object={fallback} setObject={setFallback} />,
+    object: <ComponentLibrary.ObjectInput object={fallback} setObject={setFallback} />,
+    null: null,
+  }
+
+  return (
+    <ComponentLibrary.FlexRow>
+      <ComponentLibrary.Checkbox
+        title="Enable Fallback"
+        checked={!!fallback}
+        setChecked={() => setFallbackEnabled(!fallbackEnabled)}
+        minLabelWidth={110}
+      />
+      {fallbackEnabled && (
+        <>
+          <ComponentLibrary.Selector
+            title="Type"
+            selections={types}
+            selected={'string'}
+            setSelected={changeFallbackType}
+          />
+          {fallbackType in componentFromTypeMap ? (
+            componentFromTypeMap?.[fallbackType]
+          ) : (
+            <p>Not implemented</p>
+          )}
+        </>
+      )}
+    </ComponentLibrary.FlexRow>
+  )
+}
+
+export default EvaluationFallback
+
+const getType = (value: any) => {
+  if (value === null) return 'null'
+  if (typeof value === 'string') return 'string'
+  if (typeof value === 'number') return 'number'
+  if (typeof value === 'boolean') return 'boolean'
+  if (Array.isArray(value)) return 'array'
+  if (typeof value == 'object') return 'object'
+  return 'string'
+}

--- a/src/containers/TemplateBuilder/evaluatorGui/EvaluationFallback.tsx
+++ b/src/containers/TemplateBuilder/evaluatorGui/EvaluationFallback.tsx
@@ -1,14 +1,8 @@
 import React, { useState } from 'react'
-import CheckboxIO from '../shared/CheckboxIO'
-import TextIO from '../shared/TextIO'
-import { renderArrayControl } from './guiCommon'
+import Evaluation from '../shared/Evaluation'
 
 import ComponentLibrary from './semanticComponentLibrary'
 import { EvaluationType } from './types'
-
-const DEFAULT_TYPE = 'string'
-
-const types = ['string', 'array', 'number', 'boolean', 'null', 'object']
 
 type EvaluationOutputTypeProps = {
   evaluation: EvaluationType
@@ -19,7 +13,6 @@ const EvaluationFallback: React.FC<EvaluationOutputTypeProps> = ({ evaluation, s
   const { fallback } = evaluation.asOperator
 
   const [fallbackEnabled, setFallbackEnabled] = useState(!!fallback)
-  const [fallbackType, setFallbackType] = useState(getType(fallback))
   if (evaluation.type !== 'operator') return null
 
   const setFallback = (fallbackValue?: any) => {
@@ -29,27 +22,8 @@ const EvaluationFallback: React.FC<EvaluationOutputTypeProps> = ({ evaluation, s
     })
   }
 
-  const changeFallbackType = (typeValue: any) => {
-    if (typeValue === 'string') setFallback('')
-    if (typeValue === 'number') setFallback(1)
-    if (typeValue === 'boolean') setFallback(true)
-    if (typeValue === 'array') setFallback(['text'])
-    if (typeValue === 'object') setFallback({ key: 'value' })
-    if (typeValue === 'null') setFallback(null)
-    setFallbackType(typeValue)
-  }
-
-  const componentFromTypeMap: { [key: string]: any } = {
-    string: <TextIO minLabelWidth={108} text={fallback} setText={setFallback} />,
-    boolean: <CheckboxIO title="" value={!!fallback} setValue={setFallback} />,
-    number: <ComponentLibrary.NumberInput number={fallback} setNumber={setFallback} />,
-    array: <ComponentLibrary.ObjectInput object={fallback} setObject={setFallback} />,
-    object: <ComponentLibrary.ObjectInput object={fallback} setObject={setFallback} />,
-    null: null,
-  }
-
   return (
-    <ComponentLibrary.FlexRow>
+    <div className="flex-row-start-center">
       <ComponentLibrary.Checkbox
         title="Enable Fallback"
         checked={!!fallback}
@@ -58,31 +32,17 @@ const EvaluationFallback: React.FC<EvaluationOutputTypeProps> = ({ evaluation, s
       />
       {fallbackEnabled && (
         <>
-          <ComponentLibrary.Selector
-            title="Type"
-            selections={types}
-            selected={'string'}
-            setSelected={changeFallbackType}
+          <Evaluation
+            setEvaluation={(value: any) => setFallback(value)}
+            key={'Fallback'}
+            evaluation={fallback}
+            currentElementCode={''}
+            label={''}
           />
-          {fallbackType in componentFromTypeMap ? (
-            componentFromTypeMap?.[fallbackType]
-          ) : (
-            <p>Not implemented</p>
-          )}
         </>
       )}
-    </ComponentLibrary.FlexRow>
+    </div>
   )
 }
 
 export default EvaluationFallback
-
-const getType = (value: any) => {
-  if (value === null) return 'null'
-  if (typeof value === 'string') return 'string'
-  if (typeof value === 'number') return 'number'
-  if (typeof value === 'boolean') return 'boolean'
-  if (Array.isArray(value)) return 'array'
-  if (typeof value == 'object') return 'object'
-  return 'string'
-}

--- a/src/containers/TemplateBuilder/evaluatorGui/EvaluationOutputType.tsx
+++ b/src/containers/TemplateBuilder/evaluatorGui/EvaluationOutputType.tsx
@@ -32,6 +32,7 @@ const EvaluationOutputType: React.FC<EvaluationOutputTypeProps> = ({
         title="Specify Type"
         checked={!!type}
         setChecked={() => setType(!type ? DEFAULT_TYPE : undefined)}
+        minLabelWidth={110}
       />
       {type && (
         <ComponentLibrary.Selector

--- a/src/containers/TemplateBuilder/evaluatorGui/guiDefinitions.tsx
+++ b/src/containers/TemplateBuilder/evaluatorGui/guiDefinitions.tsx
@@ -14,7 +14,7 @@ import { GuisType } from './types'
 export const guis: GuisType = [
   {
     selector: 'string',
-    default: getTypedEvaluation('Default string'),
+    default: getTypedEvaluation(''),
     match: (typedEvaluation) => typedEvaluation.type === 'string',
     render: (evaluation, setEvaluation, ComponentLibrary) => (
       <ComponentLibrary.TextInput

--- a/src/containers/TemplateBuilder/evaluatorGui/renderEvaluation.tsx
+++ b/src/containers/TemplateBuilder/evaluatorGui/renderEvaluation.tsx
@@ -12,6 +12,7 @@ import {
 } from './typeHelpers'
 import { EvaluationType, ParseAndRenderEvaluationType, RenderEvaluationElementType } from './types'
 import EvaluationOutputType from './EvaluationOutputType'
+import EvaluationFallback from './EvaluationFallback'
 
 export const renderEvaluation: ParseAndRenderEvaluationType = (
   evaluation,
@@ -25,55 +26,55 @@ export const renderEvaluation: ParseAndRenderEvaluationType = (
   return renderEvaluationElement(evaluation, _setEvaluation, ComponentLibrary, evaluatorParameters)
 }
 
-const Evaluate: React.FC<{ typedEvaluation: EvaluationType; evaluatorParameters?: IParameters }> =
-  ({ typedEvaluation, evaluatorParameters }) => {
-    const [evaluationResult, setEvaluationResult] = useState<ValueNode | undefined | null>(
-      undefined
-    )
+const Evaluate: React.FC<{
+  typedEvaluation: EvaluationType
+  evaluatorParameters?: IParameters
+}> = ({ typedEvaluation, evaluatorParameters }) => {
+  const [evaluationResult, setEvaluationResult] = useState<ValueNode | undefined | null>(undefined)
 
-    const evaluateNode = async () => {
-      try {
-        const result = await evaluateExpression(
-          convertTypedEvaluationToBaseType(typedEvaluation),
-          evaluatorParameters
-        )
-        setEvaluationResult(result)
-      } catch (e) {
-        setEvaluationResult('Problem Executing Evaluation')
-      }
+  const evaluateNode = async () => {
+    try {
+      const result = await evaluateExpression(
+        convertTypedEvaluationToBaseType(typedEvaluation),
+        evaluatorParameters
+      )
+      setEvaluationResult(result)
+    } catch (e) {
+      setEvaluationResult('Problem Executing Evaluation')
     }
-
-    return (
-      <>
-        <Icon
-          className="clickable"
-          name="play"
-          size="large"
-          onClick={() => evaluateNode()}
-          style={{ marginBottom: 8 }}
-        />
-        <Modal
-          className="config-modal"
-          open={evaluationResult !== undefined}
-          onClose={() => setEvaluationResult(undefined)}
-        >
-          <div className="config-modal-container ">
-            <Header>Evaluation Result</Header>
-            {evaluationResult === undefined && <Loading />}
-            {evaluationResult !== undefined && (
-              <pre>{JSON.stringify(evaluationResult, null, ' ')}</pre>
-            )}
-            {typeof evaluationResult === 'string' && (
-              <>
-                <Header as="h4">Markdown</Header>
-                <Markdown text={evaluationResult} />
-              </>
-            )}
-          </div>
-        </Modal>
-      </>
-    )
   }
+
+  return (
+    <>
+      <Icon
+        className="clickable"
+        name="play"
+        size="large"
+        onClick={() => evaluateNode()}
+        style={{ marginBottom: 8 }}
+      />
+      <Modal
+        className="config-modal"
+        open={evaluationResult !== undefined}
+        onClose={() => setEvaluationResult(undefined)}
+      >
+        <div className="config-modal-container ">
+          <Header>Evaluation Result</Header>
+          {evaluationResult === undefined && <Loading />}
+          {evaluationResult !== undefined && (
+            <pre>{JSON.stringify(evaluationResult, null, ' ')}</pre>
+          )}
+          {typeof evaluationResult === 'string' && (
+            <>
+              <Header as="h4">Markdown</Header>
+              <Markdown text={evaluationResult} />
+            </>
+          )}
+        </div>
+      </Modal>
+    </>
+  )
+}
 
 export const renderEvaluationElement: RenderEvaluationElementType = (
   evaluation,
@@ -106,6 +107,7 @@ export const renderEvaluationElement: RenderEvaluationElementType = (
                 evaluatorParameters={evaluatorParameters}
               />
             </ComponentLibrary.FlexRow>
+            <EvaluationFallback evaluation={typedEvaluation} setEvaluation={setEvaluation} />
             <EvaluationOutputType evaluation={typedEvaluation} setEvaluation={setEvaluation} />
             {gui.render(typedEvaluation, setEvaluation, ComponentLibrary, evaluatorParameters)}
           </ComponentLibrary.OperatorContainer>

--- a/src/containers/TemplateBuilder/evaluatorGui/renderEvaluation.tsx
+++ b/src/containers/TemplateBuilder/evaluatorGui/renderEvaluation.tsx
@@ -107,8 +107,8 @@ export const renderEvaluationElement: RenderEvaluationElementType = (
                 evaluatorParameters={evaluatorParameters}
               />
             </ComponentLibrary.FlexRow>
-            <EvaluationFallback evaluation={typedEvaluation} setEvaluation={setEvaluation} />
             <EvaluationOutputType evaluation={typedEvaluation} setEvaluation={setEvaluation} />
+            <EvaluationFallback evaluation={typedEvaluation} setEvaluation={setEvaluation} />
             {gui.render(typedEvaluation, setEvaluation, ComponentLibrary, evaluatorParameters)}
           </ComponentLibrary.OperatorContainer>
         </ComponentLibrary.FlexRow>

--- a/src/containers/TemplateBuilder/evaluatorGui/semanticComponentLibrary.tsx
+++ b/src/containers/TemplateBuilder/evaluatorGui/semanticComponentLibrary.tsx
@@ -32,13 +32,14 @@ const ComponentLibrary: ComponentLibraryType = {
 
     return (
       <div className="io-wrapper">
-        <div className="io-component key">{title}</div>
+        {title && <div className="io-component key">{title}</div>}
         <Input
           value={innerValue}
+          // type="number"
           className="io-component value"
           size="small"
           onChange={async (_, { value }) => {
-            if (!value.match(/^[\d]+$/)) return
+            if (!value.match(/^-?[\d]+$/)) return
             setInnerValue(value)
           }}
           onBlur={() => {
@@ -63,8 +64,14 @@ const ComponentLibrary: ComponentLibraryType = {
       options={selections}
     />
   ),
-  Checkbox: ({ checked, setChecked, title = '', disabled = false }) => (
-    <CheckboxIO title={title} value={checked} setValue={setChecked} disabled={disabled} />
+  Checkbox: ({ checked, setChecked, title = '', disabled = false, ...props }) => (
+    <CheckboxIO
+      title={title}
+      value={checked}
+      setValue={setChecked}
+      disabled={disabled}
+      {...props}
+    />
   ),
   Error: ({ error, info }) => (
     <div>

--- a/src/containers/TemplateBuilder/evaluatorGui/semanticComponentLibrary.tsx
+++ b/src/containers/TemplateBuilder/evaluatorGui/semanticComponentLibrary.tsx
@@ -7,7 +7,7 @@ import JsonIO from '../shared/JsonIO'
 import TextIO from '../shared/TextIO'
 import { ComponentLibraryType } from './types'
 
-// All 'sets' are done onBlur (loose focus), to avoid excessible evaluations (especially for api types)
+// All 'sets' are done onBlur (loose focus), to avoid excessive evaluations (especially for api types)
 const ComponentLibrary: ComponentLibraryType = {
   TextInput: ({ text, setText, title = '', disabled = false, isTextArea = false }) => (
     <div className="long">

--- a/src/containers/TemplateBuilder/evaluatorGui/typeHelpers.ts
+++ b/src/containers/TemplateBuilder/evaluatorGui/typeHelpers.ts
@@ -82,6 +82,7 @@ export const getTypedEvaluation: GetEvaluationType = (evaluation) => {
     resultEvaluation.type = 'operator'
     resultEvaluation.asOperator.operator = evaluation.operator
     resultEvaluation.asOperator.type = evaluation.type
+    resultEvaluation.asOperator.fallback = evaluation.fallback
     if (operator in nonGenericEvaluations) {
       return nonGenericEvaluations[operator as NonGenericTypes].toTyped(
         evaluation,
@@ -150,10 +151,12 @@ export const convertTypedEvaluationToBaseType: ConvertTypedEvaluationToBaseType 
       const operatorResult: {
         operator: Operator
         type?: string
+        fallback?: any
         children: EvaluatorNode[]
       } = {
         operator: evaluation.asOperator.operator,
         type: evaluation.asOperator.type,
+        fallback: evaluation.asOperator.fallback,
         children: [],
       }
       evaluation.asOperator.children.forEach((evaluation) => {

--- a/src/containers/TemplateBuilder/evaluatorGui/types.ts
+++ b/src/containers/TemplateBuilder/evaluatorGui/types.ts
@@ -25,6 +25,7 @@ export type ComponentLibraryType = {
     setChecked: (checked: boolean) => void
     title?: string
     disabled?: boolean
+    minLabelWidth?: number
   }>
   ObjectInput: React.FC<{
     object: object
@@ -79,6 +80,7 @@ export type EvaluationVariations =
 export type OperatorType = {
   operator: Operator
   type?: string
+  fallback?: any
   children: EvaluationType[]
 }
 

--- a/src/containers/TemplateBuilder/shared/Evaluation.tsx
+++ b/src/containers/TemplateBuilder/shared/Evaluation.tsx
@@ -93,7 +93,9 @@ const Evaluation: React.FC<EvaluationProps> = ({
   return (
     <Accordion className="evaluation-container">
       <Accordion.Title className="evaluation-container-title flex-gap-10" active={isActive}>
-        {!updateKey && <Label style={{ minWidth: 120, textAlign: 'center' }}>{label}</Label>}
+        {!updateKey && label && (
+          <Label style={{ minWidth: 120, textAlign: 'center' }}>{label}</Label>
+        )}
         {deleteKey && (
           <Icon
             className="clickable left-margin-space-10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,10 +943,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@openmsupply/expression-evaluator@^1.10.0":
-  version "1.10.0"
-  resolved "https://npm.pkg.github.com/download/@openmsupply/expression-evaluator/1.10.0/3ec570fb60395a3639e10213003a919e13ef1e14f81cf099be09d7b76960c154#33f47a87a3dcb5ab19a83077ed08576fd566deb1"
-  integrity sha512-zg3D4FIEKe38xevNTKwLolYOuqqgnerOKug/sh0Ru9Ix8ITGTaSzGACels/E3WvbRrYFPeXA+rAkgboCCeWcDQ==
+"@openmsupply/expression-evaluator@^1.11.1":
+  version "1.11.1"
+  resolved "https://npm.pkg.github.com/download/@openmsupply/expression-evaluator/1.11.1/197766f4d96375fc068583e5164e705f111e172ddad0cbe8d1ed7a7737c2d3fa#4da82d7b83502aa44283e8cb01f688ba7cbc1321"
+  integrity sha512-3d982lu9GuL7396vw/POm/8iJXAyegOB9UB5CkUoOCWckjGYrioVH0lO/dR+7UspD9D40i9gnr51BFRJbdlMvQ==
 
 "@polka/url@^1.0.0-next.15":
   version "1.0.0-next.15"


### PR DESCRIPTION
Front-end complement to [back end PR #672](https://github.com/openmsupply/application-manager-server/pull/672)

Adds UI element to enable and define the Fallback for every evaluator instance.

Don't love the UI, but it's just re-using existing elements, so significant improvements not really do-able without a larger overhaul.

Make sure you `yarn install` to get the latest version of evaluator in this branch.

Note: nothing actually changed in `Evaluation.tsx`, seems like auto-formatting changes.