### PR TITLE
#1122 Fix bug with Consolidation not correctly setting LOQ to applicant

### DIFF
--- a/src/containers/Review/ReviewPage.tsx
+++ b/src/containers/Review/ReviewPage.tsx
@@ -274,7 +274,6 @@ const ApproveAllButton: React.FC<ApproveAllButtonProps> = ({
   page,
 }) => {
   const { strings } = useLanguageProvider()
-  // const [updateReviewResponse] = useUpdateReviewResponseMutation()
   const updateReviewResponse = useUpdateReviewResponse()
 
   const reviewResponses = page.state.map((element) => element.thisReviewLatestResponse)

--- a/src/containers/Review/ReviewPage.tsx
+++ b/src/containers/Review/ReviewPage.tsx
@@ -28,7 +28,6 @@ import {
   ReviewResponseDecision,
   ReviewResponseStatus,
   ReviewStatus,
-  useUpdateReviewResponseMutation,
 } from '../../utils/generated/graphql'
 import { useLanguageProvider } from '../../contexts/Localisation'
 import useLocalisedEnums from '../../utils/hooks/useLocalisedEnums'
@@ -41,6 +40,7 @@ import ReviewSubmit from './ReviewSubmit'
 import { useUserState } from '../../contexts/UserState'
 import { useRouter } from '../../utils/hooks/useRouter'
 import { Link } from 'react-router-dom'
+import useUpdateReviewResponse from '../../utils/hooks/useUpdateReviewResponse'
 
 const ReviewPage: React.FC<{
   reviewAssignment: AssignmentDetails
@@ -274,7 +274,8 @@ const ApproveAllButton: React.FC<ApproveAllButtonProps> = ({
   page,
 }) => {
   const { strings } = useLanguageProvider()
-  const [updateReviewResponse] = useUpdateReviewResponseMutation()
+  // const [updateReviewResponse] = useUpdateReviewResponseMutation()
+  const updateReviewResponse = useUpdateReviewResponse()
 
   const reviewResponses = page.state.map((element) => element.thisReviewLatestResponse)
 
@@ -288,14 +289,16 @@ const ApproveAllButton: React.FC<ApproveAllButtonProps> = ({
 
   const massApprove = () => {
     responsesToReview.forEach((reviewResponse) => {
-      if (!reviewResponse) return
-      updateReviewResponse({
-        variables: {
-          id: reviewResponse.id,
-          decision: isConsolidation ? ReviewResponseDecision.Agree : ReviewResponseDecision.Approve,
-          stageNumber,
-        },
-      })
+      if (reviewResponse)
+        updateReviewResponse(
+          {
+            ...reviewResponse,
+            decision: isConsolidation
+              ? ReviewResponseDecision.Agree
+              : ReviewResponseDecision.Approve,
+          },
+          stageNumber
+        )
     })
   }
 


### PR DESCRIPTION
Fixes #1122

Very small bug, caused by using the mutation instead of our Hook - where we pass the especific field required to update the original review response review_response.is_visible_to_applicant in `action_update_review_visibility`.

The bug only happened during MassApprove, when clicking on the "Agree with all" button on the consolidation.