### PR TITLE
#Message Info box fix

### DIFF
--- a/semantic/src/site/collections/message.overrides
+++ b/semantic/src/site/collections/message.overrides
@@ -2,9 +2,6 @@
         Site Overrides
 *******************************/
 
-.ui.message {
-  box-shadow: @floatingBoxShadow !important;
-}
 
 // Info message blue icon
 .ui.info.message .header i.icon {
@@ -13,7 +10,6 @@
 
 // Info message left border
 .ui.info.message {
-  border: none;
   border-left: @accentBorderWidth solid @information;
 }
 

--- a/semantic/src/site/collections/message.variables
+++ b/semantic/src/site/collections/message.variables
@@ -8,8 +8,14 @@
 // Info message colours
 @infoTextColor: @headersInteractiveLow;
 @infoHeaderColor: @headersInteractiveLow;
-@infoBoxShadow: none;
 @infoBackgroundColor: @surfacesLight;
+
+
+// Box shadow on info message -- make it consistent with other Message boxes
+@infoBoxShadow:
+  0px 0px 0px @borderWidth @surfacesMed inset,
+  @shadowShadow
+;
 
 // Error message colours
 @errorHeaderColor: @attention;

--- a/semantic/src/site/collections/message.variables
+++ b/semantic/src/site/collections/message.variables
@@ -9,13 +9,7 @@
 @infoTextColor: @headersInteractiveLow;
 @infoHeaderColor: @headersInteractiveLow;
 @infoBackgroundColor: @surfacesLight;
-
-
-// Box shadow on info message -- make it consistent with other Message boxes
-@infoBoxShadow:
-  0px 0px 0px @borderWidth @surfacesMed inset,
-  @shadowShadow
-;
+@infoBoxShadow: @boxShadow;
 
 // Error message colours
 @errorHeaderColor: @attention;

--- a/src/containers/Review/notes/NotesTab.tsx
+++ b/src/containers/Review/notes/NotesTab.tsx
@@ -148,7 +148,7 @@ const NotesTab: React.FC<{
             )
           })
         ) : (
-          <Message floating header={strings.REVIEW_NOTES_NO_NOTES} />
+          <Message header={strings.REVIEW_NOTES_NO_NOTES} />
         )}
         {!showForm && (
           <div className="item-container">


### PR DESCRIPTION
Quick fix for the Message box regression I mentioned in [this comment](https://github.com/openmsupply/application-manager-web-app/issues/1134#issuecomment-1094380419)

(If we want the bigger shadow effect, we can still do it by adding "floating" prop to Message component)