### PR TITLE
#1033 #1151 Lookup table fixes/improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "dev": "webpack-dev-server --env.env=dev",
+    "start": "yarn dev",
     "prebuild": "rimraf dist",
     "build": "cross-env NODE_ENV=production webpack -p --env.env=prod",
     "serve": "serve dist",

--- a/src/LookupTable/components/DownloadButton.tsx
+++ b/src/LookupTable/components/DownloadButton.tsx
@@ -3,12 +3,14 @@ import config from '../../config'
 import React, { Fragment, useState } from 'react'
 import { Popup, Button, Icon, Message } from 'semantic-ui-react'
 import { useLanguageProvider } from '../../contexts/Localisation'
+import { DateTime } from 'luxon'
 
 const DownloadButton = ({
   id,
   open: openPopup = false,
   popUpContent = '',
   content = '',
+  name = 'lookup_table',
   ...props
 }: any) => {
   const { strings } = useLanguageProvider()
@@ -47,7 +49,7 @@ const DownloadButton = ({
         const url = window.URL.createObjectURL(new Blob([response.data]))
         const link = document.createElement('a')
         link.href = url
-        link.setAttribute('download', 'file.csv')
+        link.setAttribute('download', `${name}_${DateTime.now().toISODate()}.csv`)
         document.body.appendChild(link)
         link.click()
       })

--- a/src/LookupTable/components/ImportCsvModal.tsx
+++ b/src/LookupTable/components/ImportCsvModal.tsx
@@ -14,7 +14,6 @@ import { LookUpTableImportCsvContext } from '../contexts'
 import config from '../../config'
 import axios from 'axios'
 import { useLanguageProvider } from '../../contexts/Localisation'
-import pluralize from 'pluralize'
 
 const ImportCsvModal: React.FC<any> = ({
   onImportSuccess,
@@ -50,9 +49,7 @@ const ImportCsvModal: React.FC<any> = ({
     let formData: any = new FormData()
     formData.append('file', file)
 
-    const pluralTableName = pluralize.isPlural(tableName) ? tableName : pluralize.plural(tableName)
-
-    if (!tableStructureID) formData.append('tableName', pluralTableName)
+    if (!tableStructureID) formData.append('tableName', tableName)
 
     const JWT = localStorage.getItem(config.localStorageJWTKey || '')
     const authHeader = JWT ? { Authorization: 'Bearer ' + JWT } : undefined

--- a/src/LookupTable/components/ImportCsvModal.tsx
+++ b/src/LookupTable/components/ImportCsvModal.tsx
@@ -56,9 +56,9 @@ const ImportCsvModal: React.FC<any> = ({
 
     await axios
       .post(
-        config.serverREST +
-          '/admin/lookup-table/import' +
-          (tableStructureID ? '/' + String(tableStructureID) : ''),
+        `${config.serverREST}/admin/lookup-table/import${
+          tableStructureID ? '/' + String(tableStructureID) : ''
+        }?tableName=${tableName}`,
         formData,
         {
           headers: {

--- a/src/LookupTable/components/list/ListTable.tsx
+++ b/src/LookupTable/components/list/ListTable.tsx
@@ -82,10 +82,11 @@ const ListTable: React.FC<any> = ({
                     <DownloadButton
                       popUpContent={strings.LOOKUP_TABLE_DOWNLOAD.replace('%1', lookupTable.label)}
                       id={lookupTable.id}
+                      name={lookupTable.label}
                     />
                   </Button.Group>
                 </Table.Cell>
-                <Table.Cell icon="chevron down" collapsing />
+                {/* <Table.Cell icon="chevron down" collapsing /> */}
               </Table.Row>
               {lookupTable.isExpanded && (
                 <Table.Row key={`table-row-detail-${lookupTable.id}`}>

--- a/src/LookupTable/components/single/LookUpMainMenu.tsx
+++ b/src/LookupTable/components/single/LookUpMainMenu.tsx
@@ -42,6 +42,7 @@ const LookUpMainMenu: React.FC<any> = (props) => {
             labelPosition="left"
             popUpContent={strings.LOOKUP_TABLE_DOWNLOAD.replace('%1', tableLabel)}
             id={tableId}
+            name={tableLabel}
           />
         </Button.Group>
       }

--- a/src/LookupTable/contexts/LookUpTableImportCsvContext.tsx
+++ b/src/LookupTable/contexts/LookUpTableImportCsvContext.tsx
@@ -49,8 +49,8 @@ const LookUpTableImportCsvReducer = (
     case LookUpTableImportCsvActions.ImportCSV:
       return { ...state, file: action.payload }
     case LookUpTableImportCsvActions.SetTableName: {
-      const removeNumbers = action.payload.replace(/([0-9])/gm, '')
-      return { ...state, tableName: camelCase(removeNumbers) }
+      const restrictCharacters = action.payload.replace(/[^A-z_]/gm, '')
+      return { ...state, tableName: restrictCharacters }
     }
     case LookUpTableImportCsvActions.submittable:
       return { ...state, submittable: action.payload }

--- a/src/LookupTable/contexts/LookUpTableImportCsvContext.tsx
+++ b/src/LookupTable/contexts/LookUpTableImportCsvContext.tsx
@@ -1,4 +1,3 @@
-import { camelCase } from 'lodash'
 import React, { useReducer } from 'react'
 import {
   LookUpTableImportCsvActions,

--- a/src/LookupTable/hooks/useGetSingleTableStructure.hook.tsx
+++ b/src/LookupTable/hooks/useGetSingleTableStructure.hook.tsx
@@ -2,6 +2,7 @@ import { ApolloQueryResult, QueryLazyOptions } from '@apollo/client'
 import { useEffect, useState } from 'react'
 import { useGetLookupTableStructureByIdLazyQuery } from '../../utils/generated/graphql'
 import { LookUpTableType } from '../types'
+import pluralize from 'pluralize'
 
 type LookupTableStructureType = {
   setStructureID: (id: number) => void
@@ -28,7 +29,11 @@ const useGetTableStructure = (): LookupTableStructureType => {
 
   useEffect(() => {
     if (!loading && !error && data?.lookupTable) {
-      setStructure(data.lookupTable as any)
+      const lookupTable = data.lookupTable
+      const namePlural = pluralize.isPlural(lookupTable.name)
+        ? lookupTable.name
+        : pluralize.plural(lookupTable.name)
+      setStructure({ ...lookupTable, name: namePlural })
     }
   }, [loading, data, error])
 

--- a/src/containers/Outcomes/helpers.tsx
+++ b/src/containers/Outcomes/helpers.tsx
@@ -87,7 +87,7 @@ export const getElementDetails = (value: any, displayDefinition: DisplayDefiniti
   const isAlreadyElement = !!formatting?.elementTypePluginCode
   const elementTypePluginCode = isAlreadyElement ? formatting?.elementTypePluginCode : 'shortText'
   const elementParameters = isAlreadyElement
-    ? formatting?.elementParameters
+    ? formatting?.elementParameters ?? {}
     : {
         label: displayDefinition.title,
       }


### PR DESCRIPTION
Fix #1033 (mostly)

Requires back-end branch from [PR #719](https://github.com/openmsupply/application-manager-server/pull/719)

Addresses all the items listed in #1033, except:
>  Should interpret non-text fields as correct type (e.g. boolean or number)

Need to be a bit careful with that. Even though I've already written a function to detect the Postgres type based on the content, I noticed some lookup tables had a mix of types (code for example is sometimes a number and sometimes text), so if we assumed that the first row was representative of the whole column, we'd cause problems. So will need to leave that for now until we can think it through a bit better, but it's not high priority for now.

The main importing error is fixed in the back-end.

I'll annotate my code with some comments to point out specific things.

Edit: Also chucked in a quick fix for #1151 cos it's so tiny 93343458