### PR TITLE
Fix User Area to be on top of other ui

### DIFF
--- a/semantic/src/site/globals/site.overrides
+++ b/semantic/src/site/globals/site.overrides
@@ -296,7 +296,7 @@ a:hover {
   padding-right: 20px;
   height: @headerHeight; // TO-DO: Adjust for mobile
   justify-content: space-between;
-  z-index: 10;
+  z-index: 1000;
 }
 
 #user-area.ui.container {


### PR DESCRIPTION
Tiny fix, hope it's good for other things that were also showing on top of UserArea...

Example of previous bug:
<img width="496" alt="Resultados" src="https://user-images.githubusercontent.com/16461988/164969305-c4f8e2c1-8c1e-4f24-9ac6-0b8c04de91d0.png">
