### PR TITLE
733B Fix for incorrect default responses in config application

### DIFF
--- a/src/containers/TemplateBuilder/template/ApplicationWrapper.tsx
+++ b/src/containers/TemplateBuilder/template/ApplicationWrapper.tsx
@@ -51,7 +51,9 @@ const CreateApplicationWrapper: React.FC = ({ children }) => {
   }
 
   const create = async () => {
-    const elementsDefaults = allElements.map((element) => element.defaultValue)
+    const elementsDefaults = allElements
+      .filter((element) => element.elementTypePluginCode !== 'pageBreak')
+      .map((element) => element.defaultValue)
     const defaultValues = await getDefaultValues(elementsDefaults || [], currentUser)
 
     await createApplication({


### PR DESCRIPTION
Fix back-end issue [#733](https://github.com/openmsupply/application-manager-server/issues/733)

Classic mistake this one -- referring to one array from another using indexes to keep them aligned, except one has been filtered and one hasn't, so the indexes no longer correspond! 😆

So now I'm just filtering the `elementsDefaults` array the same as the corresponding `templateResponses` so their indexes correspond correctly.

Only applies to "is_config" applications, not real applications, as they get created through different functions.

Bad news is it's NOT related to #1126 as I suspected -- that one will require a bit more to sort it out as there's a bit to consider.
