### PR TITLE
# Fix consolidation 2

### DIFF
--- a/src/components/Sections/SectionProgress.tsx
+++ b/src/components/Sections/SectionProgress.tsx
@@ -41,8 +41,7 @@ const ConsolidationSectionProgressBar: React.FC<SectionProgressBarProps> = (prop
     doneAgreeNonConform,
     doneAgreeConform,
     doneDisagree,
-    totalReviewable,
-    totalPendingReview,
+    totalActive
   } = getConsolidationProgressDefaults(props)
   const progressLabel = getConsolidationProgressTitle(props)
   return (
@@ -55,8 +54,8 @@ const ConsolidationSectionProgressBar: React.FC<SectionProgressBarProps> = (prop
       <Progress
         className="progress"
         percent={
-          (100 * (doneAgreeNonConform + doneAgreeConform + doneDisagree)) /
-          (totalReviewable - totalPendingReview)
+          // See generateConsolidationValidity for explannation on this change
+          (100 * (doneAgreeNonConform + doneAgreeConform + doneDisagree)) / totalActive
         }
         size="tiny"
         success={doneDisagree === 0}
@@ -110,6 +109,7 @@ const useHelpers = () => {
     doneDisagree: consolidationProgress?.doneDisagree || 0,
     totalReviewable: consolidationProgress?.totalReviewable || 0,
     totalPendingReview: consolidationProgress?.totalPendingReview || 0,
+    totalActive: consolidationProgress?.totalActive || 0,
   })
 
   const getConsolidationProgressTitle = (props: SectionProgressBarProps) => {

--- a/src/utils/helpers/structure/generateConsolidationValidity.ts
+++ b/src/utils/helpers/structure/generateConsolidationValidity.ts
@@ -4,7 +4,7 @@ import { getConsolidationProgress } from './generateConsolidatorResponsesProgres
 
 const generateConsolidationValidity = (newStructure: FullStructure) => {
   const sortedPages = newStructure?.sortedPages || []
-  const { doneActiveDisagree, doneAgreeNonConform, doneActiveAgreeConform, totalReviewable } =
+  const { doneActiveDisagree, doneAgreeNonConform, doneActiveAgreeConform, totalActive } =
     getConsolidationProgress(Object.values(newStructure.sections))
 
   newStructure.firstIncompleteReviewPage = undefined
@@ -21,15 +21,20 @@ const generateConsolidationValidity = (newStructure: FullStructure) => {
     return
   }
 
-  if (totalReviewable === doneActiveAgreeConform) {
+  // This used to be totalReviewable instead of totalActive
+  // but that breaks Consolidatio to process without agree/disagree to all questions 
+  // even the ones that haven't been reviewed or answered by applicant.
+  // generateConsolidationValidity & generateConsolidatorResponsesProgress needs better logic.
+  if (totalActive === doneActiveAgreeConform) {
     newStructure.assignment.canSubmitReviewAs = Decision.Conform
     return
   }
 
   const firstIncomplete = sortedPages.find(
     ({ consolidationProgress }) =>
-      consolidationProgress?.totalReviewable !==
-      (consolidationProgress?.doneActiveAgreeConform || 0)
+      // consolidationProgress?.totalReviewable !==
+      // (consolidationProgress?.doneActiveAgreeConform || 0)
+      consolidationProgress?.totalActive !== (consolidationProgress?.doneActiveAgreeConform || 0)
   )
 
   if (!firstIncomplete) return

--- a/src/utils/helpers/structure/generateConsolidatorResponsesProgress.ts
+++ b/src/utils/helpers/structure/generateConsolidatorResponsesProgress.ts
@@ -56,8 +56,8 @@ const generatePageConsolidationProgress = (page: Page, assignedSections: string[
   if (!assignedSections.includes(page.sectionCode)) page.consolidationProgress = initial
   else {
     const totalReviewable = page.state.filter(
-      ({ isAssigned, isActiveReviewResponse, thisReviewLatestResponse, element }) => 
-        ((isAssigned && isActiveReviewResponse) || !!thisReviewLatestResponse) && element.isVisible
+      ({ isAssigned, thisReviewLatestResponse, element }) => 
+        (isAssigned || !!thisReviewLatestResponse) && element.isVisible
     )
 
     const totalActive = totalReviewable.filter(activeThisReview)

--- a/src/utils/helpers/structure/generateConsolidatorResponsesProgress.ts
+++ b/src/utils/helpers/structure/generateConsolidatorResponsesProgress.ts
@@ -56,8 +56,8 @@ const generatePageConsolidationProgress = (page: Page, assignedSections: string[
   if (!assignedSections.includes(page.sectionCode)) page.consolidationProgress = initial
   else {
     const totalReviewable = page.state.filter(
-      ({ isAssigned, thisReviewLatestResponse, element }) =>
-        (isAssigned || !!thisReviewLatestResponse) && element.isVisible
+      ({ isAssigned, isActiveReviewResponse, thisReviewLatestResponse, element }) => 
+        ((isAssigned && isActiveReviewResponse) || !!thisReviewLatestResponse) && element.isVisible
     )
 
     const totalActive = totalReviewable.filter(activeThisReview)


### PR DESCRIPTION
Have tested with a few different scenarios and seems good - would be great to also try with review that has Make final decision checked. Tested Consolidation with:
- Standard Review - with questions not answered by applicant -> Consolidation: can self-assign, start and submit
- After sending changes to lower level reviewer -> Consolidation can re-start and submit
- After sending LOQ to applicant -> Review approves (with new questions answered in section) -> Consolidation can start and submit  