### PR TITLE
Small tweak -- more sensible default minimum for number input element

### DIFF
--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -613,7 +613,7 @@ _Input for numeric fields_
 - **default** -- default value (Note: if you require a dynamic value for "default", please use the "defaultValue" field on `template_element`)
 - **type** -- `enum` -- either "integer" or "float" (default: "integer")
 - **simple** -- `boolean` (default: `true`) If `true`, the input field will always show only a non-formatted version of the number (i.e. "1000", not "1,000"), but it will have a "stepper" which can be clicked to increment the number up and down.
-- **minValue** -- minimum allowed value (default: no limit)
+- **minValue** -- minimum allowed value (default: 0)
 - **maxValue** -- maximum allowed value (default: no limit)
 - **step** -- `number` (default: `1`) If `simple == true` (above), the `step` value specifies the amount the number will be incremented or decremented by when using the stepper.
   **NOTE**: The parameters below are only relevant is `simple == false` (above)

--- a/src/formElementPlugins/number/src/ApplicationView.tsx
+++ b/src/formElementPlugins/number/src/ApplicationView.tsx
@@ -31,7 +31,7 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     maxWidth,
     type = NumberType.FLOAT,
     simple = true,
-    minValue = -Infinity,
+    minValue = 0,
     maxValue = Infinity,
     step = 1,
     locale = undefined,


### PR DESCRIPTION
It was annoying me how I could press the stepper and have negative values for the shelf life inputs in Project Reg. Was about to edit the template to set `minValue: 0`, but then realised it would just be better to have `0` as the default minimum for number input. Configuration can set a lower minimum in the rare cases we want to allow negative input.

Tiny change (and update to docs)