### PR TITLE
Don't show "required" indicator if label is not defined

### DIFF
--- a/src/formElementPlugins/checkbox/src/ApplicationView.tsx
+++ b/src/formElementPlugins/checkbox/src/ApplicationView.tsx
@@ -90,9 +90,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       {checkboxElements.map((cb: Checkbox, index: number) => (
         <Form.Field key={`${index}_${cb.label}`} disabled={!isEditable} style={styles}>

--- a/src/formElementPlugins/checkbox/src/SummaryView.tsx
+++ b/src/formElementPlugins/checkbox/src/SummaryView.tsx
@@ -24,9 +24,11 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, respons
   const { textDisplay = TextDisplay.LIST, label, description } = parameters
   return (
     <Form.Field className="element-summary-view">
-      <label style={{ color: 'black' }}>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label style={{ color: 'black' }}>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       <Markdown text={(response ? getMarkdownText(textDisplay, response) : '') as string} />
     </Form.Field>

--- a/src/formElementPlugins/datePicker/src/ApplicationView.tsx
+++ b/src/formElementPlugins/datePicker/src/ApplicationView.tsx
@@ -80,9 +80,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       <SemanticDatepicker
         locale={locale}

--- a/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/dropdownChoice/src/ApplicationView.tsx
@@ -71,9 +71,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       <Dropdown
         fluid

--- a/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
+++ b/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
@@ -147,9 +147,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       <Segment.Group>
         {/* Dummy input button required, as Semantic Button can't

--- a/src/formElementPlugins/fileUpload/src/SummaryView.tsx
+++ b/src/formElementPlugins/fileUpload/src/SummaryView.tsx
@@ -9,9 +9,11 @@ const downloadUrl = `${config.serverREST}/public`
 const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, response }) => {
   return (
     <Form.Field required={parameters.isRequired}>
-      <label style={{ color: 'black' }}>
-        <Markdown text={parameters.label} semanticComponent="noParagraph" />
-      </label>
+      {parameters?.label && (
+        <label style={{ color: 'black' }}>
+          <Markdown text={parameters?.label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={parameters.description} />
       <List horizontal verticalAlign="top">
         {response?.files &&

--- a/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
+++ b/src/formElementPlugins/listBuilder/src/ApplicationView.tsx
@@ -207,9 +207,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       <Button
         primary

--- a/src/formElementPlugins/listBuilder/src/SummaryView.tsx
+++ b/src/formElementPlugins/listBuilder/src/SummaryView.tsx
@@ -34,9 +34,11 @@ const SummaryView: React.FC<SummaryViewProps> = ({ parameters, Markdown, respons
 
   return (
     <Form.Field>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       {DisplayComponent}
     </Form.Field>
   )

--- a/src/formElementPlugins/longText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/longText/src/ApplicationView.tsx
@@ -44,9 +44,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       <Form.TextArea
         placeholder={placeholder}

--- a/src/formElementPlugins/number/src/ApplicationView.tsx
+++ b/src/formElementPlugins/number/src/ApplicationView.tsx
@@ -124,9 +124,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       <Form.Input
         fluid

--- a/src/formElementPlugins/password/src/ApplicationView.tsx
+++ b/src/formElementPlugins/password/src/ApplicationView.tsx
@@ -97,9 +97,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       <Form.Input
         name="password"

--- a/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
+++ b/src/formElementPlugins/radioChoice/src/ApplicationView.tsx
@@ -105,9 +105,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       {radioButtonOptions.map((option: any, index: number) => {
         const showOther = hasOther && index === allOptions.length - 1

--- a/src/formElementPlugins/search/src/ApplicationView.tsx
+++ b/src/formElementPlugins/search/src/ApplicationView.tsx
@@ -154,9 +154,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       <Form.Field key={`search-${label}`} error={!validationState.isValid}>
         <Search

--- a/src/formElementPlugins/shortText/src/ApplicationView.tsx
+++ b/src/formElementPlugins/shortText/src/ApplicationView.tsx
@@ -56,9 +56,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
 
   return (
     <>
-      <label>
-        <Markdown text={label} semanticComponent="noParagraph" />
-      </label>
+      {label && (
+        <label>
+          <Markdown text={label} semanticComponent="noParagraph" />
+        </label>
+      )}
       <Markdown text={description} />
       <Form.Input
         fluid


### PR DESCRIPTION
In a few places, we've used an empty `label` parameter to make a form element more tightly linked with the one above it.

Unfortunately, it currently looks bad if the unlabelled element is also "required", as the small red asterisk is displayed:
<img width="626" alt="Screen Shot 2022-05-02 at 7 39 10 PM" src="https://user-images.githubusercontent.com/5456533/166201175-b4f98a58-a61c-4b51-b625-e3a2ad702f25.png">

This small change just makes sure the whole "label" html element for each plugin is only rendered if the label parameter is defined, so that the "required" indicator won't show up if the label doesn't, like so:
<img width="604" alt="Screen Shot 2022-05-02 at 7 39 22 PM" src="https://user-images.githubusercontent.com/5456533/166201279-f631866e-0d32-45c2-8618-393e4b17f744.png">

Another example with file upload connected to a previous checkbox element:

<img width="495" alt="Screen Shot 2022-05-02 at 7 42 57 PM" src="https://user-images.githubusercontent.com/5456533/166201329-2e2dc9db-96e0-434d-93a3-07c5a65d9817.png">

<img width="497" alt="Screen Shot 2022-05-02 at 7 43 12 PM" src="https://user-images.githubusercontent.com/5456533/166201344-4aff2823-7849-4fbe-94f0-2772a9868ca7.png">

