### PR TITLE
1175 Update assignment logic to take level into account

### DIFF
--- a/src/containers/Review/assignment/AssignmentRows.tsx
+++ b/src/containers/Review/assignment/AssignmentRows.tsx
@@ -51,14 +51,13 @@ const AssignmentRows: React.FC<AssignmentRowsProps> = ({
                 sectionCode={code}
                 reviewLevel={Number(level)}
                 structure={fullStructure}
-                assignedSectionsState={[
-                  assignedSectionsByLevel[level] || defaultAssignedSections,
-                  (assignedSections) =>
-                    setAssignedSectionsByLevel({
-                      ...assignedSectionsByLevel,
-                      [level]: assignedSections,
-                    }),
-                ]}
+                assignedSections={assignedSectionsByLevel[level] || defaultAssignedSections}
+                setAssignedSections={(assignedSections) =>
+                  setAssignedSectionsByLevel({
+                    ...assignedSectionsByLevel,
+                    [level]: assignedSections,
+                  })
+                }
                 setEnableSubmit={setEnableSubmit}
                 setAssignmentError={setAssignmentError}
               />

--- a/src/containers/Review/assignment/AssignmentRows.tsx
+++ b/src/containers/Review/assignment/AssignmentRows.tsx
@@ -2,6 +2,7 @@ import React, { SetStateAction } from 'react'
 import { Header, Segment } from 'semantic-ui-react'
 import { useReviewStructureState } from '../../../contexts/ReviewStructuresState'
 import {
+  AssignedSectionsByLevel,
   AssignmentDetails,
   FullStructure,
   LevelAssignments,
@@ -14,8 +15,8 @@ interface AssignmentRowsProps {
   fullStructure: FullStructure
   assignmentInPreviousStage: AssignmentDetails
   assignmentGroupedLevel: LevelAssignments
-  assignedSections: SectionAssignee
-  setAssignedSections: React.Dispatch<SetStateAction<SectionAssignee>>
+  assignedSectionsByLevel: AssignedSectionsByLevel
+  setAssignedSectionsByLevel: React.Dispatch<SetStateAction<AssignedSectionsByLevel>>
   setEnableSubmit: React.Dispatch<SetStateAction<boolean>>
   setAssignmentError: React.Dispatch<SetStateAction<string | null>>
 }
@@ -23,12 +24,20 @@ const AssignmentRows: React.FC<AssignmentRowsProps> = ({
   fullStructure,
   assignmentInPreviousStage,
   assignmentGroupedLevel,
-  assignedSections,
-  setAssignedSections,
+  assignedSectionsByLevel,
+  setAssignedSectionsByLevel,
   setEnableSubmit,
   setAssignmentError,
 }) => {
   const { reviewStructuresState } = useReviewStructureState()
+
+  const defaultAssignedSections = Object.values(fullStructure.sections).reduce(
+    (assignedSections, { details: { code } }) => ({
+      ...assignedSections,
+      [code]: { newAssignee: undefined },
+    }),
+    {}
+  )
 
   return (
     <>
@@ -42,7 +51,14 @@ const AssignmentRows: React.FC<AssignmentRowsProps> = ({
                 sectionCode={code}
                 reviewLevel={Number(level)}
                 structure={fullStructure}
-                assignedSectionsState={[assignedSections, setAssignedSections]}
+                assignedSectionsState={[
+                  assignedSectionsByLevel[level] || defaultAssignedSections,
+                  (assignedSections) =>
+                    setAssignedSectionsByLevel({
+                      ...assignedSectionsByLevel,
+                      [level]: assignedSections,
+                    }),
+                ]}
                 setEnableSubmit={setEnableSubmit}
                 setAssignmentError={setAssignmentError}
               />

--- a/src/containers/Review/assignment/AssignmentSectionRow.tsx
+++ b/src/containers/Review/assignment/AssignmentSectionRow.tsx
@@ -16,7 +16,7 @@ type AssignmentSectionRowProps = {
   sectionCode: string
   reviewLevel: number
   structure: FullStructure
-  assignedSectionsState: [SectionAssignee, React.Dispatch<React.SetStateAction<SectionAssignee>>]
+  assignedSectionsState: [SectionAssignee, (assingedSections: SectionAssignee) => void]
   setEnableSubmit: React.Dispatch<SetStateAction<boolean>>
   setAssignmentError: React.Dispatch<SetStateAction<string | null>>
 }
@@ -67,7 +67,7 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
     assignments,
     sectionCode,
     // elements,
-    assignee: assignedSections[sectionCode]?.newAssignee,
+    assignee: assignedSections?.[sectionCode]?.newAssignee,
   })
   if (!assignmentOptions) return null
 
@@ -114,7 +114,7 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
     setShowUnassignmentModal({ open: false })
     if (!unassignment) return
     try {
-      await submitAssignments(sectionToUnassign, [unassignment])
+      await submitAssignments(Number(reviewLevel), sectionToUnassign, [unassignment])
     } catch (e) {
       console.log(e)
       setAssignmentError(strings.ASSIGNMENT_ERROR_UNASSIGN)

--- a/src/containers/Review/assignment/AssignmentSectionRow.tsx
+++ b/src/containers/Review/assignment/AssignmentSectionRow.tsx
@@ -16,7 +16,8 @@ type AssignmentSectionRowProps = {
   sectionCode: string
   reviewLevel: number
   structure: FullStructure
-  assignedSectionsState: [SectionAssignee, (assingedSections: SectionAssignee) => void]
+  assignedSections: SectionAssignee
+  setAssignedSections: (assingedSections: SectionAssignee) => void
   setEnableSubmit: React.Dispatch<SetStateAction<boolean>>
   setAssignmentError: React.Dispatch<SetStateAction<string | null>>
 }
@@ -26,7 +27,8 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
   sectionCode,
   reviewLevel,
   structure,
-  assignedSectionsState,
+  assignedSections,
+  setAssignedSections,
   setEnableSubmit,
   setAssignmentError,
 }) => {
@@ -43,7 +45,6 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
   const getAssignmentOptions = useGetAssignmentOptions()
   const [isReassignment, setIsReassignment] = useState(false)
   const [showUnassignmentModal, setShowUnassignmentModal] = useState<ModalProps>({ open: false })
-  const [assignedSections, setAssignedSections] = assignedSectionsState
   const [originalAssignee, setOriginalAssignee] = useState<string>()
 
   useEffect(() => {
@@ -169,7 +170,8 @@ const AssignmentSectionRow: React.FC<AssignmentSectionRowProps> = ({
             sectionCode={sectionCode}
             isLastLevel={isLastLevel}
             previousAssignee={assignmentOptions.selected}
-            assignedSectionsState={assignedSectionsState}
+            assignedSections={assignedSections}
+            setAssignedSections={setAssignedSections}
           />
         </Grid.Row>
       )}

--- a/src/containers/Review/assignment/AssignmentSubmit.tsx
+++ b/src/containers/Review/assignment/AssignmentSubmit.tsx
@@ -1,12 +1,17 @@
 import React, { SetStateAction } from 'react'
 import { Button } from 'semantic-ui-react'
 import { useLanguageProvider } from '../../../contexts/Localisation'
-import { AssignmentDetails, FullStructure, SectionAssignee } from '../../../utils/types'
+import {
+  AssignedSectionsByLevel,
+  AssignmentDetails,
+  FullStructure,
+  SectionAssignee,
+} from '../../../utils/types'
 import useUpdateAssignment from '../../../utils/hooks/useUpdateAssignment'
 
 interface AssignmentSubmitProps {
   fullStructure: FullStructure
-  assignedSections: SectionAssignee
+  assignedSectionsByLevel: AssignedSectionsByLevel
   assignmentsFiltered: AssignmentDetails[]
   enableSubmit: boolean
   setAssignmentError: React.Dispatch<SetStateAction<string | null>>
@@ -14,7 +19,7 @@ interface AssignmentSubmitProps {
 
 const AssignmentSubmit: React.FC<AssignmentSubmitProps> = ({
   fullStructure,
-  assignedSections,
+  assignedSectionsByLevel,
   assignmentsFiltered,
   enableSubmit,
   setAssignmentError,
@@ -26,7 +31,9 @@ const AssignmentSubmit: React.FC<AssignmentSubmitProps> = ({
 
   const handleSubmit = async () => {
     try {
-      await submitAssignments(assignedSections, assignmentsFiltered)
+      for (const [level, assignedSections] of Object.entries(assignedSectionsByLevel)) {
+        await submitAssignments(Number(level), assignedSections, assignmentsFiltered)
+      }
     } catch (err) {
       console.log(err)
       setAssignmentError(strings.ASSIGNMENT_ERROR_GENERAL)

--- a/src/containers/Review/assignment/AssignmentTab.tsx
+++ b/src/containers/Review/assignment/AssignmentTab.tsx
@@ -4,6 +4,7 @@ import Loading from '../../../components/Loading'
 import Assignment from './Assignment'
 import { useUserState } from '../../../contexts/UserState'
 import {
+  AssignedSectionsByLevel,
   AssignmentDetails,
   Filters,
   FullStructure,
@@ -28,14 +29,8 @@ const AssignmentTab: React.FC<{
     userState: { currentUser },
   } = useUserState()
   const [enableSubmit, setEnableSubmit] = useState<boolean>(false)
-  const [assignedSections, setAssignedSections] = useState<SectionAssignee>(
-    Object.values(fullStructure.sections).reduce(
-      (assignedSections, { details: { code } }) => ({
-        ...assignedSections,
-        [code]: { newAssignee: undefined },
-      }),
-      {}
-    )
+  const [assignedSectionsByLevel, setAssignedSectionsByLevel] = useState<AssignedSectionsByLevel>(
+    {}
   )
   const [assignmentError, setAssignmentError] = useState<string | null>(null)
 
@@ -128,14 +123,14 @@ const AssignmentTab: React.FC<{
           fullStructure={fullStructure}
           assignmentInPreviousStage={assignmentInPreviousStage}
           assignmentGroupedLevel={assignmentGroupedLevel}
-          assignedSections={assignedSections}
-          setAssignedSections={setAssignedSections}
+          assignedSectionsByLevel={assignedSectionsByLevel}
+          setAssignedSectionsByLevel={setAssignedSectionsByLevel}
           setEnableSubmit={setEnableSubmit}
           setAssignmentError={setAssignmentError}
         />
         <AssignmentSubmit
           fullStructure={fullStructure}
-          assignedSections={assignedSections}
+          assignedSectionsByLevel={assignedSectionsByLevel}
           assignmentsFiltered={assignmentsFiltered}
           enableSubmit={enableSubmit}
           setAssignmentError={setAssignmentError}

--- a/src/containers/Review/assignment/Reassignment.tsx
+++ b/src/containers/Review/assignment/Reassignment.tsx
@@ -10,7 +10,7 @@ interface ReassignmentProps {
   sectionCode: string
   isLastLevel: (selectedIndex: number) => boolean
   previousAssignee: number
-  assignedSectionsState: [SectionAssignee, React.Dispatch<React.SetStateAction<SectionAssignee>>]
+  assignedSectionsState: [SectionAssignee, (assignedSections: SectionAssignee) => void]
 }
 
 const Reassignment: React.FC<ReassignmentProps> = ({

--- a/src/containers/Review/assignment/Reassignment.tsx
+++ b/src/containers/Review/assignment/Reassignment.tsx
@@ -10,7 +10,8 @@ interface ReassignmentProps {
   sectionCode: string
   isLastLevel: (selectedIndex: number) => boolean
   previousAssignee: number
-  assignedSectionsState: [SectionAssignee, (assignedSections: SectionAssignee) => void]
+  assignedSections: SectionAssignee
+  setAssignedSections: (assignedSections: SectionAssignee) => void
 }
 
 const Reassignment: React.FC<ReassignmentProps> = ({
@@ -18,11 +19,11 @@ const Reassignment: React.FC<ReassignmentProps> = ({
   sectionCode,
   isLastLevel,
   previousAssignee,
-  assignedSectionsState,
+  assignedSections,
+  setAssignedSections,
 }) => {
   const { strings } = useLanguageProvider()
   const getAssignmentOptions = useGetAssignmentOptions()
-  const [assignedSections, setAssignedSections] = assignedSectionsState
   const assignmentOptions = getAssignmentOptions({
     assignments,
     sectionCode,

--- a/src/utils/hooks/useUpdateAssignment.tsx
+++ b/src/utils/hooks/useUpdateAssignment.tsx
@@ -14,6 +14,7 @@ const useUpdateAssignment = ({ fullStructure }: { fullStructure: FullStructure }
   } = useUserState()
 
   const submitAssignments = async (
+    level: number,
     assignedSections: SectionAssignee | null,
     assignmentsFiltered: AssignmentDetails[]
   ) => {
@@ -25,23 +26,25 @@ const useUpdateAssignment = ({ fullStructure }: { fullStructure: FullStructure }
     // Deduce which review assignments need to change and create patches, then
     // mutate one by one
     try {
-      assignmentsFiltered.forEach((assignment) => {
-        if (isChanging(assignment.reviewer.id, assignedSections)) {
-          const assignmentPatch = createAssignmentPatch(
-            assignment,
-            assignedSections,
-            currentUser?.userId as number
-          )
-          results.push(
-            updateReviewAssignment({
-              variables: {
-                assignmentId: assignment.id,
-                assignmentPatch,
-              },
-            })
-          )
-        }
-      })
+      assignmentsFiltered
+        .filter(({ level: assignmentLevel }) => assignmentLevel === level)
+        .forEach((assignment) => {
+          if (isChanging(assignment.reviewer.id, assignedSections)) {
+            const assignmentPatch = createAssignmentPatch(
+              assignment,
+              assignedSections,
+              currentUser?.userId as number
+            )
+            results.push(
+              updateReviewAssignment({
+                variables: {
+                  assignmentId: assignment.id,
+                  assignmentPatch,
+                },
+              })
+            )
+          }
+        })
       await Promise.all(results)
     } catch (err) {
       throw new Error('Assignment update error')

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -482,6 +482,11 @@ interface ChangeRequestsProgress {
   doneChangeRequests: number
 }
 
+export interface AssignedSectionsByLevel {
+  [level: string]: SectionAssignee
+}
+
+
 interface SectionAssignee {
   [sectionCode: string]: {
     newAssignee: number | undefined
@@ -752,15 +757,15 @@ export type FilterTypeMethod = (filterKey: string, options?: FilterTypeOptions) 
 
 export type FilterTypeDefinitions = {
   [filterType in
-    | 'number'
-    | 'date'
-    | 'boolean'
-    | 'equals'
-    | 'enumList'
-    | 'searchableListIn'
-    | 'searchableListInArray'
-    | 'staticList'
-    | 'search']: FilterTypeMethod
+  | 'number'
+  | 'date'
+  | 'boolean'
+  | 'equals'
+  | 'enumList'
+  | 'searchableListIn'
+  | 'searchableListInArray'
+  | 'staticList'
+  | 'search']: FilterTypeMethod
 }
 
 export type FilterTypes = keyof FilterTypeDefinitions

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -486,7 +486,6 @@ export interface AssignedSectionsByLevel {
   [level: string]: SectionAssignee
 }
 
-
 interface SectionAssignee {
   [sectionCode: string]: {
     newAssignee: number | undefined
@@ -757,15 +756,15 @@ export type FilterTypeMethod = (filterKey: string, options?: FilterTypeOptions) 
 
 export type FilterTypeDefinitions = {
   [filterType in
-  | 'number'
-  | 'date'
-  | 'boolean'
-  | 'equals'
-  | 'enumList'
-  | 'searchableListIn'
-  | 'searchableListInArray'
-  | 'staticList'
-  | 'search']: FilterTypeMethod
+    | 'number'
+    | 'date'
+    | 'boolean'
+    | 'equals'
+    | 'enumList'
+    | 'searchableListIn'
+    | 'searchableListInArray'
+    | 'staticList'
+    | 'search']: FilterTypeMethod
 }
 
 export type FilterTypes = keyof FilterTypeDefinitions


### PR DESCRIPTION
closes #1175 

Created new type `AssignedSectionsByLevel` which is `SectionAssignee` grouped by levels, this type is used in assignment logic.

Noticed a couple of things: 

* Should assigned level 1 be able to assign level above one ?
* Looks like we can approve consolidation when approving just one section (if other sections are not submitted by another reviewer yet)
* Review assignment of level one, that are not assigned, but when level one is fully assigned, are still AVAILABLE ? Is that ok ?