### PR TITLE
Subfolder parameter for fileUpload

### DIFF
--- a/docs/internal/Element-Type-Specs.md
+++ b/docs/internal/Element-Type-Specs.md
@@ -391,6 +391,7 @@ _Interface for uploading documents or other files_
 - **fileCountLimit**: `number` -- maximum number of files allowed to upload for this question (default: 1)
 - **fileExtensions**: `array[string]` -- list of allowed file extensions (default: no restrictions). e.g. `["pdf", "doc", "txt", "jpg", "png"]`
 - **fileSizeLimit**: `number` -- maximum file size in KB (default: no limit)
+- **subfolder**: `string` -- by default, files are uploaded into a subfolder with the name of the application serial. However, this can be over-ridden by specifying this parameter. This should rarely be required.
 
 #### Response type
 

--- a/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
+++ b/src/formElementPlugins/fileUpload/src/ApplicationView.tsx
@@ -41,7 +41,8 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
   const { getPluginStrings } = useLanguageProvider()
   const strings = getPluginStrings('fileUpload')
   const { isEditable } = element
-  const { label, description, fileCountLimit, fileExtensions, fileSizeLimit } = parameters
+  const { label, description, fileCountLimit, fileExtensions, fileSizeLimit, subfolder } =
+    parameters
 
   const { config } = applicationData
 
@@ -252,7 +253,11 @@ const ApplicationView: React.FC<ApplicationViewProps> = ({
     const fileData = new FormData()
     await fileData.append('file', file)
     return await postRequest({
-      url: `${uploadUrl}?user_id=${currentUser?.userId}&application_serial=${serialNumber}&application_response_id=${application_response_id}`,
+      url: `${uploadUrl}?user_id=${
+        currentUser?.userId
+      }&application_serial=${serialNumber}&application_response_id=${application_response_id}${
+        subfolder ? '&subfolder=' + subfolder : ''
+      }`,
       otherBody: fileData,
     })
   }


### PR DESCRIPTION
This is part of a request of Adam's. The "subfolder" can already be specified in the `/upload` endpoint -- this just makes it available to the front-end plugin.

It should rarely be needed, but it will be useful for configurations when we are trying to specify where certain files should go via the UI, such as carbone templates.