### PR TITLE
#1187 Fix objectFunctions UI in template builder

### DIFF
--- a/src/containers/TemplateBuilder/evaluatorGui/guiDefinitions.tsx
+++ b/src/containers/TemplateBuilder/evaluatorGui/guiDefinitions.tsx
@@ -231,7 +231,7 @@ export const guis: GuisType = [
     selector: 'Object functions',
     default: getTypedEvaluation({
       operator: 'objectFunctions',
-      children: ['getYear', null],
+      children: ['functions.getYear'],
     }),
     match: (typedEvaluation) => typedEvaluation.asOperator.operator === 'objectFunctions',
     render: (evaluation, setEvaluation, ComponentLibrary, evaluatorParameters) => (
@@ -241,11 +241,17 @@ export const guis: GuisType = [
           title="Function path (e.g. functions.getYear): "
         />
         {renderSingleChild(evaluation, 0, setEvaluation, ComponentLibrary, evaluatorParameters)}
-        <ComponentLibrary.Label
-          key="fallback"
-          title="Fallback (in case object path is not found): "
-        />
-        {renderSingleChild(evaluation, 1, setEvaluation, ComponentLibrary, evaluatorParameters)}
+        <ComponentLibrary.Label key="parameters" title="Function parameters: " />
+        {renderArrayControl({
+          title: 'Parameters',
+          evaluation,
+          key: 'parameters',
+          offset: 1,
+          setEvaluation,
+          newValue: getTypedEvaluation({ value: {} }),
+          ComponentLibrary,
+          evaluatorParameters,
+        })}
       </React.Fragment>
     ),
   },


### PR DESCRIPTION
Fix #1187 

Now shows appropriate UI for the `objectFunctions` operator:
![Screen Shot 2022-05-06 at 11 39 59 AM](https://user-images.githubusercontent.com/5456533/167044011-bcc001f9-afcd-486d-bad9-04fb6672c2f8.png)

